### PR TITLE
Fix gene-recovery heap overflow on large/dense scaffolds; add memory profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,54 @@ HEADERS = $(INCLUDE)/geneid.h
 PROGRAM= geneid
 PRODUCT= $(BIN)/$(PROGRAM)
 CC=gcc
-OPTS=-I$(INCLUDE) -Wall -O3
-#OPTS=-I$(INCLUDE) -Wall -g
+
+#######
+# Memory profile: pick the array-sizing constants for the target machine.
+#   make             -> MEM=auto: detect THIS machine's RAM and pick a profile
+#   make MEM=low      ~5 GB reserved  (small machines; tight on dense genomes)
+#   make MEM=medium   ~13 GB reserved (16-24 GB machines)
+#   make MEM=high     ~45 GB reserved (big servers; lazy alloc, RSS stays ~4 GB)
+# Profiles override the #ifndef'd defaults in include/geneid.h via -D.
+#
+# *** auto detects the BUILD machine's RAM. *** If you build and run on
+# different machines (e.g. a cluster login node vs a fat compute node),
+# auto can guess wrong -- pass an explicit MEM=low|medium|high matching the
+# RUN machine. The resolved profile is printed on every build, and
+# `make print-mem` shows the detected RAM. Always `make clean` when
+# switching profiles (the constants are compile-time).
+#######
+MEM ?= auto
+
+# auto -> resolve to low/medium/high from physical RAM (macOS sysctl / Linux /proc)
+ifeq ($(MEM),auto)
+  MEM_BYTES := $(shell sysctl -n hw.memsize 2>/dev/null || awk '/MemTotal/{print $$2*1024}' /proc/meminfo 2>/dev/null || echo 0)
+  MEM_RESOLVED := $(shell b="$(MEM_BYTES)"; \
+    if   [ "$$b" -ge 51539607552 ]; then echo high;   \
+    elif [ "$$b" -ge 17179869184 ]; then echo medium; \
+    elif [ "$$b" -gt 0 ];          then echo low;     \
+    else echo medium; fi)
+else
+  MEM_BYTES := 0
+  MEM_RESOLVED := $(MEM)
+endif
+
+ifeq ($(MEM_RESOLVED),low)
+  MEMFLAGS = -DLENGTHSi=220000 -DREXONS=2 -DFSORT=12 -DFDARRAY=5 -DRBSITES=150 -DRBEXONS=250
+else ifeq ($(MEM_RESOLVED),medium)
+  MEMFLAGS =
+else ifeq ($(MEM_RESOLVED),high)
+  MEMFLAGS = -DLENGTHSi=500000 -DREXONS=0.25 -DFSORT=20 -DFDARRAY=10 -DRBSITES=75 -DRBEXONS=125
+else
+  $(error Unknown MEM='$(MEM)' (resolved '$(MEM_RESOLVED)'). Use one of: auto, low, medium, high)
+endif
+
+$(info geneid memory profile: MEM=$(MEM) -> '$(MEM_RESOLVED)')
+
+OPTS=-I$(INCLUDE) -Wall -O3 $(MEMFLAGS)
+#OPTS=-I$(INCLUDE) -Wall -g $(MEMFLAGS)
+
+# Keep the program the default goal (print-mem is defined after it below)
+.DEFAULT_GOAL := $(PRODUCT)
 #######
 
 OBJECTS = $(OBJ)/BackupGenes.o $(OBJ)/PeakEdgeScore.o $(OBJ)/GetTranscriptTermini-usingslopes.o $(OBJ)/BuildAcceptors.o $(OBJ)/BuildU12Acceptors.o $(OBJ)/BuildDonors.o \
@@ -192,4 +238,10 @@ $(OBJ)/Translate.o :  $(CDIR)/Translate.c $(HEADERS)
 clean:
 	rm -f $(OBJ)/*.o $(PRODUCT) *~ $(INCLUDE)/*~ $(CDIR)/*~ core;
 	rmdir $(BIN) $(OBJ);
+
+# Show the active memory profile, detected RAM, and the -D flags it injects
+print-mem:
+	@echo "MEM=$(MEM)  resolved=$(MEM_RESOLVED)  detected_RAM_bytes=$(MEM_BYTES)"
+	@echo "MEMFLAGS=$(MEMFLAGS)"
+.PHONY: print-mem clean
 

--- a/include/geneid.h
+++ b/include/geneid.h
@@ -119,7 +119,7 @@ A. DEFINITIONS
 #define MAXNSEQUENCES 100         
 
 /* Maximum number of predicted genes        */
-#define MAXGENE 15000            
+#define MAXGENE 100000
 
 /* Maximum number of exons in a gene        */
 #define MAXEXONGENE 1000         

--- a/include/geneid.h
+++ b/include/geneid.h
@@ -50,43 +50,70 @@ A. DEFINITIONS
 #define EXONS     "geneid_v1.4"       
 #define EVIDENCE  "evidence"           
 
-/* Length of every processed fragment       */ 
-#define LENGTHSi 500000          /* medium default (was 220000) */
+/* -------------------------------------------------------------------------
+ * MEMORY PROFILE (build-time tunable)
+ * The six constants below dominate the amount of memory geneid reserves
+ * (mostly via NUMEXONS = LENGTHSi/REXONS and the FSORT multiplier). The
+ * values here are the DEFAULT ("medium") profile, sized for ~16-24 GB
+ * machines (~13 GB reserved on a large dense genome). Each is wrapped in
+ * #ifndef so the Makefile can override it on the compiler command line:
+ *     make MEM=low     (smaller arrays, ~5 GB; may be tight on dense genomes)
+ *     make             (medium, the defaults below)
+ *     make MEM=high    (max headroom, ~45 GB reserved; lazy, RSS stays low)
+ * Do not raise FSORT/REXONS independently without checking: the exon-sort
+ * table must hold the sum of all per-type build arrays (~8.2 x NUMEXONS),
+ * so FSORT should stay >= ~9.
+ * ---------------------------------------------------------------------- */
+
+/* Length of every processed fragment       */
+#ifndef LENGTHSi
+#define LENGTHSi 500000
+#endif
 
 /* Overlap between 2 fragments              */
-#define OVERLAP 10000            
+#define OVERLAP 10000
 
 /* One signal per L / RSITES bp             */
 #define RSITES 1
 
 /* /\* One U12 signal per L / RU12SITES bp             *\/ */
-/* #define RU12SITES 6   */               
+/* #define RU12SITES 6   */
 
-/* One exon per L / REXONS bp      was 3         */
-#define REXONS 0.75               /* medium default (was 2); NUMEXONS=LENGTHSi/REXONS */
+/* One exon per L / REXONS bp  (divisor: smaller -> more exon headroom) */
+#ifndef REXONS
+#define REXONS 0.75
+#endif
 
 /* /\* One U12 intron-flanking exon per L / RU12EXONS bp               *\/ */
 /* #define RU12EXONS 6  */
 
-/* Estimated amount of backup signals       */
-#define RBSITES 75               
+/* Estimated amount of backup signals (divisor: smaller -> more backup) */
+#ifndef RBSITES
+#define RBSITES 75
+#endif
 
-/* Estimated amount of backup exons : was 125        */
-#define RBEXONS 125              
+/* Estimated amount of backup exons   (divisor: smaller -> more backup) */
+#ifndef RBEXONS
+#define RBEXONS 125
+#endif
 
 /* Ratios for every exon type               */
-#define RFIRST 3                 
+#define RFIRST 3
 #define RINTER 1
 #define RTERMI 2
-#define RSINGL 4 
+#define RSINGL 4
 #define RORF   4
 #define RUTR   0.5
 
-/* Total number of exons/fragment (factor) was 8,then 12 */
-#define FSORT 12                  
+/* Total number of exons/fragment (exon-sort factor; keep >= ~9) */
+#ifndef FSORT
+#define FSORT 12
+#endif
 
-/* Number of exons to save every fragment   */ 
-#define FDARRAY 10                 /* medium default (was 5) */
+/* Number of exons to save every fragment   */
+#ifndef FDARRAY
+#define FDARRAY 10
+#endif
 
 /* Basic values (in addition to ratios)     */
 #define BASEVALUESITES_SHORT 100000

--- a/include/geneid.h
+++ b/include/geneid.h
@@ -51,7 +51,7 @@ A. DEFINITIONS
 #define EVIDENCE  "evidence"           
 
 /* Length of every processed fragment       */ 
-#define LENGTHSi 220000          
+#define LENGTHSi 500000          /* medium default (was 220000) */
 
 /* Overlap between 2 fragments              */
 #define OVERLAP 10000            
@@ -63,7 +63,7 @@ A. DEFINITIONS
 /* #define RU12SITES 6   */               
 
 /* One exon per L / REXONS bp      was 3         */
-#define REXONS 2                
+#define REXONS 0.75               /* medium default (was 2); NUMEXONS=LENGTHSi/REXONS */
 
 /* /\* One U12 intron-flanking exon per L / RU12EXONS bp               *\/ */
 /* #define RU12EXONS 6  */
@@ -86,7 +86,7 @@ A. DEFINITIONS
 #define FSORT 12                  
 
 /* Number of exons to save every fragment   */ 
-#define FDARRAY 5
+#define FDARRAY 10                 /* medium default (was 5) */
 
 /* Basic values (in addition to ratios)     */
 #define BASEVALUESITES_SHORT 100000

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -38,6 +38,12 @@ extern int PSEQ;
 extern int tDNA;
 extern int PRINTINT;
 
+/* Clamp a per-feature index into tAA[] (sized MAXEXONGENE rows) so that a
+   gene with > MAXEXONGENE features can never read past the buffer. Pairs
+   with the MAXEXONGENE write cap in TranslateGene (Translate.c). */
+#define AAIDX(cf) ( ((cf)-COFFSET) < 0 ? 0 : \
+		    ( ((cf)-COFFSET) < MAXEXONGENE ? ((cf)-COFFSET) : MAXEXONGENE-1 ) )
+
 /* Local data structure to record stats about every gene */
 typedef struct s_gene
 {
@@ -414,7 +420,10 @@ long CookingInfo(exonGFF* eorig,
   /* starting from the last exon of the last gene (bottom-up) */
   igen = 0;
   stop = (e->Strand == '*');
-  while (!stop)
+  /* Guard: info[] has room for MAXGENE genes only. Stop recording before
+     writing past the buffer (was an unchecked overflow -> segfault on
+     very large/dense scaffolds with > MAXGENE predicted genes). */
+  while (!stop && (igen < MAXGENE))
     {
       /* A. Skip BEGIN/END features */
       if (!strcmp(e->Type,sEND) || !strcmp(e->Type,sBEGIN))
@@ -663,9 +672,16 @@ long CookingInfo(exonGFF* eorig,
 	    }
 	  info[igen].nintrons =  info[igen].nexons - 1;
 	  igen++;
-	} 
+	}
     }
-  
+
+  /* Warn (non-fatal) if the MAXGENE cap truncated the gene solution */
+  if (!stop && (igen >= MAXGENE))
+    fprintf(stderr,
+	    "Warning: reached MAXGENE limit (%d) recovering gene solution; "
+	    "output truncated. Increase MAXGENE in geneid.h and recompile.\n",
+	    MAXGENE);
+
   return (igen);
 }
 
@@ -784,7 +800,7 @@ void PrintGene(exonGFF* start,
 	      PrintSite(start->Acceptor,type1,Name,strand,s,p1);
 	      if (!strcmp(start->Type,sFIRST)||!strcmp(start->Type,sINTERNAL)||!strcmp(start->Type,sTERMINAL)||!strcmp(start->Type,sSINGLE)){
 		cdsnum = (start->Strand == '-')? ccds: info[geneindex].ncds - ccds + 1;
-		PrintGCDS(start,Name,s,dAA,igen,tAA[cfeats - COFFSET][0],tAA[cfeats - COFFSET][1],nAA,cdsnum,GenePrefix);
+		PrintGCDS(start,Name,s,dAA,igen,tAA[AAIDX(cfeats)][0],tAA[AAIDX(cfeats)][1],nAA,cdsnum,GenePrefix);
 	      }else{
 		utrnum = (start->Strand == '-')? cutrs: info[geneindex].nutrs - cutrs + 1;
 		PrintGUTR(start,Name,s,igen,utrnum,GenePrefix);
@@ -808,7 +824,7 @@ void PrintGene(exonGFF* start,
 	    /*this is for CDS and UTR features*/
 	    if (!strcmp(start->Type,sFIRST)||!strcmp(start->Type,sINTERNAL)||!strcmp(start->Type,sTERMINAL)||!strcmp(start->Type,sSINGLE)){
 	      cdsnum = (start->Strand == '-')? ccds: info[geneindex].ncds - ccds + 1;
-	      PrintGCDS(start,Name,s,dAA,igen,tAA[cfeats - COFFSET][0],tAA[cfeats- COFFSET][1],nAA,cdsnum,GenePrefix);
+	      PrintGCDS(start,Name,s,dAA,igen,tAA[AAIDX(cfeats)][0],tAA[AAIDX(cfeats)][1],nAA,cdsnum,GenePrefix);
 	    }else{
 	      utrnum = (start->Strand == '-')? cutrs: info[geneindex].nutrs - cutrs + 1;
 	      PrintGUTR(start,Name,s,igen,utrnum,GenePrefix);
@@ -888,7 +904,7 @@ void PrintGene(exonGFF* start,
 	      if (!strcmp(end->Type,sFIRST)||!strcmp(start->Type,sINTERNAL)||!strcmp(start->Type,sTERMINAL)||!strcmp(start->Type,sSINGLE)){
 		cdsnum = (start->Strand == '-')? ccds: info[geneindex].ncds - ccds + 1;
 		featnum = (start->Strand == '-')? cfeats: info[geneindex].nfeats - cfeats + 1;
-		PrintGCDS(end,Name,s,dAA,igen,tAA[cfeats - COFFSET][0],tAA[cfeats - COFFSET][1],nAA,cdsnum,GenePrefix);
+		PrintGCDS(end,Name,s,dAA,igen,tAA[AAIDX(cfeats)][0],tAA[AAIDX(cfeats)][1],nAA,cdsnum,GenePrefix);
 	      }else{
 		utrnum = (start->Strand == '-')? cutrs: info[geneindex].nutrs - cutrs + 1;
 		PrintGUTR(end,Name,s,igen,utrnum,GenePrefix);
@@ -899,7 +915,7 @@ void PrintGene(exonGFF* start,
 
 	    if (!strcmp(end->Type,sFIRST)||!strcmp(start->Type,sINTERNAL)||!strcmp(start->Type,sTERMINAL)||!strcmp(start->Type,sSINGLE)){		
 	      cdsnum = (start->Strand == '-')? ccds: info[geneindex].ncds - ccds + 1;
-	      PrintGCDS(end,Name,s,dAA,igen,tAA[cfeats - COFFSET][0],tAA[cfeats - COFFSET][1],nAA,cdsnum,GenePrefix);
+	      PrintGCDS(end,Name,s,dAA,igen,tAA[AAIDX(cfeats)][0],tAA[AAIDX(cfeats)][1],nAA,cdsnum,GenePrefix);
 	    }else{
 	      utrnum = (start->Strand == '-')? cutrs: info[geneindex].nutrs - cutrs + 1;
 	      PrintGUTR(end,Name,s,igen,utrnum,GenePrefix);

--- a/src/Translate.c
+++ b/src/Translate.c
@@ -50,22 +50,32 @@ int Translate(long p1,
 	}
 
   /* Translating complet codons in the exon */
+  /* Guard: sAux is sized MAXAA; never write past it (e.g. a huge */
+  /* single-exon ORF would otherwise smash the buffer). Leave headroom */
+  /* for the trailing remainder/shared codons appended by the caller.   */
   nAA = nAux;
-  for(i=p1+ fra; i<= p2 - rmd; i=i+3)
+  for(i=p1+ fra; i<= p2 - rmd && nAux < MAXAA - 8; i=i+3)
 	{
 	  codon[0] = s[i];
 	  codon[1] = s[i+1];
 	  codon[2] = s[i+2];
 	  codon[3] = '\0';
-        
+
 	  /* Looking up the amino acid dictionary */
 	  sAux[nAux] = getAADict(dAA,codon);
 	  nAux++;
 	}
+  if (i <= p2 - rmd)
+	{
+	  static int warnedAA = 0;
+	  if (!warnedAA)
+		{ fprintf(stderr,"Warning: exon translation reached MAXAA (%d); "
+				 "protein truncated.\n", MAXAA); warnedAA = 1; }
+	}
   nAA = nAux - nAA;
-   
+
   /* Saving last uncomplete codon in the exon (remainder) */
-  for(i=p2 - rmd + 1; i <= p2; i++)
+  for(i=p2 - rmd + 1; i <= p2 && nAux < MAXAA - 1; i++)
 	{
 	  sAux[nAux] = s[i] + 32;
 	  nAux++;
@@ -105,12 +115,22 @@ void TranslateGene(exonGFF* e,
   char rmdProt[LENGTHCODON+1];
   int lastExon = 1;
 
+  /* Guard: tAA has room for MAXEXONGENE features; warn once if a gene */
+  /* exceeds it (the exon loops below stop at MAXEXONGENE to stay safe). */
+  if (nExons > MAXEXONGENE)
+    {
+      static int warnedFeats = 0;
+      if (!warnedFeats)
+	{ fprintf(stderr,"Warning: gene has %ld features > MAXEXONGENE (%d); "
+			 "protein truncated.\n", nExons, MAXEXONGENE); warnedFeats = 1; }
+    }
+
   /* A. Translating a forward sense exon: Terminal > Internal >.. First */
   if (e->Strand == '+')
     {
       prot[0] = '\0';
-      /* Traversing the list of exons */      
-      for(i=0, totalAA=0, currFrame=0; i<nExons; i++)
+      /* Traversing the list of exons (bounded by MAXEXONGENE -> tAA size) */
+      for(i=0, totalAA=0, currFrame=0; i<nExons && i<MAXEXONGENE; i++)
 	{
 	  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){
 	    /* 0. Acquire the real positions of the exon in the sequence */
@@ -163,7 +183,7 @@ void TranslateGene(exonGFF* e,
 		codon[3] = '\0';
 		/* translate this codon */
 		aa = getAADict(dAA,codon);
-		lAux = strlen(sAux);
+		lAux = strlen(sAux); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
 		sAux[lAux] = aa;
 		sAux[lAux+1] = '\0'; 
 		break;
@@ -173,13 +193,26 @@ void TranslateGene(exonGFF* e,
 		codon[0] = s[p2];
 		codon[3] = '\0';
 		aa = getAADict(dAA,codon);
-		lAux = strlen(sAux);
+		lAux = strlen(sAux); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
 		sAux[lAux] = aa;
 		sAux[lAux+1] = '\0'; 
 		break;
 	      }
 
 	    /* Concat translation(current exon) with translation(last exon) */
+	    /* Guard: keep combined length within MAXAA (sAux/prot are MAXAA) */
+	    { long lsaux = (long) strlen(sAux);
+	      long room  = MAXAA - 8 - lsaux;
+	      if (room < 0) room = 0;
+	      if ((long) strlen(prot) > room)
+		{
+		  static int warnedProt = 0;
+		  if (!warnedProt)
+		    { fprintf(stderr,"Warning: protein reached MAXAA (%d); "
+				     "truncated.\n", MAXAA); warnedProt = 1; }
+		  prot[room] = '\0';
+		}
+	    }
 	    strcat(sAux,prot);
 	    /* Leaving the result into prot */
 	    strcpy(prot,sAux);
@@ -244,9 +277,9 @@ void TranslateGene(exonGFF* e,
   /* B. Translating a reverse sense exon: First > Internal >.. Terminal */
   else
     {
-      prot[0] = '\0'; 
-      /* Traversing the list of exons */
-      for(i=0, totalAA=0, currRmd=0; i<nExons; i++)
+      prot[0] = '\0';
+      /* Traversing the list of exons (bounded by MAXEXONGENE -> tAA size) */
+      for(i=0, totalAA=0, currRmd=0; i<nExons && i<MAXEXONGENE; i++)
 	{
 	  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){
 	    p1 = (e->evidence)? 
@@ -298,7 +331,7 @@ void TranslateGene(exonGFF* e,
 		codon[3] = '\0';
 		/* translate this codon */
 		aa = getAADict(dAA,codon);
-		lAux = strlen(prot);
+		lAux = strlen(prot); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
 		prot[lAux] = aa;
 		prot[lAux+1] = '\0'; 
 		break;
@@ -308,13 +341,26 @@ void TranslateGene(exonGFF* e,
 		codon[2] = rs[0];
 		codon[3] = '\0';
 		aa = getAADict(dAA,codon);
-		lAux = strlen(prot);
+		lAux = strlen(prot); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
 		prot[lAux] = aa;
 		prot[lAux+1] = '\0'; 
 		break;
 	      }
 	  
 	    /* exon translation after translated remainder */
+	    /* Guard: keep combined length within MAXAA (sAux/prot are MAXAA) */
+	    { long lprot = (long) strlen(prot);
+	      long room  = MAXAA - 8 - lprot;
+	      if (room < 0) room = 0;
+	      if ((long) strlen(sAux) > room)
+		{
+		  static int warnedProtR = 0;
+		  if (!warnedProtR)
+		    { fprintf(stderr,"Warning: protein reached MAXAA (%d); "
+				     "truncated.\n", MAXAA); warnedProtR = 1; }
+		  sAux[room] = '\0';
+		}
+	    }
 	    strcat(prot,sAux);
 	  
 	    /* Codon information for translating the next shared codon */
@@ -373,7 +419,7 @@ void TranslateGene(exonGFF* e,
 	  break;
 	}
       
-      lAux = strlen(prot);
+      lAux = strlen(prot); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
       for(j = 0; j < currRmd; j++)
 	prot[lAux+j] = rmdProt[j];
       prot[lAux+j] = '\0'; 
@@ -417,13 +463,15 @@ void GetcDNA(exonGFF* e,
 		  /* Get the cDNA for this exon */
 		  tmpDNA[0] = '\0';
    
-		  for(j=p1; j <= p2; j++)
+		  for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
 			tmpDNA[j-p1] = s[j];
         
 		  tmpDNA[j-p1]='\0';
         
 		  /* Concat the current cDNA before the previous */
-		  strcat(tmpDNA,cDNA);
+		  { long room = MAXCDNA - 1 - (long) strlen(tmpDNA); if (room < 0) room = 0;
+	    if ((long) strlen(cDNA) > room) cDNA[room] = '\0'; } /* guard MAXCDNA */
+	  strcat(tmpDNA,cDNA);
 		  strcpy(cDNA,tmpDNA);
         
 		  *nNN += p2-p1+1;
@@ -450,7 +498,7 @@ void GetcDNA(exonGFF* e,
 		  tmpDNA[0] = '\0';
 		  rs[0] = '\0';
    
-		  for(j=p1; j <= p2; j++)
+		  for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
 			tmpDNA[j-p1] = s[j];
         
 		  tmpDNA[j-p1]='\0';
@@ -459,7 +507,9 @@ void GetcDNA(exonGFF* e,
 		  rs[j-p1]='\0';
    
 		  /* Concat the current cDNA after the previous */
-		  strcat(cDNA,rs);
+		  { long room = MAXCDNA - 1 - (long) strlen(cDNA); if (room < 0) room = 0;
+	    if ((long) strlen(rs) > room) rs[room] = '\0'; } /* guard MAXCDNA */
+	  strcat(cDNA,rs);
    
 		  *nNN += p2-p1+1;
 		  }
@@ -508,13 +558,15 @@ void GetTDNA(exonGFF* e,
 	    /* Get the cDNA for this exon */
 	    tmpDNA[0] = '\0';
    
-	    for(j=p1; j <= p2; j++)
+	    for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
 	      tmpDNA[j-p1] = s[j];
         
 	    tmpDNA[j-p1]='\0';
         
 	    /* Concat the current cDNA before the previous */
-	    strcat(tmpDNA,cDNA);
+	    { long room = MAXCDNA - 1 - (long) strlen(tmpDNA); if (room < 0) room = 0;
+	    if ((long) strlen(cDNA) > room) cDNA[room] = '\0'; } /* guard MAXCDNA */
+	  strcat(tmpDNA,cDNA);
 	    strcpy(cDNA,tmpDNA);
         
 	    *nNN += p2-p1+1;
@@ -541,7 +593,7 @@ void GetTDNA(exonGFF* e,
 	    tmpDNA[0] = '\0';
 	    rs[0] = '\0';
    
-	    for(j=p1; j <= p2; j++)
+	    for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
 	      tmpDNA[j-p1] = s[j];
         
 	    tmpDNA[j-p1]='\0';
@@ -550,7 +602,9 @@ void GetTDNA(exonGFF* e,
 	    rs[j-p1]='\0';
    
 	    /* Concat the current cDNA after the previous */
-	    strcat(cDNA,rs);
+	    { long room = MAXCDNA - 1 - (long) strlen(cDNA); if (room < 0) room = 0;
+	    if ((long) strlen(rs) > room) rs[room] = '\0'; } /* guard MAXCDNA */
+	  strcat(cDNA,rs);
    
 	    *nNN += p2-p1+1;
 	 /*  } */


### PR DESCRIPTION
## Summary

Fixes a reproducible segfault in gene-solution recovery on large / prediction-dense scaffolds, hardens the surrounding fixed-size buffers, and adds a build-time memory profile system so geneid can be sized for the target machine.

Three commits:
1. **Fix heap-buffer overflow in gene-solution recovery** (+ defensive guards)
2. **Raise default array-sizing constants for modern hardware**
3. **Add `MEM=low/medium/high` build profiles (auto-detect by default)**

## The bug

```
../bin/geneid -P Hemorrhois_hippocrepis.geneid.optimized.param -3Uv rHemHip.H1.SUPER_1.fasta
...
> Recovering gene-solution...
zsh: segmentation fault
```

Input: a ~363.8 Mb snake scaffold. Reproduces on stock `master` (exit 139 / SIGSEGV).

## Root cause (AddressSanitizer)

```
heap-buffer-overflow WRITE at CookingGenes.c:555 in CookingInfo
  ... 48 bytes after a 960000-byte region allocated at CookingGenes.c:955
```

`CookingInfo()` records each recovered gene into `info[]` (`calloc(MAXGENE, sizeof(gene))`) inside a `while(!stop)` loop with **no bound on the gene index**. This scaffold's optimal structure has **20943 genes > `MAXGENE` (15000)**, so it writes past the buffer.

## What the PR does

**1. Overflow fix + guards** (`src/CookingGenes.c`, `src/Translate.c`, `include/geneid.h`)
- `MAXGENE` 15000 → 100000 (`info[]` is 64 B/gene, allocated once).
- Bound the `CookingInfo` recovery loop and warn (non-fatal) on truncation.
- Same defensive caps (cap + one-time warning, default sizes unchanged) on the sibling fixed-size buffers reachable from the recovery path:
  - `Translate()` — cap per-exon amino-acid writes into `sAux` at `MAXAA`.
  - `TranslateGene()` — bound exon loops by `MAXEXONGENE` (`tAA`), guard the `prot`/`sAux` accumulation, and clamp `lAux` so the shared-codon / trailing writes stay inside `MAXAA`.
  - `PrintGene()` — clamp the `tAA` row index to `[0, MAXEXONGENE-1]`.
  - `GetcDNA()` / `GetTDNA()` — cap the per-exon copy and the `cDNA` accumulation at `MAXCDNA`.

**2. Modern defaults** (`include/geneid.h`)
- `LENGTHSi` 220000 → 500000, `REXONS` 2 → 0.75, `FDARRAY` 5 → 10. Reserves ~13 GB on a large dense genome; actual peak RSS ~4 GB (lazy allocation).

**3. Memory profiles** (`Makefile`, `include/geneid.h`)
- The six memory-driver constants are wrapped in `#ifndef`; a `MEM` make variable injects `-D` overrides.

| profile | reserved (`-3Uv`, 363 Mb scaffold) | sizing |
|---|---|---|
| low | ~5 GB | ~original geneid sizing |
| medium (default) | ~13 GB | 16–24 GB machines |
| high | ~45 GB | servers, max headroom |

```
make             # MEM=auto: detect RAM (sysctl / /proc) -> pick a profile, printed on build
make MEM=low|medium|high
make print-mem   # show resolved profile + detected RAM
```
`auto` inspects the **build** machine; for build-here/run-there setups (clusters) pass an explicit `MEM=` matching the run node — explicit values bypass detection. Single source of truth (geneid.h defaults = medium); no duplicated makefiles.

## Verification

- **AddressSanitizer clean** at default sizes; guarded output **byte-identical** to pre-guard (only the `# date` comment line differs).
- Guards proven under forced-tiny caps (`MAXGENE=15000`, and `MAXAA=300`/`MAXEXONGENE=20`/`MAXCDNA=900`) that trigger every guard on real genes — runs complete (exit 0), **zero ASan errors**, warnings emitted instead of crashing. (This is how the subtle reverse-strand `lAux` creep was caught — it only manifests when a protein approaches `MAXAA`.)
- Full medium-profile run: exit 0, 20943 genes, peak RSS 3.77 GB.
- All three profiles + `MEM=auto` build clean.

## Notes
- The truncation guards drop tail data **with a loud `stderr` warning** rather than resizing — a safety net, not a behavior change at default sizes (the new ceilings sit well above what single-exon-dominated genomes produce). Growable buffers would be the proper follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
