### PR TITLE
CookingGenes: replace exon-type strcmp ladders with enum dispatch + predicates

### DIFF
--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -178,6 +178,25 @@ static int exonType2int(const char* type)
   return -1;
 }
 
+/* Predicates over the exon type (used by the gene-recovery/printing loops to
+   classify features). Each takes the type string and maps it via exonType2int. */
+static int isCodingExon(const char* type)  /* First / Internal / Terminal / Single */
+{
+  int c = exonType2int(type);
+  return c == FIRST || c == INTERNAL || c == TERMINAL || c == SINGLE;
+}
+static int isAnyIntron(const char* type)   /* coding or UTR intron, any flavor */
+{
+  int c = exonType2int(type);
+  return c == INTRON || c == UTRINTRON || c == UTR5INTRON || c == UTR3INTRON;
+}
+static int isHalfUTR(const char* type)     /* UTR exon carrying a single terminus */
+{
+  int c = exonType2int(type);
+  return c == UTRFIRSTHALF || c == UTR5INTERNALHALF
+      || c == UTR3INTERNALHALF || c == UTRTERMINALHALF;
+}
+
 /* Choose the signal types and flanking profiles used to (re)score an exon of
    a given type. type1/p1 is the 5' (left-in-sequence) signal, type2/p2 the
    3' (right) signal; on the reverse strand those two roles are swapped. */
@@ -351,32 +370,14 @@ long CookingInfo(exonGFF* eorig,
 	      info[igen].start = e;
 	      info[igen].end = e;
 	      info[igen].nfeats++;
-	      if (strcmp(e->Type,sINTRON)
-		  && strcmp(e->Type,sUTRINTRON)
-		  && strcmp(e->Type,sUTR5INTRON)
-		  && strcmp(e->Type,sUTR3INTRON)
-		  && strcmp(e->Type,sUTRFIRSTHALF)
-		  && strcmp(e->Type,sUTR5INTERNALHALF)
-		  && strcmp(e->Type,sUTR3INTERNALHALF)
-		  && strcmp(e->Type,sUTRTERMINALHALF)){
+	      if (!isAnyIntron(e->Type) && !isHalfUTR(e->Type)){
 		info[igen].nexons++;
 	      }
-	      if (strcmp(e->Type,sINTRON)
-		  && strcmp(e->Type,sUTRINTRON)
-		  && strcmp(e->Type,sUTR5INTRON)
-		  && strcmp(e->Type,sUTR3INTRON)
-		  && strcmp(e->Type,sFIRST)
-		  && strcmp(e->Type,sINTERNAL)
-		  && strcmp(e->Type,sTERMINAL)
-		  && strcmp(e->Type,sSINGLE)){
+	      if (!isAnyIntron(e->Type) && !isCodingExon(e->Type)){
 		info[igen].nutrs++;
 	      }
 
-	      if (!strcmp(e->Type,sFIRST)
-		  || !strcmp(e->Type,sINTERNAL)
-		  || !strcmp(e->Type,sTERMINAL)
-		  || !strcmp(e->Type,sSINGLE)
-		  ){
+	      if (isCodingExon(e->Type)){
 		info[igen].ncds++;
 	      }
 	      /* Evidences (annotations) not added if infinitum score */
@@ -410,31 +411,13 @@ long CookingInfo(exonGFF* eorig,
 				    
 		{  
 		  info[igen].nfeats++;
-		  if (strcmp(e->Type,sINTRON)
-		      && strcmp(e->Type,sUTRINTRON)
-		      && strcmp(e->Type,sUTR5INTRON)
-		      && strcmp(e->Type,sUTR3INTRON)
-		      && strcmp(e->Type,sUTRFIRSTHALF)
-		      && strcmp(e->Type,sUTR5INTERNALHALF)
-		      && strcmp(e->Type,sUTR3INTERNALHALF)
-		      && strcmp(e->Type,sUTRTERMINALHALF)){
+		  if (!isAnyIntron(e->Type) && !isHalfUTR(e->Type)){
 		    info[igen].nexons++;
 		  }
-		  if (strcmp(e->Type,sINTRON)
-		      && strcmp(e->Type,sUTRINTRON)
-		      && strcmp(e->Type,sUTR5INTRON)
-		      && strcmp(e->Type,sUTR3INTRON)
-		      && strcmp(e->Type,sFIRST)
-		      && strcmp(e->Type,sINTERNAL)
-		      && strcmp(e->Type,sTERMINAL)
-		      && strcmp(e->Type,sSINGLE)){
+		  if (!isAnyIntron(e->Type) && !isCodingExon(e->Type)){
 		    info[igen].nutrs++;
 		  }
-		  if (!strcmp(e->Type,sFIRST)
-		      || !strcmp(e->Type,sINTERNAL)
-		      || !strcmp(e->Type,sTERMINAL)
-		      || !strcmp(e->Type,sSINGLE)
-		      ){
+		  if (isCodingExon(e->Type)){
 		    info[igen].ncds++;
 		  }
 		  /* Evidences (annotations) not summed if infinite score */
@@ -472,31 +455,13 @@ long CookingInfo(exonGFF* eorig,
 		  info[igen].start = e;
 		  info[igen].end = e;
 		  info[igen].nfeats++;
-		  if (strcmp(e->Type,sINTRON)
-		      && strcmp(e->Type,sUTRINTRON)
-		      && strcmp(e->Type,sUTR5INTRON)
-		      && strcmp(e->Type,sUTR3INTRON)
-		      && strcmp(e->Type,sUTRFIRSTHALF)
-		      && strcmp(e->Type,sUTR5INTERNALHALF)
-		      && strcmp(e->Type,sUTR3INTERNALHALF)
-		      && strcmp(e->Type,sUTRTERMINALHALF)){
+		  if (!isAnyIntron(e->Type) && !isHalfUTR(e->Type)){
 		    info[igen].nexons++;
 		  }
-		  if (strcmp(e->Type,sINTRON)
-		      && strcmp(e->Type,sUTRINTRON)
-		      && strcmp(e->Type,sUTR5INTRON)
-		      && strcmp(e->Type,sUTR3INTRON)
-		      && strcmp(e->Type,sFIRST)
-		      && strcmp(e->Type,sINTERNAL)
-		      && strcmp(e->Type,sTERMINAL)
-		      && strcmp(e->Type,sSINGLE)){
+		  if (!isAnyIntron(e->Type) && !isCodingExon(e->Type)){
 		    info[igen].nutrs++;
 		  }
-		  if (!strcmp(e->Type,sFIRST)
-		      || !strcmp(e->Type,sINTERNAL)
-		      || !strcmp(e->Type,sTERMINAL)
-		      || !strcmp(e->Type,sSINGLE)
-		      ){
+		  if (isCodingExon(e->Type)){
 		    info[igen].ncds++;
 		  }
 		  if (e->Score==MAXSCORE)
@@ -526,31 +491,13 @@ long CookingInfo(exonGFF* eorig,
 		  while( !stop && !stop2 )
 		    { 
 		      info[igen].nfeats++;
-		      if (strcmp(e->Type,sINTRON)
-			  && strcmp(e->Type,sUTRINTRON)
-			  && strcmp(e->Type,sUTR5INTRON)
-			  && strcmp(e->Type,sUTR3INTRON)
-			  && strcmp(e->Type,sUTRFIRSTHALF)
-			  && strcmp(e->Type,sUTR5INTERNALHALF)
-			  && strcmp(e->Type,sUTR3INTERNALHALF)
-			  && strcmp(e->Type,sUTRTERMINALHALF)){
+		      if (!isAnyIntron(e->Type) && !isHalfUTR(e->Type)){
 			info[igen].nexons++;
 		      }
-		      if (strcmp(e->Type,sINTRON)
-			  && strcmp(e->Type,sUTRINTRON)
-			  && strcmp(e->Type,sUTR5INTRON)
-			  && strcmp(e->Type,sUTR3INTRON)
-			  && strcmp(e->Type,sFIRST)
-			  && strcmp(e->Type,sINTERNAL)
-			  && strcmp(e->Type,sTERMINAL)
-			  && strcmp(e->Type,sSINGLE)){
+		      if (!isAnyIntron(e->Type) && !isCodingExon(e->Type)){
 			info[igen].nutrs++;
 		      }
-		      if (!strcmp(e->Type,sFIRST)
-			  || !strcmp(e->Type,sINTERNAL)
-			  || !strcmp(e->Type,sTERMINAL)
-			  || !strcmp(e->Type,sSINGLE)
-			  ){
+		      if (isCodingExon(e->Type)){
 			info[igen].ncds++;
 		      }
 		      /* Evidences (annotations) not added if infinitum score */

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -147,6 +147,40 @@ void printProt(char* Name,
 }
 
 /* Returns signal types and profiles according to the type of input exon */
+/* Map an exon-type string (sFIRST, sINTERNAL, ...) to its integer code
+   (FIRST, INTERNAL, ... defined in geneid.h). Returns -1 if unrecognized.
+   This replaces the long strcmp ladders that dispatched on the type string. */
+static int exonType2int(const char* type)
+{
+  static const struct { const char* name; int code; } exonTypeTable[] = {
+    { sFIRST,            FIRST            },
+    { sINTERNAL,         INTERNAL         },
+    { sTERMINAL,         TERMINAL         },
+    { sSINGLE,           SINGLE           },
+    { sORF,              ORF              },
+    { sZEROLENGTH,       ZEROLENGTH       },
+    { sINTRON,           INTRON           },
+    { sUTRFIRST,         UTRFIRST         },
+    { sUTRFIRSTHALF,     UTRFIRSTHALF     },
+    { sUTRINTERNAL,      UTRINTERNAL      },
+    { sUTR5INTERNALHALF, UTR5INTERNALHALF },
+    { sUTR3INTERNALHALF, UTR3INTERNALHALF },
+    { sUTRTERMINALHALF,  UTRTERMINALHALF  },
+    { sUTRTERMINAL,      UTRTERMINAL      },
+    { sUTRINTRON,        UTRINTRON        },
+    { sUTR5INTRON,       UTR5INTRON       },
+    { sUTR3INTRON,       UTR3INTRON       },
+  };
+  size_t i;
+  for (i = 0; i < sizeof(exonTypeTable)/sizeof(exonTypeTable[0]); i++)
+    if (!strcmp(type, exonTypeTable[i].name))
+      return exonTypeTable[i].code;
+  return -1;
+}
+
+/* Choose the signal types and flanking profiles used to (re)score an exon of
+   a given type. type1/p1 is the 5' (left-in-sequence) signal, type2/p2 the
+   3' (right) signal; on the reverse strand those two roles are swapped. */
 void selectFeatures(char* exonType,
                     char exonStrand,
                     profile** p1,
@@ -159,234 +193,108 @@ void selectFeatures(char* exonType,
   if (exonStrand == '+')
     {
       *strand = FORWARD;
-      if (!strcmp(exonType,sFIRST))
+      switch (exonType2int(exonType))
 	{
-	  *type1 = STA;
-	  *type2 = DON;
-	  *p1 = gp->StartProfile;
-	  *p2 = gp->DonorProfile;
-	}
-      if (!strcmp(exonType,sINTERNAL))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;    
-	}
-      if (!strcmp(exonType,sZEROLENGTH))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;    
-	}
-      if (!strcmp(exonType,sTERMINAL))
-	{
-	  *type1 = ACC;
-	  *type2 = STO;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->StopProfile;    
-	}
-      if (!strcmp(exonType,sSINGLE))
-	{
-	  *type1 = STA;
-	  *type2 = STO;
-	  *p1 = gp->StartProfile;
-	  *p2 = gp->StopProfile;    
-	}
-      if (!strcmp(exonType,sINTRON))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTRINTRON))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTR5INTRON))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTR3INTRON))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTRFIRST))
-	{
-	  *type1 = TSS;
-	  *type2 = DON;
-	  *p1 = gp->StartProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTRFIRSTHALF))
-	{
-	  *type1 = TSS;
-	  *type2 = STA;
-	  *p1 = gp->StartProfile;
-	  *p2 = gp->StartProfile;		      
-	}
-      if (!strcmp(exonType,sUTRINTERNAL))
-	{
-	  *type1 = ACC;
-	  *type2 = DON;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTR5INTERNALHALF))
-	{
-	  *type1 = ACC;
-	  *type2 = STA;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->StartProfile;		      
-	}
-      if (!strcmp(exonType,sUTR3INTERNALHALF))
-	{
-	  *type1 = STO;
-	  *type2 = DON;
-	  *p1 = gp->StopProfile;
-	  *p2 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTRTERMINAL))
-	{
-	  *type1 = ACC;
-	  *type2 = TES;
-	  *p1 = gp->AcceptorProfile;
-	  *p2 = gp->StopProfile;		      
-	}
-      if (!strcmp(exonType,sUTRTERMINALHALF))
-	{
-	  *type1 = STO;
-	  *type2 = TES;
-	  *p1 = gp->StopProfile;
-	  *p2 = gp->StopProfile;		      
+	case FIRST:
+	  *type1 = STA; *type2 = DON;
+	  *p1 = gp->StartProfile;    *p2 = gp->DonorProfile;
+	  break;
+	case INTERNAL:
+	case ZEROLENGTH:
+	case INTRON:
+	case UTRINTRON:
+	case UTR5INTRON:
+	case UTR3INTRON:
+	case UTRINTERNAL:
+	  *type1 = ACC; *type2 = DON;
+	  *p1 = gp->AcceptorProfile; *p2 = gp->DonorProfile;
+	  break;
+	case TERMINAL:
+	  *type1 = ACC; *type2 = STO;
+	  *p1 = gp->AcceptorProfile; *p2 = gp->StopProfile;
+	  break;
+	case SINGLE:
+	  *type1 = STA; *type2 = STO;
+	  *p1 = gp->StartProfile;    *p2 = gp->StopProfile;
+	  break;
+	case UTRFIRST:
+	  *type1 = TSS; *type2 = DON;
+	  *p1 = gp->StartProfile;    *p2 = gp->DonorProfile;
+	  break;
+	case UTRFIRSTHALF:
+	  *type1 = TSS; *type2 = STA;
+	  *p1 = gp->StartProfile;    *p2 = gp->StartProfile;
+	  break;
+	case UTR5INTERNALHALF:
+	  *type1 = ACC; *type2 = STA;
+	  *p1 = gp->AcceptorProfile; *p2 = gp->StartProfile;
+	  break;
+	case UTR3INTERNALHALF:
+	  *type1 = STO; *type2 = DON;
+	  *p1 = gp->StopProfile;     *p2 = gp->DonorProfile;
+	  break;
+	case UTRTERMINAL:
+	  *type1 = ACC; *type2 = TES;
+	  *p1 = gp->AcceptorProfile; *p2 = gp->StopProfile;
+	  break;
+	case UTRTERMINALHALF:
+	  *type1 = STO; *type2 = TES;
+	  *p1 = gp->StopProfile;     *p2 = gp->StopProfile;
+	  break;
 	}
     }
-  /* Reverse strand */
+  /* Reverse strand: the 5'/3' signal roles (type1/type2, p1/p2) are swapped */
   else
     {
       *strand = REVERSE;
-      if (!strcmp(exonType,sFIRST))
+      switch (exonType2int(exonType))
 	{
-	  *type2 = STA;
-	  *type1 = DON;
-	  *p2 = gp->StartProfile;
-	  *p1 = gp->DonorProfile;    
-	}
-      if (!strcmp(exonType,sINTERNAL))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;    
-	}
-      if (!strcmp(exonType,sZEROLENGTH))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;    
-	}
-      if (!strcmp(exonType,sINTRON))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;
-	}
-      if (!strcmp(exonType,sUTRINTRON))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;
-	}
-      if (!strcmp(exonType,sUTR5INTRON))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;
-	}
-      if (!strcmp(exonType,sUTR3INTRON))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;
-	}
-      if (!strcmp(exonType,sTERMINAL))
-	{
-	  *type2 = ACC;
-	  *type1 = STO;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->StopProfile;    
-	}
-      if (!strcmp(exonType,sSINGLE))
-	{
-	  *type2 = STA;
-	  *type1 = STO;
-	  *p2 = gp->StartProfile;
-	  *p1 = gp->StopProfile;    
-	}
-       if (!strcmp(exonType,sUTRFIRST))
-	{
-	  *type2 = TSS;
-	  *type1 = DON;
-	  *p2 = gp->StartProfile;
-	  *p1 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTRFIRSTHALF))
-	{
-	  *type2 = TSS;
-	  *type1 = STA;
-	  *p2 = gp->StartProfile;
-	  *p1 = gp->StartProfile;		      
-	}
-      if (!strcmp(exonType,sUTRINTERNAL))
-	{
-	  *type2 = ACC;
-	  *type1 = DON;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTR5INTERNALHALF))
-	{
-	  *type2 = ACC;
-	  *type1 = STA;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->StartProfile;		      
-	}
-      if (!strcmp(exonType,sUTR3INTERNALHALF))
-	{
-	  *type2 = STO;
-	  *type1 = DON;
-	  *p2 = gp->StopProfile;
-	  *p1 = gp->DonorProfile;		      
-	}
-      if (!strcmp(exonType,sUTRTERMINAL))
-	{
-	  *type2 = ACC;
-	  *type1 = TES;
-	  *p2 = gp->AcceptorProfile;
-	  *p1 = gp->StopProfile;		      
-	}
-      if (!strcmp(exonType,sUTRTERMINALHALF))
-	{
-	  *type2 = STO;
-	  *type1 = TES;
-	  *p2 = gp->StopProfile;
-	  *p1 = gp->StopProfile;		      
+	case FIRST:
+	  *type2 = STA; *type1 = DON;
+	  *p2 = gp->StartProfile;    *p1 = gp->DonorProfile;
+	  break;
+	case INTERNAL:
+	case ZEROLENGTH:
+	case INTRON:
+	case UTRINTRON:
+	case UTR5INTRON:
+	case UTR3INTRON:
+	case UTRINTERNAL:
+	  *type2 = ACC; *type1 = DON;
+	  *p2 = gp->AcceptorProfile; *p1 = gp->DonorProfile;
+	  break;
+	case TERMINAL:
+	  *type2 = ACC; *type1 = STO;
+	  *p2 = gp->AcceptorProfile; *p1 = gp->StopProfile;
+	  break;
+	case SINGLE:
+	  *type2 = STA; *type1 = STO;
+	  *p2 = gp->StartProfile;    *p1 = gp->StopProfile;
+	  break;
+	case UTRFIRST:
+	  *type2 = TSS; *type1 = DON;
+	  *p2 = gp->StartProfile;    *p1 = gp->DonorProfile;
+	  break;
+	case UTRFIRSTHALF:
+	  *type2 = TSS; *type1 = STA;
+	  *p2 = gp->StartProfile;    *p1 = gp->StartProfile;
+	  break;
+	case UTR5INTERNALHALF:
+	  *type2 = ACC; *type1 = STA;
+	  *p2 = gp->AcceptorProfile; *p1 = gp->StartProfile;
+	  break;
+	case UTR3INTERNALHALF:
+	  *type2 = STO; *type1 = DON;
+	  *p2 = gp->StopProfile;     *p1 = gp->DonorProfile;
+	  break;
+	case UTRTERMINAL:
+	  *type2 = ACC; *type1 = TES;
+	  *p2 = gp->AcceptorProfile; *p1 = gp->StopProfile;
+	  break;
+	case UTRTERMINALHALF:
+	  *type2 = STO; *type1 = TES;
+	  *p2 = gp->StopProfile;     *p1 = gp->StopProfile;
+	  break;
 	}
     }
 }


### PR DESCRIPTION
Phase 2 target #4 (tame the `CookingGenes.c` strcmp ladders), the clean half. Two commits, each byte-identical on all four regression cases and ASan-clean:

1. **selectFeatures → enum dispatch.** The function dispatched on the exon-type *string* via two parallel ladders of ~16 independent `strcmp()`s (one per strand). Added a table-based `exonType2int()` mapping the type string to the integer code already defined in `geneid.h` (`FIRST`, `INTERNAL`, …), and rewrote both ladders as `switch` statements. The seven types sharing the acceptor/donor profile pair collapse into one grouped case.

2. **CookingInfo membership ladders → named predicates.** `CookingInfo()` classified each feature with three 8-term `strcmp` chains repeated 4× (forward/reverse × initial/loop). Replaced with `isAnyIntron()` / `isHalfUTR()` / `isCodingExon()` built on `exonType2int()`.

Net: `strcmp` calls in `CookingGenes.c` drop from **209 → 99**, with no logic change.

**Deliberately out of scope:** `PrintGene()`'s remaining strcmps are bespoke boolean expressions mixing `start->Type`, `eaux->Type`, `end->Type`, and strand — they can't be mechanically converted without risking behavior change, so they're left for a separate careful pass. While reading them I noticed a likely latent copy-paste bug (one test reads `end->Type` for the `First` case where the surrounding terms all use `start->Type`); I left it untouched here since this PR is strictly behavior-preserving — flagging it for a follow-up.

Verified with `test/regression/run.sh` (snake, human, morc_u12, rnaseq) + AddressSanitizer. Targets `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)