### PR TITLE
CookingGenes/Translate: right-size tAA[] to the largest gene (drop MAXEXONGENE)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -149,9 +149,6 @@ A. DEFINITIONS
 /* Not a ceiling: the array doubles on demand, so gene count is data-driven. */
 #define INITGENES 256
 
-/* Maximum number of exons in a gene        */
-#define MAXEXONGENE 1000         
-
 /* Maximum length of a protein              */
 #define MAXAA 50000              
 

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -38,11 +38,10 @@ extern int PSEQ;
 extern int tDNA;
 extern int PRINTINT;
 
-/* Clamp a per-feature index into tAA[] (sized MAXEXONGENE rows) so that a
-   gene with > MAXEXONGENE features can never read past the buffer. Pairs
-   with the MAXEXONGENE write cap in TranslateGene (Translate.c). */
-#define AAIDX(cf) ( ((cf)-COFFSET) < 0 ? 0 : \
-		    ( ((cf)-COFFSET) < MAXEXONGENE ? ((cf)-COFFSET) : MAXEXONGENE-1 ) )
+/* Map a per-feature counter to a tAA[] row index. tAA is sized to the
+   largest gene's feature count (see CookingGenes), so cf-COFFSET is always
+   within range; the low-end clamp stays as a defensive guard. */
+#define AAIDX(cf) ( ((cf)-COFFSET) < 0 ? 0 : ((cf)-COFFSET) )
 
 /* Local data structure to record stats about every gene */
 typedef struct s_gene
@@ -823,6 +822,7 @@ void CookingGenes(exonGFF* e,
   int** tAA;
   double artificialScore;
   long i;
+  long tAArows;
   long cexons;
   long cintrons;
   long cutrs;
@@ -840,18 +840,22 @@ void CookingGenes(exonGFF* e,
   if ((info = (gene *) calloc(infocap,sizeof(gene))) == NULL)
     printError("Not enough memory: post-processing genes");
   
-  /* tAA[gene][exon[0] is the first amino acid of that exon */
-  /* tAA[gene][exon[1] is the last amino acid of that exon */
-  /* according to the protein product for that gene */
-  if ((tAA = (int**) calloc(MAXEXONGENE,sizeof(int*))) == NULL)
-    printError("Not enough memory: tAA general structure");
-  
-  for(i=0; i<MAXEXONGENE; i++)
-    if ((tAA[i] = (int*) calloc(2,sizeof(int))) == NULL)
-      printError("Not enough memory: tAA[] structure");
-  
   /* Post-processing of genes */
   ngen = CookingInfo(e,&info,&infocap,&artificialScore);
+
+  /* tAA[feature][0] = first amino acid of that feature's CDS, [1] = last.
+     Size it to the largest gene's feature count (no MAXEXONGENE ceiling):
+     PrintGene reads tAA[cfeats-COFFSET] and TranslateGene writes tAA[0..nfeats),
+     both bounded by that gene's nfeats. */
+  tAArows = 1;
+  for(i=0; i<ngen; i++)
+    if (info[i].nfeats > tAArows) tAArows = info[i].nfeats;
+  if ((tAA = (int**) calloc(tAArows,sizeof(int*))) == NULL)
+    printError("Not enough memory: tAA general structure");
+
+  for(i=0; i<tAArows; i++)
+    if ((tAA[i] = (int*) calloc(2,sizeof(int))) == NULL)
+      printError("Not enough memory: tAA[] structure");
   
   /* Protein space */
   /* if (PSEQ) */
@@ -1035,7 +1039,7 @@ void CookingGenes(exonGFF* e,
   if (PSEQ)
     free(prot);
   free(info);
-  for(i=0; i<MAXEXONGENE; i++)
+  for(i=0; i<tAArows; i++)
     free(tAA[i]);
   if (cDNA)
     free(tmpDNA);

--- a/src/Translate.c
+++ b/src/Translate.c
@@ -115,22 +115,12 @@ void TranslateGene(exonGFF* e,
   char rmdProt[LENGTHCODON+1];
   int lastExon = 1;
 
-  /* Guard: tAA has room for MAXEXONGENE features; warn once if a gene */
-  /* exceeds it (the exon loops below stop at MAXEXONGENE to stay safe). */
-  if (nExons > MAXEXONGENE)
-    {
-      static int warnedFeats = 0;
-      if (!warnedFeats)
-	{ fprintf(stderr,"Warning: gene has %ld features > MAXEXONGENE (%d); "
-			 "protein truncated.\n", nExons, MAXEXONGENE); warnedFeats = 1; }
-    }
-
   /* A. Translating a forward sense exon: Terminal > Internal >.. First */
   if (e->Strand == '+')
     {
       prot[0] = '\0';
-      /* Traversing the list of exons (bounded by MAXEXONGENE -> tAA size) */
-      for(i=0, totalAA=0, currFrame=0; i<nExons && i<MAXEXONGENE; i++)
+      /* Traversing the list of features; tAA is sized to hold all nExons */
+      for(i=0, totalAA=0, currFrame=0; i<nExons; i++)
 	{
 	  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){
 	    /* 0. Acquire the real positions of the exon in the sequence */
@@ -278,8 +268,8 @@ void TranslateGene(exonGFF* e,
   else
     {
       prot[0] = '\0';
-      /* Traversing the list of exons (bounded by MAXEXONGENE -> tAA size) */
-      for(i=0, totalAA=0, currRmd=0; i<nExons && i<MAXEXONGENE; i++)
+      /* Traversing the list of features; tAA is sized to hold all nExons */
+      for(i=0, totalAA=0, currRmd=0; i<nExons; i++)
 	{
 	  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){
 	    p1 = (e->evidence)? 


### PR DESCRIPTION
## Phase 2, Target #1 (growable arrays) — sub-target 1b

Right-sizes the `tAA[]` table (per-feature first/last amino-acid indices, used to print CDS phase) instead of capping it at a fixed `MAXEXONGENE`=1000 features.

Previously a gene with > `MAXEXONGENE` features hit the v1.4.6 truncation guard: `TranslateGene` capped its write loops at `MAXEXONGENE`, the `AAIDX` read macro clamped to `MAXEXONGENE-1`, and a "protein truncated" warning fired.

### Changes
- `tAA` is now allocated **after** `CookingInfo` (once `info[]` is populated), sized to the **largest gene's feature count**. `PrintGene` reads `tAA[cfeats-COFFSET]` and `TranslateGene` writes `tAA[0..nfeats)`, both bounded by that gene's `nfeats` — so one row per feature of the biggest gene is exactly enough.
- Removed the `MAXEXONGENE` write caps in `TranslateGene`, the read clamp in `AAIDX` (keeps only its defensive low-end guard), and the truncation warning.
- `MAXEXONGENE` is now unused → dropped from `geneid.h`.

### Verification
- Regression suite **4/4 byte-identical**.
- **ASan-clean** on the snake (full `-3UDTA` protein/cDNA/tDNA) and morc_u12 (dense multi-feature) fixtures — exercises the read/write at the exact right-sized boundary.

Second of the Target #1 sub-targets. Remaining: the exon/site build tables (NUMEXONS×FSORT, NUMSITES) — the dominant reservation that makes the MEM build profiles unnecessary; protein/cDNA string buffers stay deferred to Target #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)