### PR TITLE
Translate: grow cDNA/tDNA transcript buffers instead of capping at MAXCDNA

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -152,8 +152,9 @@ A. DEFINITIONS
 /* Maximum length of a protein              */
 #define MAXAA 50000              
 
-/* Maximum length of (cDNA) in genes        */
-#define MAXCDNA MAXAA*3          
+/* Initial capacity of the growable cDNA/tDNA transcript buffers (GetcDNA/   */
+/* GetTDNA). Not a ceiling: the buffers grow to fit the transcript length.   */
+#define INITCDNA 4096
 
 /* Maximum number of isochores              */
 #define MAXISOCHORES 4           
@@ -1059,8 +1060,8 @@ void ScoreExons(char *Sequence,
                 int nIsochores,
                 packGC* GCInfo);
 
-void GetcDNA(exonGFF* e, char* s, long nExons, char* cDNA, long* nNN);
-void GetTDNA(exonGFF* e, char* s, long nExons, char* tDNA, long* nTN);
+void GetcDNA(exonGFF* e, char* s, long nExons, char** cDNA, long* cap, long* nNN);
+void GetTDNA(exonGFF* e, char* s, long nExons, char** tDNA, long* cap, long* nTN);
 
 float ComputeGC(packGC* GCInfo, long inigc, long endgc);
 

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -818,6 +818,8 @@ void CookingGenes(exonGFF* e,
   char* prot;
   char* tmpDNA;
   char* tmpTDNA;
+  long tmpDNAcap;
+  long tmpTDNAcap;
   long nAA, nNN, nTN;
   int** tAA;
   double artificialScore;
@@ -832,7 +834,9 @@ void CookingGenes(exonGFF* e,
 
   tmpDNA = NULL;
   tmpTDNA = NULL;
-  
+  tmpDNAcap = 0;
+  tmpTDNAcap = 0;
+
 
   /* Get info about each gene (growable: starts at INITGENES, doubles as
      CookingInfo records more genes -- gene count is no longer capped). */
@@ -862,14 +866,18 @@ void CookingGenes(exonGFF* e,
   if ((prot = (char*) calloc(MAXAA,sizeof(char))) == NULL)
     printError("Not enough memory: protein product");
   
-  /* cDNA memory if required */
-  if (cDNA)
-    if ((tmpDNA = (char*) calloc(MAXCDNA,sizeof(char))) == NULL)
+  /* cDNA memory if required (growable: GetcDNA grows it to fit the transcript) */
+  if (cDNA){
+    tmpDNAcap = INITCDNA;
+    if ((tmpDNA = (char*) calloc(tmpDNAcap,sizeof(char))) == NULL)
       printError("Not enough memory: cDNA product");
-  /* tDNA memory if required */
-  if (tDNA)
-    if ((tmpTDNA = (char*) calloc(MAXCDNA,sizeof(char))) == NULL)
+  }
+  /* tDNA memory if required (growable: GetTDNA grows it to fit the transcript) */
+  if (tDNA){
+    tmpTDNAcap = INITCDNA;
+    if ((tmpTDNA = (char*) calloc(tmpTDNAcap,sizeof(char))) == NULL)
       printError("Not enough memory: tDNA product");
+  }
   
   /* Principal header: forced annotations not used in gene score sum */
   if (XML)
@@ -893,9 +901,9 @@ void CookingGenes(exonGFF* e,
       
       /* Get genomic DNA for exons if required */
       if (cDNA)
-	GetcDNA(info[igen].start,s,(info[igen].nfeats), tmpDNA, &nNN);
+	GetcDNA(info[igen].start,s,(info[igen].nfeats), &tmpDNA, &tmpDNAcap, &nNN);
       if (tDNA)
-	GetTDNA(info[igen].start,s,(info[igen].nfeats), tmpTDNA, &nTN);
+	GetTDNA(info[igen].start,s,(info[igen].nfeats), &tmpTDNA, &tmpTDNAcap, &nTN);
 	  
       /* Gene header */
       if (XML)
@@ -1018,7 +1026,7 @@ void CookingGenes(exonGFF* e,
       /* Pretty-printing of every gene */
       for(igen=ngen-1; igen>=0; igen--)
 	{
-	  GetcDNA(info[igen].start,s,(info[igen].nfeats), tmpDNA, &nNN);
+	  GetcDNA(info[igen].start,s,(info[igen].nfeats), &tmpDNA, &tmpDNAcap, &nNN);
 	  if (nNN > 0)
 	    printProt(Name,ngen-igen,tmpDNA,nNN,DNA,GenePrefix);
 
@@ -1028,7 +1036,7 @@ void CookingGenes(exonGFF* e,
       /* Pretty-printing of every gene */
       for(igen=ngen-1; igen>=0; igen--)
 	{
-	  GetTDNA(info[igen].start,s,(info[igen].nfeats), tmpTDNA, &nTN);
+	  GetTDNA(info[igen].start,s,(info[igen].nfeats), &tmpTDNA, &tmpTDNAcap, &nTN);
 	  printProt(Name,ngen-igen,tmpTDNA,nTN,TDNA,GenePrefix);
 
 	}
@@ -1043,6 +1051,8 @@ void CookingGenes(exonGFF* e,
     free(tAA[i]);
   if (cDNA)
     free(tmpDNA);
+  if (tDNA)
+    free(tmpTDNA);
 }
 
 

--- a/src/Translate.c
+++ b/src/Translate.c
@@ -29,6 +29,25 @@
 
 #include "geneid.h"
 
+/* Grow *buf (a C string buffer) so it can hold at least `need` bytes,        */
+/* preserving existing contents. Used by the cDNA/tDNA builders so the        */
+/* transcript length is data-driven rather than capped at a fixed size.       */
+static void growStr(char** buf, long* cap, long need)
+{
+  long ncap;
+  char* tmp;
+
+  if (need <= *cap)
+    return;
+  ncap = (*cap > 0) ? *cap : 1;
+  while (ncap < need)
+    ncap *= 2;
+  if ((tmp = (char*) realloc(*buf, ncap * sizeof(char))) == NULL)
+    printError("Not enough memory: growing sequence buffer");
+  *buf = tmp;
+  *cap = ncap;
+}
+
 /* Obtaining the amino acid sequence from an exon (given a reading frame) */
 int Translate(long p1,
               long p2,
@@ -424,17 +443,20 @@ void TranslateGene(exonGFF* e,
 void GetcDNA(exonGFF* e,
              char* s,
              long nExons,
-             char* cDNA,
+             char** pcDNA,
+             long* pcap,
              long* nNN)
-{  
-  char* tmpDNA;
+{
+  char* cDNA = *pcDNA;
+  long  cap  = *pcap;
+  char* tmpDNA = NULL;
+  long  tmpcap = 0;
+  char* rs = NULL;
+  long  rscap = 0;
   long p1,p2;
-  char* rs;
+  long ltmp,lc;
   int i;
   long j;
-
-  if ((tmpDNA = (char*) calloc(MAXCDNA,sizeof(char))) == NULL)
-    printError("Not enough memory: producing CDS DNA");
 
   cDNA[0] = '\0';
 
@@ -443,27 +465,30 @@ void GetcDNA(exonGFF* e,
       for(i=0, *nNN = 0; i<nExons; i++)
 		{
 		  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){
-		    p1 = (e->evidence)? 
-		      e->Acceptor->Position + e->offset1: 
+		    p1 = (e->evidence)?
+		      e->Acceptor->Position + e->offset1:
 		      e->Acceptor->Position + e->offset1 - COFFSET;
-		    p2 = (e->evidence)? 
-		      e->Donor->Position + e->offset2: 
+		    p2 = (e->evidence)?
+		      e->Donor->Position + e->offset2:
 		      e->Donor->Position + e->offset2 - COFFSET;
-	  
+
 		  /* Get the cDNA for this exon */
+		  growStr(&tmpDNA,&tmpcap, p2-p1+2);
 		  tmpDNA[0] = '\0';
-   
-		  for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
+
+		  for(j=p1; j <= p2; j++)
 			tmpDNA[j-p1] = s[j];
-        
+
 		  tmpDNA[j-p1]='\0';
-        
+
 		  /* Concat the current cDNA before the previous */
-		  { long room = MAXCDNA - 1 - (long) strlen(tmpDNA); if (room < 0) room = 0;
-	    if ((long) strlen(cDNA) > room) cDNA[room] = '\0'; } /* guard MAXCDNA */
-	  strcat(tmpDNA,cDNA);
+		  ltmp = (long) strlen(tmpDNA);
+		  lc   = (long) strlen(cDNA);
+		  growStr(&tmpDNA,&tmpcap, ltmp+lc+1);
+		  strcat(tmpDNA,cDNA);
+		  growStr(&cDNA,&cap, ltmp+lc+1);
 		  strcpy(cDNA,tmpDNA);
-        
+
 		  *nNN += p2-p1+1;
 		  }
 		  e = e->PreviousExon;
@@ -472,46 +497,45 @@ void GetcDNA(exonGFF* e,
   /* Reverse and complement the sequence in this strand */
   else
     {
-      if ((rs = (char*) calloc(MAXCDNA,sizeof(char))) == NULL)
-		printError("Not enough memory: producing reverse CDS DNA");
-
       for(i=0, *nNN = 0; i<nExons; i++)
 		{
 		  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){
-		    p1 = (e->evidence)? 
-		      e->Acceptor->Position + e->offset1: 
+		    p1 = (e->evidence)?
+		      e->Acceptor->Position + e->offset1:
 		      e->Acceptor->Position + e->offset1 - COFFSET;
-		    p2 = (e->evidence)? 
-		      e->Donor->Position + e->offset2: 
+		    p2 = (e->evidence)?
+		      e->Donor->Position + e->offset2:
 		      e->Donor->Position + e->offset2 - COFFSET;
 		  /* Get the cDNA for this exon */
+		  growStr(&tmpDNA,&tmpcap, p2-p1+2);
+		  growStr(&rs,&rscap, p2-p1+2);
 		  tmpDNA[0] = '\0';
 		  rs[0] = '\0';
-   
-		  for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
+
+		  for(j=p1; j <= p2; j++)
 			tmpDNA[j-p1] = s[j];
-        
+
 		  tmpDNA[j-p1]='\0';
-        
+
 		  ReverseSubSequence(0, j-p1-1, tmpDNA, rs);
 		  rs[j-p1]='\0';
-   
+
 		  /* Concat the current cDNA after the previous */
-		  { long room = MAXCDNA - 1 - (long) strlen(cDNA); if (room < 0) room = 0;
-	    if ((long) strlen(rs) > room) rs[room] = '\0'; } /* guard MAXCDNA */
-	  strcat(cDNA,rs);
-   
+		  growStr(&cDNA,&cap, (long)strlen(cDNA)+(long)strlen(rs)+1);
+		  strcat(cDNA,rs);
+
 		  *nNN += p2-p1+1;
 		  }
 		  e = e->PreviousExon;
-		  
-		} 
-      /* Set free reverse sequence */
-      free(rs);
+
+		}
     }
 
-  /* Set free temporary result sequence */
-  free(tmpDNA);
+  /* Set free temporary buffers; hand back the (possibly grown) result */
+  if (tmpDNA) free(tmpDNA);
+  if (rs) free(rs);
+  *pcDNA = cDNA;
+  *pcap = cap;
 }
 
 /* Extract the genomic (exonic) sequence of a predicted gene */
@@ -519,17 +543,20 @@ void GetcDNA(exonGFF* e,
 void GetTDNA(exonGFF* e,
              char* s,
              long nExons,
-             char* cDNA,
+             char** pcDNA,
+             long* pcap,
              long* nNN)
-{  
-  char* tmpDNA;
+{
+  char* cDNA = *pcDNA;
+  long  cap  = *pcap;
+  char* tmpDNA = NULL;
+  long  tmpcap = 0;
+  char* rs = NULL;
+  long  rscap = 0;
   long p1,p2;
-  char* rs;
+  long ltmp,lc;
   int i;
   long j;
-
-  if ((tmpDNA = (char*) calloc(MAXCDNA,sizeof(char))) == NULL)
-    printError("Not enough memory: producing exonic DNA");
 
   cDNA[0] = '\0';
 
@@ -538,27 +565,30 @@ void GetTDNA(exonGFF* e,
       for(i=0, *nNN = 0; i<nExons; i++)
 	{
 /* 	  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){ */
-	    p1 = (e->evidence)? 
-	      e->Acceptor->Position + e->offset1: 
+	    p1 = (e->evidence)?
+	      e->Acceptor->Position + e->offset1:
 	      e->Acceptor->Position + e->offset1 - COFFSET;
-	    p2 = (e->evidence)? 
-	      e->Donor->Position + e->offset2: 
+	    p2 = (e->evidence)?
+	      e->Donor->Position + e->offset2:
 	      e->Donor->Position + e->offset2 - COFFSET;
-	  
+
 	    /* Get the cDNA for this exon */
+	    growStr(&tmpDNA,&tmpcap, p2-p1+2);
 	    tmpDNA[0] = '\0';
-   
-	    for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
+
+	    for(j=p1; j <= p2; j++)
 	      tmpDNA[j-p1] = s[j];
-        
+
 	    tmpDNA[j-p1]='\0';
-        
+
 	    /* Concat the current cDNA before the previous */
-	    { long room = MAXCDNA - 1 - (long) strlen(tmpDNA); if (room < 0) room = 0;
-	    if ((long) strlen(cDNA) > room) cDNA[room] = '\0'; } /* guard MAXCDNA */
-	  strcat(tmpDNA,cDNA);
+	    ltmp = (long) strlen(tmpDNA);
+	    lc   = (long) strlen(cDNA);
+	    growStr(&tmpDNA,&tmpcap, ltmp+lc+1);
+	    strcat(tmpDNA,cDNA);
+	    growStr(&cDNA,&cap, ltmp+lc+1);
 	    strcpy(cDNA,tmpDNA);
-        
+
 	    *nNN += p2-p1+1;
 	  /* } */
 	  e = e->PreviousExon;
@@ -567,44 +597,43 @@ void GetTDNA(exonGFF* e,
   /* Reverse and complement the sequence in this strand */
   else
     {
-      if ((rs = (char*) calloc(MAXCDNA,sizeof(char))) == NULL)
-	printError("Not enough memory: producing reverse exonic DNA");
-
       for(i=0, *nNN = 0; i<nExons; i++)
 	{
 /* 	  if (!strcmp(e->Type,sSINGLE)||!strcmp(e->Type,sFIRST)||!strcmp(e->Type,sINTERNAL)||!strcmp(e->Type,sTERMINAL)){ */
-	    p1 = (e->evidence)? 
-	      e->Acceptor->Position + e->offset1: 
+	    p1 = (e->evidence)?
+	      e->Acceptor->Position + e->offset1:
 	      e->Acceptor->Position + e->offset1 - COFFSET;
-	    p2 = (e->evidence)? 
-	      e->Donor->Position + e->offset2: 
+	    p2 = (e->evidence)?
+	      e->Donor->Position + e->offset2:
 	      e->Donor->Position + e->offset2 - COFFSET;
 	    /* Get the cDNA for this exon */
+	    growStr(&tmpDNA,&tmpcap, p2-p1+2);
+	    growStr(&rs,&rscap, p2-p1+2);
 	    tmpDNA[0] = '\0';
 	    rs[0] = '\0';
-   
-	    for(j=p1; j <= p2 && (j-p1) < MAXCDNA - 1; j++)
+
+	    for(j=p1; j <= p2; j++)
 	      tmpDNA[j-p1] = s[j];
-        
+
 	    tmpDNA[j-p1]='\0';
-        
+
 	    ReverseSubSequence(0, j-p1-1, tmpDNA, rs);
 	    rs[j-p1]='\0';
-   
+
 	    /* Concat the current cDNA after the previous */
-	    { long room = MAXCDNA - 1 - (long) strlen(cDNA); if (room < 0) room = 0;
-	    if ((long) strlen(rs) > room) rs[room] = '\0'; } /* guard MAXCDNA */
-	  strcat(cDNA,rs);
-   
+	    growStr(&cDNA,&cap, (long)strlen(cDNA)+(long)strlen(rs)+1);
+	    strcat(cDNA,rs);
+
 	    *nNN += p2-p1+1;
 	 /*  } */
 	  e = e->PreviousExon;
-		  
-	} 
-      /* Set free reverse sequence */
-      free(rs);
+
+	}
     }
 
-  /* Set free temporary result sequence */
-  free(tmpDNA);
+  /* Set free temporary buffers; hand back the (possibly grown) result */
+  if (tmpDNA) free(tmpDNA);
+  if (rs) free(rs);
+  *pcDNA = cDNA;
+  *pcap = cap;
 }


### PR DESCRIPTION
## Phase 2, Target #5 (fragile string building) — cDNA/tDNA buffers

`GetcDNA`/`GetTDNA` built the transcript in fixed `MAXCDNA` (= `MAXAA*3` = 150 000) buffers. A longer gene hit the v1.4.6 truncation guards — the per-exon copy loops stopped at `MAXCDNA-1` and the concat steps clamped the running string — **silently truncating** the printed cDNA/tDNA.

### Changes
- New small `growStr()` helper realloc-doubles a `char` buffer to fit (contents preserved).
- `GetcDNA`/`GetTDNA` now take the caller's buffer **+ capacity by reference** and grow it to the transcript length; their per-exon temporaries (`tmpDNA`, `rs`) grow to the exon length. The `MAXCDNA` copy bounds, the concat clamps, and the cap are removed.
- `MAXCDNA` dropped from `geneid.h` in favour of `INITCDNA` (initial size only).
- Also frees `tmpTDNA`, which was leaked.

### Verification
- Regression suite **4/4 byte-identical** — including a run with `INITCDNA` forced to **4** (many reallocs): output unchanged.
- **ASan-clean** on the snake (reverse-strand) and human (forward-strand) fixtures, both cDNA and tDNA paths.

First step of Target #5. The protein (`MAXAA`) path — `sAux`/`prot` with codon/frame bookkeeping in `Translate`/`TranslateGene` — is a separate follow-up. (Target #1's remaining 1c, the exon/site tables, is still deferred per earlier discussion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)