### PR TITLE
Translate: grow the whole-protein buffer instead of capping at MAXAA

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -149,8 +149,14 @@ A. DEFINITIONS
 /* Not a ceiling: the array doubles on demand, so gene count is data-driven. */
 #define INITGENES 256
 
-/* Maximum length of a protein              */
-#define MAXAA 50000              
+/* Per-exon translation guard: max amino acids one exon contributes in       */
+/* Translate() (a single exon is always far below this; PrintExons relies on  */
+/* it too). The WHOLE-protein length is no longer capped -- see INITAA.       */
+#define MAXAA 50000
+
+/* Initial capacity of the growable whole-protein buffer (prot/sAux in        */
+/* TranslateGene). Not a ceiling: it grows to fit the assembled protein.      */
+#define INITAA 8192
 
 /* Initial capacity of the growable cDNA/tDNA transcript buffers (GetcDNA/   */
 /* GetTDNA). Not a ceiling: the buffers grow to fit the transcript length.   */
@@ -1015,7 +1021,8 @@ void TranslateGene(exonGFF* e,
                    dict* dAA,
                    long nExons,
                    int** tAA,
-                   char* prot,
+                   char** prot,
+                   long* cap,
                    long* nAA);
 
 void resetDumpHash(dumpHash* h);

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -816,6 +816,7 @@ void CookingGenes(exonGFF* e,
   gene* info;
   long infocap;
   char* prot;
+  long protcap;
   char* tmpDNA;
   char* tmpTDNA;
   long tmpDNAcap;
@@ -861,9 +862,10 @@ void CookingGenes(exonGFF* e,
     if ((tAA[i] = (int*) calloc(2,sizeof(int))) == NULL)
       printError("Not enough memory: tAA[] structure");
   
-  /* Protein space */
-  /* if (PSEQ) */
-  if ((prot = (char*) calloc(MAXAA,sizeof(char))) == NULL)
+  /* Protein space (growable: TranslateGene grows it to fit the assembled
+     protein, so whole-protein length is no longer capped at MAXAA) */
+  protcap = INITAA;
+  if ((prot = (char*) calloc(protcap,sizeof(char))) == NULL)
     printError("Not enough memory: protein product");
   
   /* cDNA memory if required (growable: GetcDNA grows it to fit the transcript) */
@@ -897,7 +899,7 @@ void CookingGenes(exonGFF* e,
       cfeats = 0;
       /* Translate gene into protein */
 /*       sprintf(mess,"gene: %ld; nfeats: %ld",igen,info[igen].nfeats);printMess(mess); */
-      TranslateGene(info[igen].start,s,dAA,(info[igen].nfeats),tAA,prot,&nAA);
+      TranslateGene(info[igen].start,s,dAA,(info[igen].nfeats),tAA,&prot,&protcap,&nAA);
       
       /* Get genomic DNA for exons if required */
       if (cDNA)
@@ -1015,7 +1017,7 @@ void CookingGenes(exonGFF* e,
 	  
 	  
 	  /* Translate gene into protein */
-	  TranslateGene(info[igen].start,s,dAA,(info[igen].nfeats),tAA,prot,&nAA);
+	  TranslateGene(info[igen].start,s,dAA,(info[igen].nfeats),tAA,&prot,&protcap,&nAA);
 	  /* Protein in FASTA format (except promoters) */
 	  if (strcmp(info[igen].start->Type,sPROMOTER) && nAA>0)
 	    printProt(Name,ngen-igen,prot,nAA,PROT,GenePrefix);

--- a/src/Translate.c
+++ b/src/Translate.c
@@ -116,14 +116,18 @@ void TranslateGene(exonGFF* e,
                    dict* dAA,
                    long nExons,
                    int** tAA,
-                   char* prot,
+                   char** pprot,
+                   long* pprotcap,
                    long* nAA)
-{  
+{
   long i;
   short j;
   int totalAA;
   int currAA;
-  char sAux[MAXAA];
+  char* prot = *pprot;
+  long  protcap = *pprotcap;
+  char* sAux = NULL;
+  long  sAuxcap = 0;
   char* rs;
   long p1, p2;
   char codon[LENGTHCODON+1];
@@ -133,6 +137,11 @@ void TranslateGene(exonGFF* e,
   int lAux;
   char rmdProt[LENGTHCODON+1];
   int lastExon = 1;
+
+  /* sAux is the per-exon scratch buffer handed to Translate(), which may
+     write up to MAXAA chars into it; keep it at least that large. It also
+     holds (exon + running protein) at the concat steps, so it grows too. */
+  growStr(&sAux,&sAuxcap, MAXAA);
 
   /* A. Translating a forward sense exon: Terminal > Internal >.. First */
   if (e->Strand == '+')
@@ -192,38 +201,28 @@ void TranslateGene(exonGFF* e,
 		codon[3] = '\0';
 		/* translate this codon */
 		aa = getAADict(dAA,codon);
-		lAux = strlen(sAux); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
+		lAux = strlen(sAux);
 		sAux[lAux] = aa;
-		sAux[lAux+1] = '\0'; 
+		sAux[lAux+1] = '\0';
 		break;
-            
+
 	      case 2:
 		/* curr RMD must be ONE */
 		codon[0] = s[p2];
 		codon[3] = '\0';
 		aa = getAADict(dAA,codon);
-		lAux = strlen(sAux); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
+		lAux = strlen(sAux);
 		sAux[lAux] = aa;
-		sAux[lAux+1] = '\0'; 
+		sAux[lAux+1] = '\0';
 		break;
 	      }
 
-	    /* Concat translation(current exon) with translation(last exon) */
-	    /* Guard: keep combined length within MAXAA (sAux/prot are MAXAA) */
-	    { long lsaux = (long) strlen(sAux);
-	      long room  = MAXAA - 8 - lsaux;
-	      if (room < 0) room = 0;
-	      if ((long) strlen(prot) > room)
-		{
-		  static int warnedProt = 0;
-		  if (!warnedProt)
-		    { fprintf(stderr,"Warning: protein reached MAXAA (%d); "
-				     "truncated.\n", MAXAA); warnedProt = 1; }
-		  prot[room] = '\0';
-		}
-	    }
+	    /* Concat translation(current exon) before the running protein.
+	       Grow both buffers to hold the combined string (no MAXAA cap). */
+	    growStr(&sAux,&sAuxcap, (long)strlen(sAux)+(long)strlen(prot)+1);
 	    strcat(sAux,prot);
 	    /* Leaving the result into prot */
+	    growStr(&prot,&protcap, (long)strlen(sAux)+1);
 	    strcpy(prot,sAux);
 
 	    /* 3. Saving information to translate the next shared codon */
@@ -278,9 +277,11 @@ void TranslateGene(exonGFF* e,
 	}
       
       /* Concat uncomplete codon at the beginning of the protein */
+      growStr(&sAux,&sAuxcap, (long)strlen(rmdProt)+(long)strlen(prot)+1);
       sprintf(sAux,"%s%s",rmdProt,prot);
+      growStr(&prot,&protcap, (long)strlen(sAux)+1);
       strcpy(prot,sAux);
-		
+
     }
 
   /* B. Translating a reverse sense exon: First > Internal >.. Terminal */
@@ -340,36 +341,27 @@ void TranslateGene(exonGFF* e,
 		codon[3] = '\0';
 		/* translate this codon */
 		aa = getAADict(dAA,codon);
-		lAux = strlen(prot); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
+		growStr(&prot,&protcap, (long)strlen(prot)+2);
+		lAux = strlen(prot);
 		prot[lAux] = aa;
-		prot[lAux+1] = '\0'; 
+		prot[lAux+1] = '\0';
 		break;
-	      
+
 	      case 2:
 		/* curr FRAME must be ONE */
 		codon[2] = rs[0];
 		codon[3] = '\0';
 		aa = getAADict(dAA,codon);
-		lAux = strlen(prot); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
+		growStr(&prot,&protcap, (long)strlen(prot)+2);
+		lAux = strlen(prot);
 		prot[lAux] = aa;
-		prot[lAux+1] = '\0'; 
+		prot[lAux+1] = '\0';
 		break;
 	      }
-	  
-	    /* exon translation after translated remainder */
-	    /* Guard: keep combined length within MAXAA (sAux/prot are MAXAA) */
-	    { long lprot = (long) strlen(prot);
-	      long room  = MAXAA - 8 - lprot;
-	      if (room < 0) room = 0;
-	      if ((long) strlen(sAux) > room)
-		{
-		  static int warnedProtR = 0;
-		  if (!warnedProtR)
-		    { fprintf(stderr,"Warning: protein reached MAXAA (%d); "
-				     "truncated.\n", MAXAA); warnedProtR = 1; }
-		  sAux[room] = '\0';
-		}
-	    }
+
+	    /* exon translation after translated remainder; grow prot to hold
+	       the running protein plus this exon (no MAXAA cap). */
+	    growStr(&prot,&protcap, (long)strlen(prot)+(long)strlen(sAux)+1);
 	    strcat(prot,sAux);
 	  
 	    /* Codon information for translating the next shared codon */
@@ -407,9 +399,11 @@ void TranslateGene(exonGFF* e,
 		  
 	}
       /* Frame of the last exon in the gene */
+      growStr(&sAux,&sAuxcap, (long)strlen(rmdProt)+(long)strlen(prot)+1);
       sprintf(sAux,"%s%s",rmdProt,prot);
+      growStr(&prot,&protcap, (long)strlen(sAux)+1);
       strcpy(prot,sAux);
-      
+
       /* Remainder of the first exon in sequence */
       switch (currRmd)
 	{
@@ -428,13 +422,18 @@ void TranslateGene(exonGFF* e,
 	  break;
 	}
       
-      lAux = strlen(prot); if (lAux > MAXAA - 9) lAux = MAXAA - 9; /* clamp: keep prot/sAux writes inside MAXAA */
+      growStr(&prot,&protcap, (long)strlen(prot)+currRmd+1);
+      lAux = strlen(prot);
       for(j = 0; j < currRmd; j++)
 	prot[lAux+j] = rmdProt[j];
-      prot[lAux+j] = '\0'; 
-      
+      prot[lAux+j] = '\0';
+
     } /* end of reverse translation */
 
+  /* Hand back the (possibly grown) protein buffer; free the scratch buffer */
+  free(sAux);
+  *pprot = prot;
+  *pprotcap = protcap;
   *nAA = totalAA;
 }
 


### PR DESCRIPTION
## Phase 2, Target #5 (fragile string building) — protein buffer

`TranslateGene` assembled the protein in fixed `MAXAA` (50 000) buffers — a **stack** `char sAux[MAXAA]` plus the caller's `prot` — and the v1.4.6 guards clamped every concat/append to `MAXAA`, silently truncating any protein that long (and carrying a ~50 KB stack frame).

### Changes
- `TranslateGene` now takes `prot` **+ capacity by reference** and grows it (via the existing `growStr()` helper) as the protein is assembled.
- `sAux` moves to the heap, kept `>= MAXAA` so `Translate()`'s per-exon contract still holds, and grown further at the concat steps.
- All `MAXAA` concat clamps and truncation warnings removed. `prot` starts at the new `INITAA` size and doubles to fit.
- `MAXAA` is retained only as the **per-exon** translation guard in `Translate()` / `PrintExons` (a single exon is always far below it). Making `Translate()` itself growable (and `PrintExons`) is a possible later follow-up.

### Verification
- Regression **4/4 byte-identical** (also with `INITAA` forced to **4** — many reallocs per gene).
- A real **153-exon / 23 313-aa** gene from SUPER_1 (`-j 199140000 -k 199295000`, the longest protein on the chromosome) is **byte-identical** before/after.
- **ASan-clean** on that region and the snake fixture, including the `>MAXAA` concat-growth path stressed via a temporary `MAXAA=100` build.

This removes the whole-protein `MAXAA` ceiling; combined with #11 (cDNA/tDNA) the printed sequences are no longer truncated. Target #1's remaining 1c (exon/site tables) is still deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)