### PR TITLE
Build*: make the per-type exon arrays growable (drop NUMEXONS/Rxxx caps)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -167,6 +167,12 @@ A. DEFINITIONS
 /* capped (the old "increase FSORT" hard error is gone).                      */
 #define INITSORT 4096
 
+/* Initial capacity of the growable per-type exon Build arrays (packExons).   */
+/* Not a ceiling: each Build* grows its array on demand, so the old           */
+/* "decrease RFIRST/RINTER/..." hard errors and the NUMEXONS/Rxxx reservation */
+/* are gone.                                                                  */
+#define INITEXONS 4096
+
 /* Maximum number of isochores              */
 #define MAXISOCHORES 4           
 
@@ -550,7 +556,14 @@ typedef struct s_packExons
   long nUtr3InternalHalfExons;
   long nUtrTerminalHalfExons;
   long nUtrTerminalExons;
-  long nExons;                         
+  long nExons;
+  /* Allocated capacity of each growable per-type array (grown by Build*) */
+  long capInitialExons;
+  long capInternalExons;
+  long capZeroLengthExons;
+  long capTerminalExons;
+  long capSingles;
+  long capORFs;
 } packExons;
 
 typedef struct s_packGenes
@@ -806,43 +819,43 @@ long BuildInitialExons(site *Start, long nStarts,
                        int MaxDonors,
 		       char* ExonType,
 		       char* Sequence,
-                       exonGFF *Exon,long nexons );
+                       exonGFF **Exon, long* cap );
 
-long BuildInternalExons(site *Acceptor, long nAcceptors, 
+long BuildInternalExons(site *Acceptor, long nAcceptors,
                         site *Donor, long nDonors,
                         site *Stop, long nStops,
                         int MaxDonors,
 			char* ExonType,
 			char* Sequence,
-                        exonGFF* Exon,long nexons);
+                        exonGFF** Exon, long* cap);
 
-long BuildZeroLengthExons(site *Acceptor, long nAcceptors, 
+long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
                         site *Donor, long nDonors,
                         site *Stop, long nStops,
                         int MaxDonors,
 			char* ExonType,
 			char* Sequence,
-                        exonGFF* Exon,long nexons); 
+                        exonGFF** Exon, long* cap);
 
-long BuildTerminalExons (site *Acceptor, long nAcceptors, 
+long BuildTerminalExons (site *Acceptor, long nAcceptors,
                          site *Stop, long nStops,
                          long LengthSequence,
                          long cutPoint,
 			 char* ExonType,
 			 char* Sequence,
-			 exonGFF* Exon,long nexons);
+			 exonGFF** Exon, long* cap);
 
-long BuildSingles(site *Start, long nStarts, 
+long BuildSingles(site *Start, long nStarts,
                   site *Stop, long nStops,
                   long cutPoint,
 		  char* Sequence,
-                  exonGFF *Exon);
+                  exonGFF **Exon, long* cap);
 
-long BuildORFs(site *Start, long nStarts, 
+long BuildORFs(site *Start, long nStarts,
 	       site *Stop, long nStops,
 	       long cutPoint,
 	       char* Sequence,
-	       exonGFF *Exon);
+	       exonGFF **Exon, long* cap);
 
 long BuildUTRExons(
 		   site *Start, long nStarts, 
@@ -855,6 +868,11 @@ long BuildUTRExons(
 packSites* RequestMemorySites();
 packExons* RequestMemoryExons();
 exonGFF* RequestMemorySortExons();
+
+/* Grow an exonGFF array *buf to hold at least `need` entries (realloc-double,
+   zeroing the new entries since the arrays were originally calloc'd). Shared
+   by the growable per-type Build arrays and the exon-sort table. */
+void GrowExonArray(exonGFF** buf, long* cap, long need);
 site* RequestMemorySortSites();
 gparam* RequestMemoryParams();
 packGenes* RequestMemoryGenes();

--- a/src/BuildInitialExons.c
+++ b/src/BuildInitialExons.c
@@ -40,16 +40,17 @@ long BuildInitialExons(site *Start, long nStarts,
                        int MaxDonors,
 					   char* ExonType,
 					   char* Sequence,
-                       exonGFF *Exon,long nexons) 
+                       exonGFF **ExonP, long* capP)
 {
   /* Best exons built by using the current start codon */
   exonGFF *LocalExon;
   int nLocalExons, LowestLocalExon;
   float LowestLocalScore;
-  
-  /* Maximum allowed number of predicted initial exons per fragment */
-  long HowMany;
-  
+
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
   int Frame;
   long i, j, js, k, ks;
   int l;
@@ -65,9 +66,8 @@ long BuildInitialExons(site *Start, long nStarts,
   
   /* Main loop, forall start codon looking for donor sites... */
   /* ...until the first stop codon in frame is reached */
-  HowMany = (MAXBACKUPSITES)? (long)(nexons/RFIRST): nexons;
   for (i = 0, j = 0, k = 0, nExon = 0;
-       (nExon < HowMany) && (i < nStarts); i++)
+       (i < nStarts); i++)
 	{ 
 	  /* Reset the best local exons array */
 	  nLocalExons = 0;
@@ -143,8 +143,9 @@ long BuildInitialExons(site *Start, long nStarts,
 		} /* end while */
 	  
 	  /* Save the best exons beginning by the current start */
-	  for (l=0;(l<nLocalExons) && (nExon<HowMany);l++) 
+	  for (l=0; l<nLocalExons; l++)
 		{
+		  GrowExonArray(&Exon,&cap,nExon+1);
 		  Exon[nExon] = LocalExon[l];
 		  (Exon+nExon)->Frame = 0;
 		  (Exon+nExon)->Remainder = ((Exon+nExon)->Donor->Position -
@@ -161,12 +162,11 @@ long BuildInitialExons(site *Start, long nStarts,
          nExon++;
 		}
 	}
-  
-  if (nExon >= HowMany)
-	printError("Too many initial exons: decrease RFIRST parameter");
-  
+
   free(LocalExon);
-  
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nExon);
 }
 

--- a/src/BuildInternalExons.c
+++ b/src/BuildInternalExons.c
@@ -41,7 +41,7 @@ long BuildInternalExons(site *Acceptor, long nAcceptors,
                         int MaxDonors,
 			char* ExonType,
 			char* Sequence,
-                        exonGFF* Exon, long nexons)
+                        exonGFF** ExonP, long* capP)
 {
   /* Best exons built using the current Acceptor and frame availability */
   struct iexon
@@ -49,19 +49,20 @@ long BuildInternalExons(site *Acceptor, long nAcceptors,
     site *Acceptor;
     site *Donor;
     int Frame[FRAMES];
-  } *LocalExon; 
+  } *LocalExon;
   int nLocalExons, LowestLocalExon;
   float LowestLocalScore;
-  
-  /* Boolean array of windows: closed or opened */ 
+
+  /* Boolean array of windows: closed or opened */
   int Frame[FRAMES];
-  
+
   long i, j, js, k, ks;
   int f, l, ll;
-  
-  /* Maximum allowed number of predicted internal exons per fragment */
-  long HowMany;
-  
+
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
   /* Final number of predicted internal exons */
   long nExon;
   
@@ -73,11 +74,8 @@ long BuildInternalExons(site *Acceptor, long nAcceptors,
   
   /* Main loop, forall Acceptor looking for donor sites... */
   /* ...until 3 windows are closed due to 3 stop codons */
-  HowMany = (MAXBACKUPSITES)? (long)(nexons/RINTER): nexons;
-  
-  
   for (i=0, j=0, k=0, nExon = 0;
-       (i < nAcceptors) && (nExon<HowMany); i++)
+       (i < nAcceptors); i++)
     {
       /* Open the 3 windows */
       for (f=0;f<FRAMES;f++) 
@@ -227,13 +225,14 @@ long BuildInternalExons(site *Acceptor, long nAcceptors,
 	}/* end if EXTRA */
 	  
       /* Save predicted exons for the current Acceptor site */
-      for (l=0;(l<nLocalExons) && (nExon<HowMany);l++) 
+      for (l=0; l<nLocalExons; l++)
 	{
 	  /* There are exons in every frame */
-	  for (ll=0;(ll<FRAMES) && (nExon < HowMany);ll++)
-	    if ((LocalExon+l)->Frame[ll]) 
+	  for (ll=0; ll<FRAMES; ll++)
+	    if ((LocalExon+l)->Frame[ll])
 	      {
 		/* Frame was opened then */
+		GrowExonArray(&Exon,&cap,nExon+1);
 		(Exon+nExon)->Acceptor = (LocalExon+l)->Acceptor;
 		(Exon+nExon)->Donor = (LocalExon+l)->Donor;
 		(Exon+nExon)->Frame = ll;
@@ -258,12 +257,11 @@ long BuildInternalExons(site *Acceptor, long nAcceptors,
 	      }
 	}
     }
-  
-  if (nExon >= HowMany)
-    printError("Too many internal exons: decrease RINTER parameter");
-  
+
   free(LocalExon);
-  
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nExon);
 }
 

--- a/src/BuildORFs.c
+++ b/src/BuildORFs.c
@@ -36,21 +36,21 @@ extern long MAXBACKUPSITES;
 long BuildORFs(site *Start, long nStarts, 
                site *Stop, long nStops,
                long cutPoint, char* Sequence,
-               exonGFF *Exon) 
+               exonGFF **ExonP, long* capP)
 {
   int Frame;
   long i, j, js;
-  
-  /* Maximum allowed number of ORFs per fragment */     
-  long HowMany;
-  
+
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
   /* Final number of predicted ORFs */
   long nSingles;
-  
+
   /* Main loop, for each Start codon searching the first Stop in frame */
-  HowMany=(MAXBACKUPSITES)? (long)(NUMEXONS/RSINGL): NUMEXONS;
   for (i=0, j=0, nSingles=0;
-	   (i < nStarts) && (j<nStops) && (nSingles<HowMany);
+	   (i < nStarts) && (j<nStops);
 	   i++)
     {
       Frame = ((Start+i)->Position + 1) % 3;
@@ -74,6 +74,7 @@ long BuildORFs(site *Start, long nStarts,
 			   >= 
 			   ORFLENGTH)
 			{
+			  GrowExonArray(&Exon,&cap,nSingles+1);
 			  (Exon + nSingles)->Acceptor = (Start+i);
 			  (Exon + nSingles)->Donor = (Stop+js);
 			  (Exon + nSingles)->Frame = 0;
@@ -89,9 +90,8 @@ long BuildORFs(site *Start, long nStarts,
 			}
 		}
     }
-  
-  if (nSingles >= HowMany)
-	printError("Too many ORF exons: decrease RSINGL parameter");
-  
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nSingles);
 }

--- a/src/BuildSingles.c
+++ b/src/BuildSingles.c
@@ -37,21 +37,21 @@ long BuildSingles(site *Start, long nStarts,
                   site *Stop, long nStops,
                   long cutPoint, 
 				  char* Sequence,
-                  exonGFF *Exon) 
+                  exonGFF **ExonP, long* capP)
 {
-  /* Maximum allowed number of predicted single gene exons per fragment */
-  long HowMany;
-  
   int Frame;
   long i, j, js;
-  
+
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
   /* Final number of predicted single genes exons */
   long nSingles;
-  
+
   /* Main loop, for each Start codon searching the first Stop in frame */
-  HowMany = (MAXBACKUPSITES)? (long)(NUMEXONS/RSINGL) : NUMEXONS;
   for (i=0, j=0, nSingles=0;
-	   (i < nStarts) && (j<nStops) && (nSingles< HowMany);
+	   (i < nStarts) && (j<nStops);
 	   i++)
     {
       Frame = (Start+i)->Position % 3;
@@ -74,6 +74,7 @@ long BuildSingles(site *Start, long nStarts,
 		  if ( ((Stop+js)->Position + LENGTHCODON - (Start+i)->Position + 1)
 			   >= SINGLEGENELENGTH)
 			{
+			  GrowExonArray(&Exon,&cap,nSingles+1);
 			  (Exon + nSingles)->Acceptor = (Start+i);
 			  (Exon + nSingles)->Donor = (Stop+js);
 			  (Exon + nSingles)->Frame = 0;
@@ -86,9 +87,8 @@ long BuildSingles(site *Start, long nStarts,
 			}
 		}
     }
-  
-  if (nSingles >= HowMany)
-	printError("Too many single gene exons: decrease RSINGL parameter");
-  
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nSingles);
 }

--- a/src/BuildTerminalExons.c
+++ b/src/BuildTerminalExons.c
@@ -40,24 +40,22 @@ long BuildTerminalExons (site *Acceptor, long nAcceptors,
                          long cutPoint,
 						 char* ExonType,
 						 char* Sequence,
-						 exonGFF* Exon, long nexons)
+						 exonGFF** ExonP, long* capP)
 {
   int Frame[FRAMES];
   long i, f, j, js;
 /*   char mess[MAXSTRING]; */
   /* Final number of predicted terminal exons */
   long nExon;
-  
-  /* Maximum allowed number of predicted initial exons per fragment */
-  long HowMany;
-  
-  
+
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
   /* Main loop: forall Acceptor, first Stop in every Frame defines an exon */
   /* There are therefore, 3 terminal exons starting by this Acceptor */
-  HowMany = (MAXBACKUPSITES)? (long)(nexons/RTERMI): nexons;
-  
   for (i=0, j=0, js=0, nExon=0;
-       (i<nAcceptors) && (nExon<HowMany);
+       (i<nAcceptors);
        i++)
     {
       /* Open the 3 frames for current Acceptor */
@@ -73,8 +71,7 @@ long BuildTerminalExons (site *Acceptor, long nAcceptors,
       
       /* Use current Stops if its frame is still opened */
       while ((Frame[0]==1 || Frame[1]==1 || Frame[2]==1)
-			 && (js < nStops)
-			 && (nExon<HowMany))
+			 && (js < nStops))
 		{
 		  if (Frame[f=((Stop+js)->Position - (Acceptor+i)->Position + 1) % 3])
 			{
@@ -85,6 +82,7 @@ long BuildTerminalExons (site *Acceptor, long nAcceptors,
 			      )
 				{
 				  
+				  GrowExonArray(&Exon,&cap,nExon+1);
 				  (Exon+nExon)->Acceptor=(Acceptor+i);
 				  (Exon+nExon)->Donor=(Stop+js);
 				  (Exon+nExon)->Frame = f;
@@ -103,10 +101,9 @@ long BuildTerminalExons (site *Acceptor, long nAcceptors,
 			} 
 		  js++;
 		} /* next stop */     
-    } /* next acceptor */   
-  
-  if (nExon >= HowMany)
-	printError("Too many terminal exons: decrease RTERMI parameter");
-  
+    } /* next acceptor */
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nExon);
 }

--- a/src/BuildZeroLengthExons.c
+++ b/src/BuildZeroLengthExons.c
@@ -43,7 +43,7 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
                         int MaxDonors,
 			char* ExonType,
 			char* Sequence,
-                        exonGFF* Exon, long nexons)
+                        exonGFF** ExonP, long* capP)
 {
   /* Best exons built using the current Acceptor and frame availability */
   struct iexon
@@ -51,20 +51,21 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
     site *Acceptor;
     site *Donor;
     int Frame[FRAMES];
-  } *LocalExon; 
+  } *LocalExon;
   int nLocalExons, LowestLocalExon;
   float LowestLocalScore;
   /* char mess[MAXSTRING]; */
 
-  /* Boolean array of windows: closed or opened */ 
+  /* Boolean array of windows: closed or opened */
   int Frame[FRAMES];
-  
+
   long i, j, js, k;
   int f, l, ll;
-  
-  /* Maximum allowed number of predicted internal exons per fragment */
-  long HowMany;
-  
+
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
   /* Final number of predicted internal exons */
   long nExon;
   
@@ -76,11 +77,8 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
   
   /* Main loop, forall Acceptor looking for donor sites... */
   /* ...until 3 windows are closed due to 3 stop codons */
-  HowMany = (MAXBACKUPSITES)? (long)(nexons/RINTER): nexons;
-  
-  
   for (i=0, j=0, k=0, nExon = 0;
-       (i < nAcceptors) && (nExon<HowMany); i++)
+       (i < nAcceptors); i++)
     {
       /* Open the 3 windows */
       for (f=0;f<FRAMES;f++) 
@@ -122,13 +120,14 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
       }
      	  	  
       /* Save predicted exons for the current Acceptor site */
-      for (l=0;(l<nLocalExons) && (nExon<HowMany);l++) 
+      for (l=0; l<nLocalExons; l++)
 	{
 	  /* There are exons in every frame */
-	  for (ll=0;(ll<FRAMES) && (nExon < HowMany);ll++)
-	    if ((LocalExon+l)->Frame[ll]) 
+	  for (ll=0; ll<FRAMES; ll++)
+	    if ((LocalExon+l)->Frame[ll])
 	      {
 		/* Frame was opened then */
+		GrowExonArray(&Exon,&cap,nExon+1);
 		(Exon+nExon)->Acceptor = (LocalExon+l)->Acceptor;
 		(Exon+nExon)->Donor = (LocalExon+l)->Donor;
 		(Exon+nExon)->Frame = ll;
@@ -155,12 +154,11 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
 	      }
 	}
     }
-  
-  if (nExon >= HowMany)
-    printError("Too many zero-length exons: decrease RINTER parameter");
-  
+
   free(LocalExon);
-  
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nExon);
 }
 

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -101,6 +101,26 @@ packSites* RequestMemorySites()
   return(allSites);
 }
 
+/* Grow an exonGFF array *buf to hold at least `need` entries. Doubles the
+   capacity, preserves existing contents, and zeroes the new entries (the
+   arrays were originally calloc'd, so unfilled slots must stay zeroed). */
+void GrowExonArray(exonGFF** buf, long* cap, long need)
+{
+  long ncap;
+  exonGFF* tmp;
+
+  if (need <= *cap)
+    return;
+  ncap = (*cap > 0) ? *cap : 1;
+  while (ncap < need)
+    ncap *= 2;
+  if ((tmp = (exonGFF*) realloc(*buf, ncap * sizeof(exonGFF))) == NULL)
+    printError("Not enough memory: growing exon array");
+  memset(tmp + *cap, 0, (ncap - *cap) * sizeof(exonGFF));
+  *buf = tmp;
+  *cap = ncap;
+}
+
 /* Allocating pack of exons (only in one sense) in memory */
 packExons* RequestMemoryExons()
 {
@@ -112,36 +132,40 @@ packExons* RequestMemoryExons()
        (struct s_packExons *) malloc(sizeof(struct s_packExons))) == NULL)
     printError("Not enough memory: pack of exons");  
 
+  /* Per-type exon arrays start small and grow on demand (see GrowExonArray /
+     the Build* functions); their capacity is tracked in cap* fields. */
   /* InitialExons */
-  HowMany = (long)(NUMEXONS/RFIRST);
-  if ((allExons->InitialExons = 
-       (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+  allExons->capInitialExons = INITEXONS;
+  if ((allExons->InitialExons =
+       (exonGFF*) calloc(allExons->capInitialExons, sizeof(exonGFF))) == NULL)
     printError("Not enough memory: first exons");
-      
+
   /* InternalExons */
-  HowMany = (long)(NUMEXONS/RINTER); 
-  if ((allExons->InternalExons = 
-       (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+  allExons->capInternalExons = INITEXONS;
+  if ((allExons->InternalExons =
+       (exonGFF*) calloc(allExons->capInternalExons, sizeof(exonGFF))) == NULL)
     printError("Not enough memory: internal exons");
 
   /* ZeroLengthExons */
-  HowMany = (long)(NUMEXONS/RINTER); 
-  if ((allExons->ZeroLengthExons = 
-       (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+  allExons->capZeroLengthExons = INITEXONS;
+  if ((allExons->ZeroLengthExons =
+       (exonGFF*) calloc(allExons->capZeroLengthExons, sizeof(exonGFF))) == NULL)
     printError("Not enough memory: zero length exons");
-         
+
   /* TerminalExons */
-  HowMany = (long)(NUMEXONS/RTERMI);
-  if ((allExons->TerminalExons = 
-       (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+  allExons->capTerminalExons = INITEXONS;
+  if ((allExons->TerminalExons =
+       (exonGFF*) calloc(allExons->capTerminalExons, sizeof(exonGFF))) == NULL)
     printError("Not enough memory: terminal exons");
 
   /* SingleExons */
-  HowMany = (long)(NUMEXONS/RSINGL);
-  if ((allExons->Singles = 
-       (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+  allExons->capSingles = INITEXONS;
+  if ((allExons->Singles =
+       (exonGFF*) calloc(allExons->capSingles, sizeof(exonGFF))) == NULL)
     printError("Not enough memory: single genes");
-  
+
+  allExons->capORFs = 0;
+
   if (UTR){
     /* UTR Exons */
     HowMany = (long)(NUMEXONS/RUTR);
@@ -184,9 +208,9 @@ packExons* RequestMemoryExons()
   /* IF Scan ORF is switched on... */
   if (scanORF)
     {
-	  HowMany = (long)(NUMEXONS/RORF);
-	  if ((allExons->ORFs = 
-		   (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+	  allExons->capORFs = INITEXONS;
+	  if ((allExons->ORFs =
+		   (exonGFF*) calloc(allExons->capORFs, sizeof(exonGFF))) == NULL)
         printError("Not enough memory: Open Reading Frames");
     }
   allExons->nInitialExons = 0;

--- a/src/SortExons.c
+++ b/src/SortExons.c
@@ -29,26 +29,6 @@
 
 #include "geneid.h"
 
-/* Grow the exon-sort table *buf so it can hold at least `need` entries,
-   preserving existing contents and zeroing the new ones (the table was
-   originally calloc'd, and unfilled slots must stay zeroed). */
-static void growExons(exonGFF** buf, long* cap, long need)
-{
-  long ncap;
-  exonGFF* tmp;
-
-  if (need <= *cap)
-    return;
-  ncap = *cap;
-  while (ncap < need)
-    ncap *= 2;
-  if ((tmp = (exonGFF*) realloc(*buf, ncap * sizeof(exonGFF))) == NULL)
-    printError("Not enough memory: growing exon sort table");
-  memset(tmp + *cap, 0, (ncap - *cap) * sizeof(exonGFF));
-  *buf = tmp;
-  *cap = ncap;
-}
-
 extern int RSS;
 extern int EVD;
 extern int UTR;
@@ -303,7 +283,7 @@ void SortExons(packExons* allExons,
   long right;
   long room;
   char mess[MAXSTRING];
-  /* Growable exon-sort table (grows on demand; see growExons) */
+  /* Growable exon-sort table (grows on demand; see GrowExonArray) */
   exonGFF* Exons = *pExons;
   long cap = *pcap;
 
@@ -595,7 +575,7 @@ void SortExons(packExons* allExons,
   /* FIRST SPLIT: Insert first artificial exon */
   if (l1 == lowerlimit)
     {
-      growExons(&Exons,&cap, 2);
+      GrowExonArray(&Exons,&cap, 2);
       InsertBeginExon(Exons,lowerlimit);
       n = 2;
     }
@@ -611,7 +591,7 @@ void SortExons(packExons* allExons,
       while (q != NULL)
 		{
 		  /* Grow the table on demand instead of capping at FSORT*NUMEXONS */
-		  growExons(&Exons,&cap, n+1);
+		  GrowExonArray(&Exons,&cap, n+1);
 		  /* Save the extracted exon */
 		  Exons[n].Acceptor = q->Exon->Acceptor;
 		  Exons[n].Donor = q->Exon->Donor;
@@ -644,7 +624,7 @@ void SortExons(packExons* allExons,
   /* FINISHING split: Insert last artificial exon */
   if (l2 == upperlimit)
 	{
-	  growExons(&Exons,&cap, n+2);
+	  GrowExonArray(&Exons,&cap, n+2);
 	  InsertEndExon(Exons, n, upperlimit + 1);
 	  n = n + 2;
 	}

--- a/src/manager.c
+++ b/src/manager.c
@@ -298,7 +298,7 @@ void  manager(char *Sequence,
 			allSites->DonorSites,allSites->nDonorSites,
 			allSites->StopCodons,allSites->nStopCodons,
 			gp->MaxDonors,sFIRST,Sequence,
-			allExons->InitialExons,NUMEXONS);
+			&allExons->InitialExons, &allExons->capInitialExons);
     sprintf(mess,"Initial Exons \t\t%8ld", allExons->nInitialExons);
     printRes(mess); 
 
@@ -307,7 +307,7 @@ void  manager(char *Sequence,
 			 allSites->DonorSites,allSites->nDonorSites,
 			 allSites->StopCodons,allSites->nStopCodons,
 			 gp->MaxDonors,sINTERNAL,Sequence,
-			 allExons->InternalExons,NUMEXONS);
+			 &allExons->InternalExons, &allExons->capInternalExons);
     sprintf(mess,"Internal Exons \t\t%8ld", allExons->nInternalExons);
     printRes(mess); 
 
@@ -317,7 +317,7 @@ void  manager(char *Sequence,
 			     allSites->DonorSites,allSites->nDonorSites,
 			     allSites->StopCodons,allSites->nStopCodons,
 			     gp->MaxDonors,sZEROLENGTH,Sequence,
-			     allExons->ZeroLengthExons,NUMEXONS);
+			     &allExons->ZeroLengthExons, &allExons->capZeroLengthExons);
       sprintf(mess,"Zero-Length Exons \t%8ld", allExons->nZeroLengthExons);
       printRes(mess); 
     }
@@ -325,7 +325,7 @@ void  manager(char *Sequence,
       BuildTerminalExons(allSites->AcceptorSites,allSites->nAcceptorSites,
 			 allSites->StopCodons,allSites->nStopCodons,
 			 LengthSequence,cutPoint,sTERMINAL,Sequence,
-			 allExons->TerminalExons,NUMEXONS);
+			 &allExons->TerminalExons, &allExons->capTerminalExons);
     sprintf(mess,"Terminal Exons \t\t%8ld", allExons->nTerminalExons);
     printRes(mess); 
   
@@ -333,7 +333,7 @@ void  manager(char *Sequence,
       BuildSingles(allSites->StartCodons,allSites->nStartCodons,
 		   allSites->StopCodons,allSites->nStopCodons,
 		   cutPoint, Sequence,
-		   allExons->Singles);
+		   &allExons->Singles, &allExons->capSingles);
     sprintf(mess,"Single genes \t\t%8ld", allExons->nSingles);
     printRes(mess); 
     
@@ -402,7 +402,7 @@ void  manager(char *Sequence,
 	  BuildORFs(allSites->StopCodons,allSites->nStopCodons,
 		    allSites->StopCodons,allSites->nStopCodons,
 		    cutPoint, Sequence,
-		    allExons->ORFs);
+		    &allExons->ORFs, &allExons->capORFs);
 	sprintf(mess,"ORFs \t\t\t%8ld", allExons->nORFs);
 	printRes(mess); 
       }


### PR DESCRIPTION
## Phase 2, Target #1c — per-type exon Build arrays

The six coding-exon builders filled fixed `packExons` arrays sized at `NUMEXONS/Rxxx` and **aborted** with `printError("decrease RFIRST/RINTER/RTERMI/RSINGL")` once a dense fragment exceeded that share. Like the sort table (#14), those ratios were both a memory tax and hard correctness ceilings. (The short-sequence path even passed the *undivided* `NUMEXONS` as the bound while the array was only `NUMEXONS/Rxxx` — a latent overflow.)

### Changes
- Each array (`InitialExons`, `InternalExons`, `ZeroLengthExons`, `TerminalExons`, `Singles`, `ORFs`) starts at `INITEXONS` and **grows on demand**.
- `BuildInitial/Internal/ZeroLength/Terminal/Singles/ORFs` now take the array **+ capacity by reference** and grow before each write via a shared `GrowExonArray()` helper (realloc-double + zero new slots). Capacity persists across fragments in new `packExons` `cap*` fields.
- The "decrease Rxxx" aborts are gone. `SortExons`'s local `growExons` is replaced by the shared helper (DRY).

### Verification
- Regression **5/5 byte-identical** (also with `INITEXONS` forced to **4** → many reallocs per builder).
- The **full SUPER_1 chromosome** (20 909 genes) byte-identical before/after.
- **ASan-clean** on the snake and the long-protein window.

Pointer safety mirrors #14: the per-type arrays are filled before `SortExons` value-copies them into the sort table, and nothing retains a pointer into them across a grow.

Remaining 1c: the UTR exon arrays (`BuildUTRExons`, 7 arrays) and the site builders / site-sort table. After those the `MEM` profiles become largely unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)