### PR TITLE
BuildUTRExons: make the 7 UTR exon arrays growable (drop NUMEXONS/RUTR cap)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -564,6 +564,13 @@ typedef struct s_packExons
   long capTerminalExons;
   long capSingles;
   long capORFs;
+  long capUtrInitialExons;
+  long capUtrInitialHalfExons;
+  long capUtrInternalExons;
+  long capUtr5InternalHalfExons;
+  long capUtr3InternalHalfExons;
+  long capUtrTerminalHalfExons;
+  long capUtrTerminalExons;
 } packExons;
 
 typedef struct s_packGenes
@@ -858,12 +865,12 @@ long BuildORFs(site *Start, long nStarts,
 	       exonGFF **Exon, long* cap);
 
 long BuildUTRExons(
-		   site *Start, long nStarts, 
+		   site *Start, long nStarts,
 		   site *Donor, long nDonors,
 		   int MaxDonors,
 		   int MaxExonLength,long cutPoint,
 		   char* ExonType,
-		   exonGFF *Exon,long nexons);
+		   exonGFF **Exon, long* cap);
 
 packSites* RequestMemorySites();
 packExons* RequestMemoryExons();

--- a/src/BuildUTRExons.c
+++ b/src/BuildUTRExons.c
@@ -40,7 +40,7 @@ long BuildUTRExons(
 				int MaxDonors,
 				int MaxExonLength,long cutPoint,
 				char* ExonType,
-				exonGFF *Exon,long nexons) 
+				exonGFF **ExonP, long* capP)
 {
   /* Best exons built by using the current start codon */
   exonGFF *LocalExon;
@@ -48,9 +48,10 @@ long BuildUTRExons(
   float LowestLocalScore;
 /*   char mess[MAXSTRING]; */
 
-  /* Maximum allowed number of predicted initial exons per fragment */
-  long HowMany;
-  
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  exonGFF* Exon = *ExonP;
+  long cap = *capP;
+
 /*   int Frame; */
 /*   int js; */
 
@@ -59,16 +60,15 @@ long BuildUTRExons(
   float pen = 0.002;
   /* Final number of predicted UTR exons */
   long nExon;
-  
+
   /* Allocating space for exons built by using the current start codon */
   /* MaxDonors is the maximum allowed number of exons with this signal */
   if ((LocalExon = (exonGFF*) calloc(MaxDonors,sizeof(exonGFF))) == NULL)
-    printError("Not enough memory: local UTR exons"); 
-  
+    printError("Not enough memory: local UTR exons");
+
   /* Main loop, forall beginning sites looking for ending sites... */
-  HowMany = (MAXBACKUPSITES)? (long)(nexons/RUTR): nexons;
   for (i = 0, j = 0, k = 0, nExon = 0;
-       (nExon < HowMany) && (i < nStarts); i++)
+       (i < nStarts); i++)
     { 
       /* Reset the best local exons array */
       nLocalExons = 0;
@@ -147,8 +147,9 @@ long BuildUTRExons(
 	} /* end while */
 	  
 	  /* Save the best exons beginning by the current start */
-      for (l=0;(l<nLocalExons) && (nExon<HowMany);l++) 
+      for (l=0; l<nLocalExons; l++)
 	{
+	  GrowExonArray(&Exon,&cap,nExon+1);
 	  Exon[nExon] = LocalExon[l];
 	  (Exon+nExon)->Frame = 0;
 	  (Exon+nExon)->Remainder = 0; 
@@ -164,12 +165,11 @@ long BuildUTRExons(
 	  
 	}
     }
-  
-  if (nExon >= HowMany)
-    printError("Too many UTR exons: decrease RUTR parameter");
-  
+
   free(LocalExon);
-  
+
+  *ExonP = Exon;
+  *capP = cap;
   return(nExon);
 }
 

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -125,8 +125,7 @@ void GrowExonArray(exonGFF** buf, long* cap, long need)
 packExons* RequestMemoryExons()
 {
   packExons* allExons;
-  long HowMany;
-  
+
   /* Allocating memory for exons */
   if ((allExons = 
        (struct s_packExons *) malloc(sizeof(struct s_packExons))) == NULL)
@@ -165,45 +164,52 @@ packExons* RequestMemoryExons()
     printError("Not enough memory: single genes");
 
   allExons->capORFs = 0;
+  allExons->capUtrInitialExons = 0;
+  allExons->capUtrInitialHalfExons = 0;
+  allExons->capUtrInternalExons = 0;
+  allExons->capUtr5InternalHalfExons = 0;
+  allExons->capUtr3InternalHalfExons = 0;
+  allExons->capUtrTerminalHalfExons = 0;
+  allExons->capUtrTerminalExons = 0;
 
   if (UTR){
-    /* UTR Exons */
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->UtrInitialExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    /* UTR Exons: start small; BuildUTRExons grows each on demand */
+    allExons->capUtrInitialExons = INITEXONS;
+    if ((allExons->UtrInitialExons =
+	 (exonGFF*) calloc(allExons->capUtrInitialExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: UtrInitialExons");
 
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->UtrInitialHalfExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    allExons->capUtrInitialHalfExons = INITEXONS;
+    if ((allExons->UtrInitialHalfExons =
+	 (exonGFF*) calloc(allExons->capUtrInitialHalfExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: UtrInitialhalfExons");
 
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->UtrInternalExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    allExons->capUtrInternalExons = INITEXONS;
+    if ((allExons->UtrInternalExons =
+	 (exonGFF*) calloc(allExons->capUtrInternalExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: UtrInternalExons");
 
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->Utr5InternalHalfExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    allExons->capUtr5InternalHalfExons = INITEXONS;
+    if ((allExons->Utr5InternalHalfExons =
+	 (exonGFF*) calloc(allExons->capUtr5InternalHalfExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: Utr5InternalHalfExons");
 
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->Utr3InternalHalfExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    allExons->capUtr3InternalHalfExons = INITEXONS;
+    if ((allExons->Utr3InternalHalfExons =
+	 (exonGFF*) calloc(allExons->capUtr3InternalHalfExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: Utr3InternalHalfExons");
 
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->UtrTerminalHalfExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    allExons->capUtrTerminalHalfExons = INITEXONS;
+    if ((allExons->UtrTerminalHalfExons =
+	 (exonGFF*) calloc(allExons->capUtrTerminalHalfExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: UtrTerminalHalfExons");
 
-    HowMany = (long)(NUMEXONS/RUTR);
-    if ((allExons->UtrTerminalExons = 
-	 (exonGFF*) calloc(HowMany, sizeof(exonGFF))) == NULL)
+    allExons->capUtrTerminalExons = INITEXONS;
+    if ((allExons->UtrTerminalExons =
+	 (exonGFF*) calloc(allExons->capUtrTerminalExons, sizeof(exonGFF))) == NULL)
       printError("Not enough memory: UtrTerminalExons");
   }
- 
+
 
   /* IF Scan ORF is switched on... */
   if (scanORF)

--- a/src/manager.c
+++ b/src/manager.c
@@ -342,7 +342,7 @@ void  manager(char *Sequence,
 	BuildUTRExons(allSites->TS,allSites->nTS,
 		      allSites->DonorSites,allSites->nDonorSites,
 		      MAXUTRDONORS,MAXUTREXONLENGTH,cutPoint,sUTRFIRST,
-		      allExons->UtrInitialExons,NUMEXONS);
+		      &allExons->UtrInitialExons, &allExons->capUtrInitialExons);
       sprintf(mess,"UTR Initial Exons \t%8ld", allExons->nUtrInitialExons);
       printRes(mess);
 
@@ -350,7 +350,7 @@ void  manager(char *Sequence,
 	BuildUTRExons(allSites->TS,allSites->nTS,
 		      allSites->StartCodons,allSites->nStartCodons,
 		      MAXUTRDONORS,MAXUTREXONLENGTH,cutPoint,sUTRFIRSTHALF,
-		      allExons->UtrInitialHalfExons,NUMEXONS);
+		      &allExons->UtrInitialHalfExons, &allExons->capUtrInitialHalfExons);
       sprintf(mess,"UTR Initial Half Exons \t%8ld", allExons->nUtrInitialHalfExons);
       printRes(mess);
 
@@ -358,42 +358,42 @@ void  manager(char *Sequence,
 	BuildUTRExons(allSites->AcceptorSites,allSites->nAcceptorSites,
 		      allSites->DonorSites,allSites->nDonorSites,
 		      MAXUTRDONORS,MAXUTREXONLENGTH,cutPoint,sUTRINTERNAL,
-		      allExons->UtrInternalExons,NUMEXONS);
+		      &allExons->UtrInternalExons, &allExons->capUtrInternalExons);
       sprintf(mess,"UTR Internal Exons \t%8ld", allExons->nUtrInternalExons);
-      printRes(mess); 
+      printRes(mess);
 
       allExons->nUtr5InternalHalfExons =
 	BuildUTRExons(allSites->AcceptorSites,allSites->nAcceptorSites,
 		      allSites->StartCodons,allSites->nStartCodons,
 		      MAXUTRDONORS,MAXUTREXONLENGTH,cutPoint,sUTR5INTERNALHALF,
-		      allExons->Utr5InternalHalfExons,NUMEXONS);
+		      &allExons->Utr5InternalHalfExons, &allExons->capUtr5InternalHalfExons);
       sprintf(mess,"UTR 5' Int. Half Exons \t%8ld", allExons->nUtr5InternalHalfExons);
-      printRes(mess);  
+      printRes(mess);
 
       allExons->nUtr3InternalHalfExons =
 	BuildUTRExons(allSites->StopCodons,allSites->nStopCodons,
 		      allSites->DonorSites,allSites->nDonorSites,
 		      MAXUTRDONORS,MAXNMDLENGTH,cutPoint,sUTR3INTERNALHALF,
-		      allExons->Utr3InternalHalfExons,NUMEXONS);
+		      &allExons->Utr3InternalHalfExons, &allExons->capUtr3InternalHalfExons);
       sprintf(mess,"UTR 3' Int. Half Exons \t%8ld", allExons->nUtr3InternalHalfExons);
-      printRes(mess);  
+      printRes(mess);
 
       allExons->nUtrTerminalHalfExons =
 	BuildUTRExons(allSites->StopCodons,allSites->nStopCodons,
 		      allSites->TE,allSites->nTE,
 		      MAXUTRDONORS,MAX3UTREXONLENGTH,cutPoint,sUTRTERMINALHALF,
-		      allExons->UtrTerminalHalfExons,NUMEXONS);
+		      &allExons->UtrTerminalHalfExons, &allExons->capUtrTerminalHalfExons);
       sprintf(mess,"UTR Term. Half Exons \t%8ld", allExons->nUtrTerminalHalfExons);
-      printRes(mess);   
+      printRes(mess);
 
       allExons->nUtrTerminalExons =
 	BuildUTRExons(allSites->AcceptorSites,allSites->nAcceptorSites,
 		      allSites->TE,allSites->nTE,
 		      MAXUTRDONORS,MAX3UTREXONLENGTH,cutPoint,sUTRTERMINAL,
-		      allExons->UtrTerminalExons,NUMEXONS);
+		      &allExons->UtrTerminalExons, &allExons->capUtrTerminalExons);
       sprintf(mess,"UTR Terminal Exons \t%8ld", allExons->nUtrTerminalExons);
-      printRes(mess); 
- 
+      printRes(mess);
+
     }
 
     if (scanORF)


### PR DESCRIPTION
## Phase 2, Target #1c — UTR exon arrays

Same treatment as the 6 coding-exon builders ([#15](https://github.com/guigolab/geneid/pull/15)): `BuildUTRExons` filled a fixed `NUMEXONS/RUTR` array (shared by all 7 UTR exon types — `UtrInitial`, `UtrInitialHalf`, `UtrInternal`, `Utr5InternalHalf`, `Utr3InternalHalf`, `UtrTerminalHalf`, `UtrTerminal`) and aborted with `printError("decrease RUTR")` once a dense fragment exceeded it.

### Changes
- `BuildUTRExons` takes the array + capacity by reference and grows it on demand via the shared `GrowExonArray()` helper.
- Each of the 7 arrays gets its own `INITEXONS`-sized allocation and capacity field in `packExons` (`capUtrInitialExons`..`capUtrTerminalExons`).
- The "decrease RUTR" abort is gone.

### Verification
- Regression **5/5 byte-identical** (also with `INITEXONS` forced to **4**, forcing growth in all 7 UTR arrays).
- **ASan-clean** on `rnaseq` (real UTR prediction via `-u` with RNA-seq evidence) and `snake` (`-3UDTA`, UTR enabled).

(Skipped a full-SUPER_1-chromosome run for this one — that run only used `-3U`/U12, not `-u`, so it never exercises the UTR path; the regression suite's `rnaseq` case is the one that actually drives `BuildUTRExons` with real evidence.)

Remaining 1c: the site-sort table (4 buffers, threaded through `manager()`) and the site build packs + dumpster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)