### PR TITLE
SortSites: make the site-sort scratch buffers growable (drop FSORT*NUMSITES)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -173,6 +173,11 @@ A. DEFINITIONS
 /* are gone.                                                                  */
 #define INITEXONS 4096
 
+/* Initial capacity of the growable site-sort scratch buffers (SortSites,     */
+/* via packSortSites). Not a ceiling: each grows on demand, so the old        */
+/* "increase FSORT" abort on the site-sort path is gone.                      */
+#define INITSITESORT 1024
+
 /* Maximum number of isochores              */
 #define MAXISOCHORES 4           
 
@@ -499,10 +504,25 @@ typedef struct s_packSites
   long  nTS;
   long  nTE;
 
-  long nSites;                         
+  long nSites;
 } packSites;
 
-typedef struct s_exonGFF *pexonGFF;    
+/* Scratch buffers SortSites uses to stage sorted sites before copying them
+   back into the originating packSites arrays (donor/acceptor/TS/TE). Each
+   grows on demand (see GrowSiteArray); capacity persists across fragments. */
+typedef struct s_packSortSites
+{
+  site* donorsites;
+  long  donorsitescap;
+  site* acceptorsites;
+  long  acceptorsitescap;
+  site* tssites;
+  long  tssitescap;
+  site* tesites;
+  long  tesitescap;
+} packSortSites;
+
+typedef struct s_exonGFF *pexonGFF;
 typedef struct s_exonGFF
 {
   site* Acceptor;
@@ -881,6 +901,10 @@ exonGFF* RequestMemorySortExons();
    by the growable per-type Build arrays and the exon-sort table. */
 void GrowExonArray(exonGFF** buf, long* cap, long need);
 site* RequestMemorySortSites();
+
+/* Grow a site array *buf to hold at least `need` entries (realloc-double,
+   zeroing the new entries). Used by the growable site-sort scratch buffers. */
+void GrowSiteArray(site** buf, long* cap, long need);
 gparam* RequestMemoryParams();
 packGenes* RequestMemoryGenes();
 packDump* RequestMemoryDumpster();
@@ -924,7 +948,7 @@ void SortExons(packExons* allExons,
                long l1, long l2,long lowerlimit,
 	       long upperlimit);
 
-void SortSites(site *Sites, long nSites, site *sortedSites,        
+void SortSites(site *Sites, long nSites, site **sortedSites, long* cap,
                long l1, long l2
 	       );
 
@@ -1130,10 +1154,7 @@ void  manager(char *Sequence, long LengthSequence,
 	      gparam** isochores,
 	      int nIsochores,
 	      packGC* GCInfo,
-	      site* acceptorsites,
-	      site* donorsites,
-	      site* tssites,
-	      site* tesites
+	      packSortSites* sortSites
 	      );
 
 void resetEvidenceCounters(packExternalInformation* external);

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -257,15 +257,34 @@ exonGFF* RequestMemorySortExons()
 site* RequestMemorySortSites()
 {
   site *sites;
-  long HowMany;
 
-  /* Sorting Exons */
-  HowMany = NUMSITES * FSORT;
+  /* Start small; SortSites grows this on demand (see GrowSiteArray), so it
+     is no longer reserved at NUMSITES*FSORT up front nor capped. */
   if ((sites =
-       (site*) calloc(HowMany, sizeof(site)))  == NULL)
+       (site*) calloc(INITSITESORT, sizeof(site)))  == NULL)
     printError("Not enough memory: table to sort sites");
 
   return(sites);
+}
+
+/* Grow a site array *buf to hold at least `need` entries. Doubles the
+   capacity, preserves existing contents, and zeroes the new entries (the
+   array was originally calloc'd, so unfilled slots must stay zeroed). */
+void GrowSiteArray(site** buf, long* cap, long need)
+{
+  long ncap;
+  site* tmp;
+
+  if (need <= *cap)
+    return;
+  ncap = (*cap > 0) ? *cap : 1;
+  while (ncap < need)
+    ncap *= 2;
+  if ((tmp = (site*) realloc(*buf, ncap * sizeof(site))) == NULL)
+    printError("Not enough memory: growing site array");
+  memset(tmp + *cap, 0, (ncap - *cap) * sizeof(site));
+  *buf = tmp;
+  *cap = ncap;
 }
 
 /* Allocating memory for input evidences (annotations) */

--- a/src/SortSites.c
+++ b/src/SortSites.c
@@ -28,10 +28,6 @@
 
 #include "geneid.h"
 
-/* Maximum allowed number of sites  */
-extern long NUMSITES;
-
-
 /* Struct for a node (list): pointer to site and to next node */
 struct siteitem 
 {
@@ -69,9 +65,9 @@ void UpdateSiteList(struct siteitem** p, site* InputSite)
 
 /* Sort all of predicted sites by placing them in an array of lists */
 /* corresponding every list to a beginning position for predicted sites */
-void SortSites(site* Sites, long numSites,  site* sortedSites,     
+void SortSites(site* Sites, long numSites, site** psortedSites, long* pcap,
                long l1, long l2)
-{ 
+{
   struct siteitem **SiteList, *q;
   long i;
   long pos;
@@ -82,7 +78,9 @@ void SortSites(site* Sites, long numSites,  site* sortedSites,
   long right;
 /*   long room; */
 /*   char mess[MAXSTRING]; */
-  long HowMany;
+  /* Growable scratch buffer (grows on demand; see GrowSiteArray) */
+  site* sortedSites = *psortedSites;
+  long cap = *pcap;
 
   /* 0. Creating the array for sorting: 1 - Length of fragment */
   left = l1;
@@ -115,7 +113,6 @@ void SortSites(site* Sites, long numSites,  site* sortedSites,
   n = 0;
 
   /* 3. Traversing the table extracting the sites sorted by left position */
-  HowMany = FSORT*NUMSITES;
   /* for (i=0, n=0; i<l; i++) */
   for (i=0; i<l+10; i++)
     {
@@ -124,6 +121,7 @@ void SortSites(site* Sites, long numSites,  site* sortedSites,
       while (q != NULL)
 		{
 		  /* Save the extracted site */
+		  GrowSiteArray(&sortedSites,&cap, n+1);
 
 		  sortedSites[n].Position = q->Site->Position;
 		  sortedSites[n].Score = q->Site->Score;
@@ -136,19 +134,22 @@ void SortSites(site* Sites, long numSites,  site* sortedSites,
 		  strcpy(sortedSites[n].subtype,q->Site->subtype);
 		  strcpy(sortedSites[n].type,q->Site->type);
 		  n++;
-		  if (n >= HowMany)
-			printError("Too many predicted sites: increase FSORT parameter");
-	  
+
 		  q=q->nexitem;
 		}
 
 	  /* Free chained items in the processed list q */
-	  FreeSiteItems(SiteList[i]);       
+	  FreeSiteItems(SiteList[i]);
 	}
 
   /* Free empty array */
   free(SiteList);
-  for (i=0; i<numSites; i++) 
+
+  /* Hand back the (possibly grown) scratch buffer and its capacity */
+  *psortedSites = sortedSites;
+  *pcap = cap;
+
+  for (i=0; i<numSites; i++)
     {  
       Sites[i].Position = sortedSites[i].Position;
       Sites[i].Score = sortedSites[i].Score ;

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -145,11 +145,8 @@ int main (int argc, char *argv[])
   packSites* allSites_r;
   packExons* allExons_r;
   
-  /* Structures for sorting sites */
-  site* donorsites;
-  site* acceptorsites;
-  site* tssites = NULL;
-  site* tesites = NULL;
+  /* Growable scratch buffers for sorting sites (see packSortSites) */
+  packSortSites sortSites;
 
   /* Table to sort predicted exons by acceptor (growable; see SortExons) */
   exonGFF* exons;
@@ -251,11 +248,20 @@ int main (int argc, char *argv[])
   exons         = (exonGFF*)      RequestMemorySortExons();
   exonscap      = INITSORT;
   printMess("Request Memory Sort Sites\n");
-  donorsites    = (site*)         RequestMemorySortSites(); /* Temporary structure for sorting donor sites */
-  acceptorsites = (site*)         RequestMemorySortSites(); /* Temporary structure for sorting acceptor sites */
+  /* Scratch buffers for SortSites; each grows on demand (see GrowSiteArray) */
+  sortSites.donorsites    = (site*) RequestMemorySortSites();
+  sortSites.donorsitescap = INITSITESORT;
+  sortSites.acceptorsites    = (site*) RequestMemorySortSites();
+  sortSites.acceptorsitescap = INITSITESORT;
+  sortSites.tssites = NULL;
+  sortSites.tssitescap = 0;
+  sortSites.tesites = NULL;
+  sortSites.tesitescap = 0;
   if (UTR){
-    tssites = (site*)         RequestMemorySortSites(); /* Temporary structure for sorting acceptor sites */
-    tesites = (site*)         RequestMemorySortSites(); /* Temporary structure for sorting acceptor sites */
+    sortSites.tssites    = (site*) RequestMemorySortSites();
+    sortSites.tssitescap = INITSITESORT;
+    sortSites.tesites    = (site*) RequestMemorySortSites();
+    sortSites.tesitescap = INITSITESORT;
   }
   printMess("Request Memory Isochores, etc.\n");
   isochores     = (gparam**)      RequestMemoryIsochoresParams(); 
@@ -418,7 +424,7 @@ int main (int argc, char *argv[])
 			  FORWARD, 
 			  external, hsp, gp,
 			  isochores,nIsochores,
-			  GCInfo,acceptorsites,donorsites,tssites,tesites);
+			  GCInfo,&sortSites);
 		}      
 	      if (RVS) 
 		{
@@ -435,7 +441,7 @@ int main (int argc, char *argv[])
 			  REVERSE, 
 			  external, hsp, gp,
 			  isochores,nIsochores,
-			  GCInfo_r,acceptorsites,donorsites,tssites,tesites);
+			  GCInfo_r,&sortSites);
 				  				  
 		  /* normalised positions: according to forward sense reading */
 		  RecomputePositions(allSites_r, LengthSequence);

--- a/src/manager.c
+++ b/src/manager.c
@@ -51,7 +51,7 @@ extern int UTR;
 extern long NUMSITES,NUMEXONS;
 
 /* Management of splice sites prediction and exon construction/scoring */
-void  manager(char *Sequence, 
+void  manager(char *Sequence,
 	      long LengthSequence,
 	      packSites* allSites,
 	      packExons* allExons,
@@ -63,10 +63,7 @@ void  manager(char *Sequence,
 	      gparam** isochores,
 	      int nIsochores,
 	      packGC* GCInfo,
-	      site* acceptorsites,
-	      site* donorsites,
-	      site* tssites,
-	      site* tesites
+	      packSortSites* sortSites
 	      )
 {
   char mess[MAXSTRING];
@@ -246,8 +243,8 @@ void  manager(char *Sequence,
   if ( U12GTAG || U12ATAC || U2GCAG || U2GTA || U2GTG || U2GTY ){
     /* Predicted sites must be sorted by position */
     printMess ("Sorting Donor and Acceptor sites ...");
-    SortSites(allSites->DonorSites,allSites->nDonorSites,donorsites,l1b,l2b);
-    SortSites(allSites->AcceptorSites,allSites->nAcceptorSites,acceptorsites,l1a,l2a);
+    SortSites(allSites->DonorSites,allSites->nDonorSites,&sortSites->donorsites,&sortSites->donorsitescap,l1b,l2b);
+    SortSites(allSites->AcceptorSites,allSites->nAcceptorSites,&sortSites->acceptorsites,&sortSites->acceptorsitescap,l1a,l2a);
   }
   allSites->nTS=0;
   allSites->nTE=0;
@@ -285,8 +282,8 @@ void  manager(char *Sequence,
   if ( UTR ){
     /* Predicted sites must be sorted by position */
     printMess ("Sorting TSS/TES sites ...");
-    SortSites(allSites->TS,allSites->nTS,tssites,l1,l2);
-    SortSites(allSites->TE,allSites->nTE,tesites,l1,l2);
+    SortSites(allSites->TS,allSites->nTS,&sortSites->tssites,&sortSites->tssitescap,l1,l2);
+    SortSites(allSites->TE,allSites->nTE,&sortSites->tesites,&sortSites->tesitescap,l1,l2);
   }
   if (GENAMIC || (!GENAMIC && (EFP || EIP || ETP || ESP || EOP || EXP))){
     /* 2. Building exons with splice sites predicted before */ 


### PR DESCRIPTION
## Phase 2, Target #1c — site-sort scratch buffers

The 4 site-sort scratch buffers (donor/acceptor/TS/TE) were `calloc`'d once at `FSORT*NUMSITES` and aborted with `printError("increase FSORT")` on overflow — mirroring the exon-sort table's old ceiling ([#14](https://github.com/guigolab/geneid/pull/14)).

These buffers are pure scratch: `SortSites` writes the sorted result into them and then copies it straight back into the originating `packSites` array, so nothing else holds a pointer into them.

### Changes
- Bundled the 4 buffers + their capacities into a new `packSortSites` struct (both `manager()` calls — FWD and RVS — already shared the same instance, so this also replaces 8 raw params on `manager()` with one struct pointer).
- Each buffer starts at `INITSITESORT` and grows on demand via a new `GrowSiteArray()` helper (same realloc-double + zero-new-slots pattern as `GrowExonArray`).
- `SortSites` takes its scratch buffer + capacity by reference and hands back the grown pointer. The "increase FSORT" abort is gone.

### Verification
- Regression **5/5 byte-identical** (also with `INITSITESORT` forced to **4**, forcing growth + cross-split reuse on the multi-split snake).
- The **full SUPER_1 chromosome** (20 909 genes) byte-identical before/after.
- **ASan-clean** on the snake and `rnaseq` (UTR TS/TE sort path) fixtures.

Remaining 1c: the site *build* packs (`BuildAcceptors`/`Donors`/`U12*`, "decrease RSITES") + the dumpster (`MAXBACKUP*`) + `d`-arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)