### PR TITLE
site builders: make the predicted-site arrays growable (drop NUMSITES caps)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -178,6 +178,11 @@ A. DEFINITIONS
 /* "increase FSORT" abort on the site-sort path is gone.                      */
 #define INITSITESORT 1024
 
+/* Initial capacity of the growable predicted-site arrays (packSites). Not a   */
+/* ceiling: the site builders grow each array on demand, so the old NUMSITES  */
+/* reservation and the "decrease RSITES" hard errors are gone.                */
+#define INITSITES 4096
+
 /* Maximum number of isochores              */
 #define MAXISOCHORES 4           
 
@@ -497,12 +502,21 @@ typedef struct s_packSites
   site* TS;
   site* TE;
 
-  long  nStartCodons;                  
+  long  nStartCodons;
   long  nAcceptorSites;
   long  nDonorSites;
   long  nStopCodons;
   long  nTS;
   long  nTE;
+
+  /* Allocated capacity of each growable site array (grown by the Build/Get
+     site builders; the arrays are no longer reserved at NUMSITES nor capped). */
+  long  capStartCodons;
+  long  capAcceptorSites;
+  long  capDonorSites;
+  long  capStopCodons;
+  long  capTS;
+  long  capTE;
 
   long nSites;
 } packSites;
@@ -794,10 +808,10 @@ void printRes(char* s);
 
 void printReadingInfo(char* s);
 
-long GetSitesWithProfile(char *s, profile *p, site *st, long l1, long l2); 
+long GetSitesWithProfile(char *s, profile *p, site **st, long* cap, long l1, long l2);
 
 long GetTSS(
-	    site* sc,
+	    site** sc, long* cap,
 	    site* Acceptors, long nAcceptors,
 	    packExternalInformation* external,
 	    packHSP* hsp,
@@ -808,7 +822,7 @@ long GetTSS(
 	    );
 
 long GetTES(
-	    site* sc,
+	    site** sc, long* cap,
 	    site* Donors, long nDonors,
 	    packExternalInformation* external,
 	    packHSP* hsp,
@@ -822,14 +836,14 @@ long GetTES(
 long BuildDonors(char* s,short class,char* type,
 		 char* subtype,
 		 profile* p,
-		 site* st, 
-		 long l1, 
+		 site** st,
+		 long l1,
 		 long l2,
 		 long ns,
-		 long nsites,
+		 long* cap,
 		 int Strand,
 		 packExternalInformation* external
-		 ); 
+		 );
 float PeakEdgeScore(long Position, 
 		    int Strand, 
 		    packExternalInformation* external, 
@@ -838,7 +852,7 @@ int ClusterEdge(long Position,
 		int Strand, 
 		packExternalInformation* external, 
 		long l1, long l2);
-long GetStopCodons(char *s, profile *p, site *sc, long l1, long l2);
+long GetStopCodons(char *s, profile *p, site **sc, long* cap, long l1, long l2);
 
 long BuildInitialExons(site *Start, long nStarts, 
                        site *Donor, long nDonors,
@@ -1179,14 +1193,14 @@ long  BuildU12Acceptors(char* s,
 			profile* u12_p,
 			profile* u12bp,
 			profile* ppt,
-			site* st, 
-			long l1, 
+			site** st,
+			long l1,
 			long l2,
 			long ns,
-			long nsites,
+			long* cap,
 			int Strand,
 			packExternalInformation* external);
-					 
+
 long  BuildAcceptors(char* s,
 		     short class,
 		     char* type,
@@ -1194,10 +1208,10 @@ long  BuildAcceptors(char* s,
 		     profile* p,
 		     profile* ppt,
 		     profile* bp,
-		     site* st, 
-		     long l1, 
+		     site** st,
+		     long l1,
 		     long l2,
 		     long ns,
-		     long nsites,
+		     long* cap,
 		     int Strand,
 		     packExternalInformation* external);

--- a/src/BuildAcceptors.c
+++ b/src/BuildAcceptors.c
@@ -31,8 +31,6 @@
 /* Function TRANS: char -> integer such that A=0, C=1, G=2 and T/U=2 */
 extern int TRANS[];
 
-/* Maximum allowed number of generic sites */
-extern long NUMSITES;
 extern int UTR;
 /* Additional profiles */
 extern int BP;
@@ -146,14 +144,14 @@ long  BuildAcceptors(char* s,
 		     profile* p,
 		     profile* ppt,
 		     profile* bp,
-		     site* st, 
-		     long l1, 
+		     site** stP,
+		     long l1,
 		     long l2,
 		     long ns,
-		     long nsites,
+		     long* capP,
 		     int Strand,
-		     packExternalInformation* external) 
-{ 
+		     packExternalInformation* external)
+{
   int i,j;
   char* sOriginal;
   float score;
@@ -165,6 +163,9 @@ long  BuildAcceptors(char* s,
   long left,right;
   int index;
   float cutoff;
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* st = *stP;
+  long cap = *capP;
   /* Final number of predicted signals (that type) */
   /*   ns = 0; */
 
@@ -177,7 +178,7 @@ long  BuildAcceptors(char* s,
   /* 1. Searching sites between beginning of the sequence and p->offset */
   if (!l1)
     {
-      for (is = 0; is < (p->offset)  && (ns<NUMSITES); is++)
+      for (is = 0; is < (p->offset) ; is++)
 	{
 	  score=0.0;
 	  /* Applying part of the profile */
@@ -196,6 +197,7 @@ long  BuildAcceptors(char* s,
 	  scoreBP = 0.0;
 	  scoreAcc = 0.0;
 	  if (score >= cutoff){
+	    GrowSiteArray(&st,&cap,ns+1);
 	    /* Using additional profiles */
 	    if (PPT)
 	      scorePPT = ComputeU2PPTProfile(sOriginal,p->offset-is,l2,ppt,&st[ns]);
@@ -239,7 +241,7 @@ long  BuildAcceptors(char* s,
   if (p->order == 0)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension -1) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+p->dimension -1) && (is < right- left + 1))
 	{ 
 	  /* is = 0..right */
 	  score=0.0;
@@ -257,6 +259,7 @@ long  BuildAcceptors(char* s,
 	  scoreBP = 0.0;
 	  scoreAcc = 0.0;
 	  if (score >= cutoff){
+	    GrowSiteArray(&st,&cap,ns+1);
 	    /* Using additional profiles */
 	    if (PPT)
 	      scorePPT = ComputeU2PPTProfile(sOriginal,left + is + p->offset,l2,ppt,&st[ns]);
@@ -291,7 +294,7 @@ long  BuildAcceptors(char* s,
   else if (p->order == 1)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension -1) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+p->dimension -1) && (is < right- left + 1))
 	{ 
 	  /* is = 0..right */
 	  score=0.0;
@@ -309,6 +312,7 @@ long  BuildAcceptors(char* s,
 	  scoreBP = 0.0;
 	  scoreAcc = 0.0;
 	  if (score >= cutoff){
+	    GrowSiteArray(&st,&cap,ns+1);
 	    /* Using additional profiles */
 	    if (PPT)
 	      scorePPT = ComputeU2PPTProfile(sOriginal,left + is + p->offset,l2,ppt,&st[ns]);
@@ -345,7 +349,7 @@ long  BuildAcceptors(char* s,
   else
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension -1) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+p->dimension -1) && (is < right- left + 1))
 	{ 
 	  /* is = 0..right */
 	  score=0.0;
@@ -365,6 +369,7 @@ long  BuildAcceptors(char* s,
 	  scoreBP = 0.0;
 	  scoreAcc = 0.0;
 	  if (score >= cutoff){
+	    GrowSiteArray(&st,&cap,ns+1);
 	    /* Using additional profiles */
 	    if (PPT)
 	      scorePPT = ComputeU2PPTProfile(sOriginal,left + is + p->offset,l2,ppt,&st[ns]);
@@ -397,10 +402,9 @@ long  BuildAcceptors(char* s,
 	  s++;
 	}
     }
-  if (ns >= nsites)
-    printError("Too many predicted sites: decrease RSITES parameter");
-  
-  return(ns);   
+  *stP = st;
+  *capP = cap;
+  return(ns);
 }
 
  

--- a/src/BuildDonors.c
+++ b/src/BuildDonors.c
@@ -32,8 +32,6 @@
 /* Function TRANS: char -> integer such that A=0, C=1, G=2 and T/U=2 */
 extern int TRANS[];
 
-/* Maximum allowed number of generic sites */
-extern long NUMSITES;
 extern int UTR;
 
 
@@ -43,25 +41,28 @@ long  BuildDonors(char* s,
 		  char* type,
 		  char* subtype,
 		  profile* p,
-		  site* st, 
-		  long l1, 
+		  site** stP,
+		  long l1,
 		  long l2,
 		  long ns,
-		  long nsites,
+		  long* capP,
 		  int Strand,
 		  packExternalInformation* external
-		  ) 
+		  )
 {
   int i,j;
   float score;
   long is;
   long left,right;
   int index;
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* st = *stP;
+  long cap = *capP;
 
   /* 1. Searching sites between beginning of the sequence and p->offset */
   if (!l1)
     {
-      for (is = 0; is < p->offset && (ns<nsites); is++)
+      for (is = 0; is < p->offset; is++)
 		{
 		  score=0.0;
 		  /* Applying part of the profile */
@@ -81,6 +82,7 @@ long  BuildDonors(char* s,
 		  }
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = is + p->order;
 			  st[ns].Score= score;
 			  st[ns].class= class;
@@ -101,7 +103,7 @@ long  BuildDonors(char* s,
   if (p->order == 0)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension-1) && (is < right- left + 1) && (ns<nsites))
+      while (*(s+p->dimension-1) && (is < right- left + 1))
 		{ 
 		  /* is = 0..right */
 		  score=0.0;
@@ -120,6 +122,7 @@ long  BuildDonors(char* s,
 		  }
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = left + is + p->offset;
 			  st[ns].Score=score;
 			  st[ns].class= class;
@@ -135,7 +138,7 @@ long  BuildDonors(char* s,
   else if (p->order == 1)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension-1) && (is < right- left + 1) && (ns<nsites))
+      while (*(s+p->dimension-1) && (is < right- left + 1))
 		{ 
 		  /* is = 0..right */
 		  score=0.0;
@@ -154,6 +157,7 @@ long  BuildDonors(char* s,
 		  }
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = left + is + p->offset;
 			  st[ns].Score=score;
 			  st[ns].class= class;
@@ -170,7 +174,7 @@ long  BuildDonors(char* s,
   else
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension-1) && (is < right- left + 1) && (ns<nsites))
+      while (*(s+p->dimension-1) && (is < right- left + 1))
 		{ 
 		  /* is = 0..right */
 		  score=0.0;
@@ -191,6 +195,7 @@ long  BuildDonors(char* s,
 		  }
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = left + is + p->offset;
 			  st[ns].Score=score;
 			  st[ns].class= class;
@@ -203,9 +208,8 @@ long  BuildDonors(char* s,
 		}
     }
   
-  if (ns >= nsites)
-    printError("Too many predicted sites: decrease RSITES parameter");
-
+  *stP = st;
+  *capP = cap;
   return(ns);
 }
 

--- a/src/BuildU12Acceptors.c
+++ b/src/BuildU12Acceptors.c
@@ -31,9 +31,6 @@
 /* Function TRANS: char -> integer such that A=0, C=1, G=2 and T/U=2 */
 extern int TRANS[];
 
-/* Maximum allowed number of generic sites */
-extern long NUMSITES;
-
 /* Additional profiles */
 extern int BP;
 extern int PPT;
@@ -141,14 +138,14 @@ long  BuildU12Acceptors(char* s,
 			profile* u12_p,
 			profile* u12bp,
 			profile* ppt,
-			site* st, 
-			long l1, 
+			site** stP,
+			long l1,
 			long l2,
 			long ns,
-			long nsites,
+			long* capP,
 			int Strand,
-			packExternalInformation* external) 
-{ 
+			packExternalInformation* external)
+{
   int i,j;
   char* sOriginal;
   float score;
@@ -160,6 +157,9 @@ long  BuildU12Acceptors(char* s,
   long left,right;
   int index;
   float cutoff;
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* st = *stP;
+  long cap = *capP;
 
   /* Back-up the origin of the sequence */
   sOriginal = s;
@@ -171,9 +171,9 @@ long  BuildU12Acceptors(char* s,
   /* 1. Searching sites between beginning of the sequence and p->offset */
   if (!l1)
     {
-      for (is = 0; is < u12_p->offset && (ns<NUMSITES); is++)
+      for (is = 0; is < u12_p->offset; is++)
 	{ 	  
-	  if (ns<NUMSITES){
+	  {
 		  	  
 	    scorePPT = 0.0;
 	    scoreBP = 0.0;
@@ -194,6 +194,7 @@ long  BuildU12Acceptors(char* s,
 	      {
 				  
 		/* Using additional profiles */
+		GrowSiteArray(&st,&cap,ns+1);
 		scoreBP = ComputeU12BranchProfile(sOriginal,u12_p->offset-is,l2,u12bp,&st[ns]);
 		if (scoreBP >=u12bp->cutoff) {
 		if (PPT)
@@ -237,9 +238,9 @@ long  BuildU12Acceptors(char* s,
   if (u12_p->order == 0)
     {
       /* discovering splice sites with current profile */
-      while (*(s+u12_p->dimension-1) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+u12_p->dimension-1) && (is < right- left + 1))
 	{ 	
-	  if (ns<NUMSITES){
+	  {
 
 	    scorePPT = 0.0;
 	    scoreBP = 0.0;
@@ -258,6 +259,7 @@ long  BuildU12Acceptors(char* s,
 	    if (score >= cutoff) 
 	      {
 		/* Using additional profiles */
+		GrowSiteArray(&st,&cap,ns+1);
 		scoreBP = ComputeU12BranchProfile(sOriginal,left + is + u12_p->offset,l2,u12bp,&st[ns]);  
 		if (scoreBP >=u12bp->cutoff) {	  
 		if (PPT)
@@ -295,9 +297,9 @@ long  BuildU12Acceptors(char* s,
     {
 
       /* discovering splice sites with current profile */
-      while (*(s+u12_p->dimension-1) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+u12_p->dimension-1) && (is < right- left + 1))
 	{ 		
-	  if (ns<NUMSITES){
+	  {
 	    /*Do for U12GTAG*/
 			  
 	    scorePPT = 0.0;
@@ -318,6 +320,7 @@ long  BuildU12Acceptors(char* s,
 	    if (score >= cutoff) 
 	      {
 		/* Using additional profiles */
+		GrowSiteArray(&st,&cap,ns+1);
 		scoreBP = ComputeU12BranchProfile(sOriginal,left + is + u12_p->offset,l2,u12bp,&st[ns]);
 		if (scoreBP >=u12bp->cutoff) {	  
 		if (PPT)
@@ -354,9 +357,9 @@ long  BuildU12Acceptors(char* s,
   else
     {
       /* discovering splice sites with current profile */
-      while (*(s+u12_p->dimension-1) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+u12_p->dimension-1) && (is < right- left + 1))
 	{ 
-	  if (ns<NUMSITES){
+	  {
 			  
 	    scorePPT = 0.0;
 	    scoreBP = 0.0;
@@ -376,6 +379,7 @@ long  BuildU12Acceptors(char* s,
 	    if (score >= cutoff) 
 	      {
 		/* Using additional profiles */
+		GrowSiteArray(&st,&cap,ns+1);
 		scoreBP = ComputeU12BranchProfile(sOriginal,left + is + u12_p->offset,l2,u12bp,&st[ns]);
 		if (scoreBP >=u12bp->cutoff) {
 		if (PPT)
@@ -407,11 +411,9 @@ long  BuildU12Acceptors(char* s,
 	  s++;
 	}
     }
-  if (ns >= nsites)
-    printError("Too many predicted sites: decrease RSITES parameter");
-  
-  return(ns);  
-
+  *stP = st;
+  *capP = cap;
+  return(ns);
 }
 
  

--- a/src/GetSitesWithProfile.c
+++ b/src/GetSitesWithProfile.c
@@ -32,28 +32,28 @@
 /* Function TRANS: char -> integer such that A=0, C=1, G=2 and T/U=2 */
 extern int TRANS[];
 
-/* Maximum allowed number of generic sites */
-extern long NUMSITES;
-
 long  GetSitesWithProfile(char* s,
                           profile* p,
-                          site* st, 
-                          long l1, 
-                          long l2) 
+                          site** stP, long* capP,
+                          long l1,
+                          long l2)
 {
   int i,j;
   float score;
   long ns,is;
   long left,right;
   int index;
-  
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* st = *stP;
+  long cap = *capP;
+
   /* Final number of predicted signals (that type) */
   ns = 0;
   
   /* 1. Searching sites between beginning of the sequence and p->offset */
   if (!l1)
     {
-      for (is = 0; is < p->offset && (ns<NUMSITES); is++)
+      for (is = 0; is < p->offset; is++)
 		{
 		  score=0.0;
 		  /* Applying part of the profile */
@@ -71,6 +71,7 @@ long  GetSitesWithProfile(char* s,
 		  score = p->afactor + (p->bfactor * score);
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = is + p->order;
 			  st[ns].Score=score;
 			  st[ns].class=U2;
@@ -90,7 +91,7 @@ long  GetSitesWithProfile(char* s,
   if (p->order == 0)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+p->dimension) && (is < right- left + 1))
 		{ 
 		  /* is = 0..right */
 		  score=0.0;
@@ -107,6 +108,7 @@ long  GetSitesWithProfile(char* s,
 		  score = p->afactor + (p->bfactor * score);
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = left + is + p->offset;
 			  st[ns].Score=score;
 			  st[ns].class=U2;
@@ -121,7 +123,7 @@ long  GetSitesWithProfile(char* s,
   else if (p->order == 1)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+p->dimension) && (is < right- left + 1))
 		{ 
 		  /* is = 0..right */
 		  score=0.0;
@@ -138,6 +140,7 @@ long  GetSitesWithProfile(char* s,
 		  score = p->afactor + (p->bfactor * score);
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = left + is + p->offset;
 			  st[ns].Score=score;
 			  st[ns].class=U2;
@@ -152,7 +155,7 @@ long  GetSitesWithProfile(char* s,
   else
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension) && (is < right- left + 1) && (ns<NUMSITES))
+      while (*(s+p->dimension) && (is < right- left + 1))
 		{ 
 		  /* is = 0..right */
 		  score=0.0;
@@ -171,6 +174,7 @@ long  GetSitesWithProfile(char* s,
 		  score = p->afactor + (p->bfactor * score);
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&st,&cap,ns+1);
 			  st[ns].Position = left + is + p->offset;
 			  st[ns].Score=score;
 			  st[ns].class=U2;
@@ -182,9 +186,8 @@ long  GetSitesWithProfile(char* s,
 		}
     }
   
-  if (ns >= NUMSITES)
-    printError("Too many predicted sites: decrease RSITES parameter");
-  
+  *stP = st;
+  *capP = cap;
   return(ns);
 }
 

--- a/src/GetStopCodons.c
+++ b/src/GetStopCodons.c
@@ -32,18 +32,18 @@
 /* Function TRANS: char -> integer such that A=0, C=1, G=2 and T/U=2 */
 extern int TRANS[];
 
-/* Maximum allowed number of generic sites */
-extern long NUMSITES;
-
 long GetStopCodons(char* s,
                    profile* p,
-                   site* sc, 
-                   long l1, 
-                   long l2) 
+                   site** scP, long* capP,
+                   long l1,
+                   long l2)
 {
   long ns,is;
   float score;
   int i,j;
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* sc = *scP;
+  long cap = *capP;
   
   /* Strings defining Stop codons */
   static char *stop[] =
@@ -63,7 +63,7 @@ long GetStopCodons(char* s,
   /* 1. Searching sites between beginning of the sequence and p->offset */
   if (!l1)
     {
-      for (is = 0; is < p->offset && (ns<NUMSITES); is++)
+      for (is = 0; is < p->offset; is++)
 		{
 		  score=0.0;
 		  /* Applying part of the profile */
@@ -80,6 +80,7 @@ long GetStopCodons(char* s,
 		  
 		  if (score >= p->cutoff) 
 			{
+			  GrowSiteArray(&sc,&cap,ns+1);
 			  sc[ns].Position = is + p->order;
 			  sc[ns].Score=score;
 			  sc[ns].class=U2;
@@ -99,7 +100,7 @@ long GetStopCodons(char* s,
   if (p->order==0)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension) && (is < right - left + 1) && (ns<NUMSITES))  
+      while (*(s+p->dimension) && (is < right - left + 1))  
 		{
 		  /* The candidate region must contain the STOP in the right position */
 		  strncpy(codon,s+p->offset+1,LENGTHCODON);
@@ -123,6 +124,7 @@ long GetStopCodons(char* s,
 			  if (score >= p->cutoff) 
 				{
 				  /* Position given is last coding position before Stop */ 
+				  GrowSiteArray(&sc,&cap,ns+1);
 				  sc[ns].Position=left + is + p->offset;
 				  sc[ns].Score=score;
 				  sc[ns].class=U2;
@@ -137,7 +139,7 @@ long GetStopCodons(char* s,
   else if (p->order==1)
     {
       /* discovering splice sites with current profile */
-      while (*(s+p->dimension) && (is < right - left + 1) && (ns<NUMSITES))  
+      while (*(s+p->dimension) && (is < right - left + 1))  
 		{
 		  /* The candidate region must contain the STOP in the right position */
 		  strncpy(codon,s+p->offset+1,LENGTHCODON);
@@ -161,6 +163,7 @@ long GetStopCodons(char* s,
 			  if (score >= p->cutoff) 
 				{
 				  /* Position given is last coding position before Stop */ 
+				  GrowSiteArray(&sc,&cap,ns+1);
 				  sc[ns].Position=left + is + p->offset;
 				  sc[ns].Score=score;
 				  sc[ns].class=U2;
@@ -175,7 +178,7 @@ long GetStopCodons(char* s,
   else
     {
 	  /* discovering splice sites with current profile */
-      while (*(s+p->dimension) && (is < right - left + 1) && (ns<NUMSITES))  
+      while (*(s+p->dimension) && (is < right - left + 1))  
 		{
 		  /* The candidate region must contain the STOP in the right position */
 		  strncpy(codon,s+p->offset+1,LENGTHCODON);
@@ -199,6 +202,7 @@ long GetStopCodons(char* s,
 			  if (score >= p->cutoff) 
 				{
 				  /* Position given is last coding position before Stop */ 
+				  GrowSiteArray(&sc,&cap,ns+1);
 				  sc[ns].Position=left + is + p->offset;
 				  sc[ns].Score=score;
 				  sc[ns].class=U2;
@@ -216,7 +220,7 @@ long GetStopCodons(char* s,
       s=(s-is);
       is+=p->offset;
       
-      while (*(s+is) && (ns<NUMSITES))  
+      while (*(s+is))  
 		{
 		  /* The candidate region must contain the STOP in the right position */
 		  strncpy(codon,(s+is),LENGTHCODON);
@@ -225,6 +229,7 @@ long GetStopCodons(char* s,
 		  if (!strcmp(codon,stop[0]) || !strcmp(codon,stop[1]) || !strcmp(codon,stop[2]))
 			{
 			  /* Position given is last coding position before Stop */
+			  GrowSiteArray(&sc,&cap,ns+1);
 			  sc[ns].Position=is-1;  
 			  sc[ns].Score=0;
 			  sc[ns].class=U2;
@@ -234,8 +239,7 @@ long GetStopCodons(char* s,
 		}
     }
   
-  if (ns >= NUMSITES)
-    printError("Too many predicted sites: decrease RSITES parameter");
-  
+  *scP = sc;
+  *capP = cap;
   return(ns);
 }

--- a/src/GetTranscriptTermini-usingslopes.c
+++ b/src/GetTranscriptTermini-usingslopes.c
@@ -29,24 +29,24 @@
 
 #include "geneid.h"
 
-/* Maximum allowed number of generic sites */
-extern long NUMSITES;
-
 long GetTSS(
-	    site* sc,
+	    site** scP, long* capP,
 	    site* Acceptors, long nAcceptors,
 	    packExternalInformation* external,
 	    packHSP* hsp,
 	    int Strand,
-	    long LengthSequence, 
+	    long LengthSequence,
 	    long l1,
 	    long l2
-	    ) 
+	    )
 {
   long ns;
   float thresh = 1.2;
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* sc = *scP;
+  long cap = *capP;
   /* Final number of potential transcript termini */
-  ns = 0;  
+  ns = 0;
 /*   char mess[MAXSTRING]; */
   float score;
   long is;
@@ -61,7 +61,7 @@ long GetTSS(
   float prev_prev_score = 0;
   is = 0;     
 
-  while ((is < (l2- l1 + 1)) && (ns<NUMSITES))
+  while ((is < (l2- l1 + 1)))
     { 
       /* is = 0..right */
       ssExists =0;
@@ -71,7 +71,7 @@ long GetTSS(
       score = score + pes; 
 /*       sprintf(mess,"pos %ld:%f",l1 + is -1,prev_score); */
 /* 	  	printMess(mess); */
-      if ((ns<NUMSITES)&&((cluster_edge == 1)||(prev_score>thresh && prev_score>prev_prev_score && prev_score>score))){
+      if (((cluster_edge == 1)||(prev_score>thresh && prev_score>prev_prev_score && prev_score>score))){
 	j=js;
 	while ((j < nAcceptors) && ((Acceptors+j)->Position < (l1 + is - 1 - window)))
 	  j++;
@@ -91,6 +91,7 @@ long GetTSS(
 /* 	  	printMess(mess); */
 /* 	  sprintf(mess,"PES TSS: pos %ld:%f",l1 + is -1,prev_score); */
 /* 	  	printMess(mess); */
+	  GrowSiteArray(&sc,&cap,ns+1);
 	  sc[ns].Position=(l1 + is -1);  
 	  sc[ns].Score=prev_score;
 	  sc[ns].class=U2;
@@ -106,26 +107,28 @@ long GetTSS(
       prev_score = score;
     }
 
-  if (ns >= NUMSITES)
-    printError("Too many predicted sites: decrease RSITES parameter");
-  
+  *scP = sc;
+  *capP = cap;
   return(ns);
 
 
 }
 
 long GetTES(
-	    site* sc,
+	    site** scP, long* capP,
 	    site* Donors, long nDonors,
 	    packExternalInformation* external,
 	    packHSP* hsp,
 	    int Strand,
-	    long LengthSequence, 
+	    long LengthSequence,
 	    long l1,
 	    long l2,
 	    long ns
-	    ) 
+	    )
 {
+  /* Growable output array (grows on demand; capacity tracked by caller) */
+  site* sc = *scP;
+  long cap = *capP;
   /* Final number of potential transcript termini */
   /* ns = 0;   */
 /*   char mess[MAXSTRING]; */
@@ -142,7 +145,7 @@ long GetTES(
   is = 0;     
   float prev_score =0;
   float prev_prev_score = 0;
-  while ((is < (l2- l1 + 1)) && (ns<NUMSITES))
+  while ((is < (l2- l1 + 1)))
     { 
       /* is = 0..right */
       ssExists = 0;
@@ -151,7 +154,7 @@ long GetTES(
       cluster_edge = ClusterEdge(l1 + is,Strand,external,l1,l2);
       score = score - pes; /* (pes>0?pes:-pes); */
 		  
-      if ((ns<NUMSITES)&&((cluster_edge == -1)||(prev_score>thresh && prev_score>prev_prev_score && prev_score>score))){
+      if (((cluster_edge == -1)||(prev_score>thresh && prev_score>prev_prev_score && prev_score>score))){
 	j=js;
 	while ((j < nDonors) && ((Donors+j)->Position < (l1 + is -1 - window)))
 	  j++;
@@ -167,6 +170,7 @@ long GetTES(
 	if (ssExists == 0){
 /* 	  sprintf(mess,"TES pos: %ld   PES TES: pos %ld:%f",l1 + is,LengthSequence - (l1 + is),score); */
 /* 	  	printMess(mess); */
+	  GrowSiteArray(&sc,&cap,ns+1);
 	  sc[ns].Position=(l1 + is -1);  
 	  sc[ns].Score=prev_score;
 	  sc[ns].class=U2;
@@ -178,9 +182,8 @@ long GetTES(
       is++;
     }
 
-  if (ns >= NUMSITES)
-    printError("Too many predicted sites: decrease RSITES parameter");
-  
+  *scP = sc;
+  *capP = cap;
   return(ns);
 
 

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -67,35 +67,45 @@ packSites* RequestMemorySites()
        (struct s_packSites *) malloc(sizeof(struct s_packSites))) == NULL)
     printError("Not enough memory: pack of sites");  
   
+  /* Site arrays start small and grow on demand (see GrowSiteArray / the site
+     builders); capacity is tracked per array in cap* fields. */
   /* Start codons */
-  if ((allSites->StartCodons = 
-       (struct s_site *) calloc(NUMSITES, sizeof(struct s_site))) == NULL)
+  allSites->capStartCodons = INITSITES;
+  if ((allSites->StartCodons =
+       (struct s_site *) calloc(allSites->capStartCodons, sizeof(struct s_site))) == NULL)
     printError("Not enough memory: start codons");
-  
+
   /* Acceptor sites */
-  if ((allSites->AcceptorSites = 
-       (struct s_site *) calloc(NUMSITES, sizeof(struct s_site))) == NULL)
+  allSites->capAcceptorSites = INITSITES;
+  if ((allSites->AcceptorSites =
+       (struct s_site *) calloc(allSites->capAcceptorSites, sizeof(struct s_site))) == NULL)
     printError("Not enough memory: acceptor sites");
-	      	      
+
   /* Donor sites */
-  if ((allSites->DonorSites = 
-       (struct s_site *) calloc(NUMSITES, sizeof(struct s_site))) == NULL)
+  allSites->capDonorSites = INITSITES;
+  if ((allSites->DonorSites =
+       (struct s_site *) calloc(allSites->capDonorSites, sizeof(struct s_site))) == NULL)
     printError("Not enough memory: donor sites");
 
   /* Stop codons */
-  if ((allSites->StopCodons = 
-       (struct s_site *) calloc(NUMSITES, sizeof(struct s_site))) == NULL)
+  allSites->capStopCodons = INITSITES;
+  if ((allSites->StopCodons =
+       (struct s_site *) calloc(allSites->capStopCodons, sizeof(struct s_site))) == NULL)
     printError("Not enough memory: stop codons");
 
+  allSites->capTS = 0;
+  allSites->capTE = 0;
   if (UTR){
     /* TSS */
-    if ((allSites->TS = 
-	 (struct s_site *) calloc(NUMSITES, sizeof(struct s_site))) == NULL)
+    allSites->capTS = INITSITES;
+    if ((allSites->TS =
+	 (struct s_site *) calloc(allSites->capTS, sizeof(struct s_site))) == NULL)
       printError("Not enough memory: TSS");
-    
+
     /* TES */
-    if ((allSites->TE = 
-	 (struct s_site *) calloc(NUMSITES, sizeof(struct s_site))) == NULL)
+    allSites->capTE = INITSITES;
+    if ((allSites->TE =
+	 (struct s_site *) calloc(allSites->capTE, sizeof(struct s_site))) == NULL)
       printError("Not enough memory: TES");
   }
   return(allSites);

--- a/src/manager.c
+++ b/src/manager.c
@@ -133,7 +133,7 @@ void  manager(char *Sequence,
   printMess ("Computing sites ...");
 
   allSites->nStartCodons =
-    GetSitesWithProfile(Sequence,gp->StartProfile,allSites->StartCodons,l1a,l2a);
+    GetSitesWithProfile(Sequence,gp->StartProfile,&allSites->StartCodons,&allSites->capStartCodons,l1a,l2a);
   sprintf(mess, "Start Codons \t\t%8ld", allSites->nStartCodons);
   printRes(mess);
   
@@ -147,8 +147,8 @@ void  manager(char *Sequence,
 		   gp->AcceptorProfile,
 		   gp->PolyPTractProfile,
 		   gp->BranchPointProfile,
-		   allSites->AcceptorSites,
-		   l1a,l2a,numAccsites,NUMSITES,Strand,external);
+		   &allSites->AcceptorSites,
+		   l1a,l2a,numAccsites,&allSites->capAcceptorSites,Strand,external);
   
   sprintf(mess, "Acceptor Sites \t\t%8ld", allSites->nAcceptorSites - numAccsites);
   numAccsites = allSites->nAcceptorSites;
@@ -161,8 +161,8 @@ void  manager(char *Sequence,
 					   gp->U12gtagAcceptorProfile,
 					   gp->U12BranchPointProfile,
 					   gp->PolyPTractProfile,
-					   allSites->AcceptorSites,
-					   l1a,l2a,numAccsites,NUMSITES,Strand,external);
+					   &allSites->AcceptorSites,
+					   l1a,l2a,numAccsites,&allSites->capAcceptorSites,Strand,external);
 
 	  sprintf(mess, "U12gtag Acceptor Sites \t%8ld", allSites->nAcceptorSites - numAccsites);
 	  numAccsites = allSites->nAcceptorSites;
@@ -175,8 +175,8 @@ void  manager(char *Sequence,
 					   gp->U12atacAcceptorProfile,
 					   gp->U12BranchPointProfile,
 					   gp->PolyPTractProfile,
-					   allSites->AcceptorSites,
-					   l1a,l2a,numAccsites,NUMSITES,Strand,external);
+					   &allSites->AcceptorSites,
+					   l1a,l2a,numAccsites,&allSites->capAcceptorSites,Strand,external);
 
 	  sprintf(mess, "U12atac Acceptor Sites \t%8ld", allSites->nAcceptorSites - numAccsites);
 	  numAccsites = allSites->nAcceptorSites;
@@ -186,57 +186,57 @@ void  manager(char *Sequence,
   long numDonsites = 0;
 
   allSites->nDonorSites =
-    /* BuildDonors(Sequence,U2,sU2type,sU2, gp->DonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES); */
-    BuildDonors(Sequence,U2,sU2type,sU2, gp->DonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+    /* BuildDonors(Sequence,U2,sU2type,sU2, gp->DonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites); */
+    BuildDonors(Sequence,U2,sU2type,sU2, gp->DonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
   sprintf (mess,"Donor Sites \t\t%8ld", allSites->nDonorSites);
   numDonsites = allSites->nDonorSites;
   printRes(mess);
 
   if (U12GTAG){
 	  allSites->nDonorSites =
-	    BuildDonors(Sequence,U12gtag,sU12type,sU12gtag, gp->U12gtagDonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+	    BuildDonors(Sequence,U12gtag,sU12type,sU12gtag, gp->U12gtagDonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
 	  sprintf (mess,"U12gtag Donor Sites \t%8ld", allSites->nDonorSites - numDonsites);
 	  numDonsites = allSites->nDonorSites;
 	  printRes(mess);
   }
   if (U12ATAC){
 	  allSites->nDonorSites =
-	    BuildDonors(Sequence, U12atac,sU12type,sU12atac, gp->U12atacDonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+	    BuildDonors(Sequence, U12atac,sU12type,sU12atac, gp->U12atacDonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
 	  sprintf (mess,"U12atac Donor Sites \t%8ld", allSites->nDonorSites - numDonsites);
 	  numDonsites = allSites->nDonorSites;
 	  printRes(mess);
   }
   if (U2GCAG){
 	  allSites->nDonorSites =
-	    BuildDonors(Sequence,U2, sU2type,sU2gcag, gp->U2gcagDonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+	    BuildDonors(Sequence,U2, sU2type,sU2gcag, gp->U2gcagDonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
 	  sprintf (mess,"U2gcag Donor Sites \t%8ld", allSites->nDonorSites - numDonsites);
 	  numDonsites = allSites->nDonorSites;
 	  printRes(mess);
   }  
   if (U2GTA){
 	  allSites->nDonorSites =
-    	BuildDonors(Sequence,U2,sU2type,sU2gta, gp->U2gtaDonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+    	BuildDonors(Sequence,U2,sU2type,sU2gta, gp->U2gtaDonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
 	  sprintf (mess,"U2gta Donor Sites \t%8ld", allSites->nDonorSites - numDonsites);
 	  numDonsites = allSites->nDonorSites;
 	  printRes(mess);
   }  
   if (U2GTG){
 	  allSites->nDonorSites =
-    	BuildDonors(Sequence,U2,sU2type,sU2gtg, gp->U2gtgDonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+    	BuildDonors(Sequence,U2,sU2type,sU2gtg, gp->U2gtgDonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
 	  sprintf (mess,"U2gtg Donor Sites \t%8ld", allSites->nDonorSites - numDonsites);
 	  numDonsites = allSites->nDonorSites;
 	  printRes(mess);
   }  
   if (U2GTY){
 	  allSites->nDonorSites =
-    	BuildDonors(Sequence,U2,sU2type,sU2gty, gp->U2gtyDonorProfile,allSites->DonorSites,l1b,l2b,numDonsites,NUMSITES,Strand,external);
+    	BuildDonors(Sequence,U2,sU2type,sU2gty, gp->U2gtyDonorProfile,&allSites->DonorSites,l1b,l2b,numDonsites,&allSites->capDonorSites,Strand,external);
 	  sprintf (mess,"U2gty Donor Sites \t%8ld", allSites->nDonorSites - numDonsites);
 	  numDonsites = allSites->nDonorSites;
 	  printRes(mess);
   }  
 
   allSites->nStopCodons =
-	GetStopCodons(Sequence,gp->StopProfile, allSites->StopCodons,l1c,l2c);
+	GetStopCodons(Sequence,gp->StopProfile, &allSites->StopCodons,&allSites->capStopCodons,l1c,l2c);
   sprintf (mess,"Stop Codons \t\t%8ld", allSites->nStopCodons);
   printRes(mess);
   
@@ -250,18 +250,18 @@ void  manager(char *Sequence,
   allSites->nTE=0;
   if (UTR){
     allSites->nTS =
-      GetTSS(allSites->TS,allSites->AcceptorSites, allSites->nAcceptorSites, external,hsp,Strand,LengthSequence,l1,l2);
+      GetTSS(&allSites->TS,&allSites->capTS,allSites->AcceptorSites, allSites->nAcceptorSites, external,hsp,Strand,LengthSequence,l1,l2);
     sprintf(mess, "TS \t\t\t%8ld", allSites->nTS);
     printRes(mess);
     long numTE = 0;
     if(PAS){allSites->nTE =
-	GetSitesWithProfile(Sequence,gp->PolyASignalProfile,allSites->TE,l1,l2);
+	GetSitesWithProfile(Sequence,gp->PolyASignalProfile,&allSites->TE,&allSites->capTE,l1,l2);
       sprintf(mess, "PolyA Signals \t\t%8ld", allSites->nTE);
       numTE = allSites->nTE;
       printRes(mess);
     }
     allSites->nTE =
-      GetTES(allSites->TE,allSites->DonorSites, allSites->nDonorSites,external,hsp,Strand,LengthSequence,l1,l2,numTE);
+      GetTES(&allSites->TE,&allSites->capTE,allSites->DonorSites, allSites->nDonorSites,external,hsp,Strand,LengthSequence,l1,l2,numTE);
     sprintf(mess, "TE \t\t\t%8ld", allSites->nTE);
     printRes(mess);
   }


### PR DESCRIPTION
## Phase 2, Target #1c — predicted-site arrays (the last fixed table)

The six site builders filled the `packSites` arrays (`StartCodons`, `AcceptorSites`, `DonorSites`, `StopCodons`, `TS`, `TE`), each `calloc`'d at `NUMSITES`, and aborted with `printError("decrease RSITES")` on overflow — so `NUMSITES` was both a per-fragment reservation and a hard correctness ceiling.

### Changes
- `GetSitesWithProfile` (start codons + PolyA), `GetStopCodons`, `BuildAcceptors`, `BuildU12Acceptors`, `BuildDonors`, `GetTSS`/`GetTES` now take the array **+ capacity by reference** and grow before each write via the shared `GrowSiteArray()` helper. Capacity persists across fragments in new `packSites` `cap*` fields; each array starts at `INITSITES`.
- The acceptor/donor arrays are filled by **several appending calls** (U2, then the U12/U2* flavours) sharing a running count — growth propagates through `allSites` so later calls see the grown array.
- **Subtlety handled:** `BuildAcceptors`/`BuildU12Acceptors` stash `PositionBP`/`PositionPPT` into `&st[ns]` via `ComputeU2*Profile` *before* committing the site, so the grow is placed at the top of the `score>=cutoff` block — ahead of that borrow, not right before the field writes.

### Realloc safety
Mirrors the earlier tables: the site arrays are filled during the site-build phase; the exon records that point into them are only created **later** (exon-build phase), after every site array has reached its final size.

### Verification
- Regression **5/5 byte-identical** (also with `INITSITES` forced to **4** — many reallocs, incl. the appending acceptor/donor accumulation and cross-split reuse).
- The **full SUPER_1 chromosome** (20 909 genes) byte-identical before/after.
- **ASan-clean** on snake, morc_u12 (U12 acceptors/donors) and rnaseq (UTR TS/TE).

With this, the exon-sort table (#14), per-type exon arrays (#15/#16), site-sort buffers (#17) and now the site arrays all grow on demand — the `NUMSITES`/`NUMEXONS`/`FSORT` reservations and every "increase FSORT / decrease Rxxx" abort on the core prediction path are gone. Remaining Target #1 pieces: the dumpster (`MAXBACKUP*`) and genamic's `d`-arrays (`FDARRAY*NUMEXONS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)