### PR TITLE
BuildSort: make the sort-by-donor (d) arrays growable (drop FDARRAY*NUMEXONS)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -183,6 +183,11 @@ A. DEFINITIONS
 /* reservation and the "decrease RSITES" hard errors are gone.                */
 #define INITSITES 4096
 
+/* Initial capacity of each growable sort-by-donor array (packGenes->d[class], */
+/* filled by BuildSort). Grows on demand, replacing the FDARRAY*NUMEXONS       */
+/* reservation (and an unchecked overflow).                                   */
+#define INITDARRAY 256
+
 /* Maximum number of isochores              */
 #define MAXISOCHORES 4           
 
@@ -613,6 +618,7 @@ typedef struct s_packGenes
   exonGFF* Ghost;
   exonGFF* GOptim;
   exonGFF* **d;
+  long* dcap;   /* allocated capacity of each d[class] (grown by BuildSort) */
   long* km;
   long* je;
 } packGenes;
@@ -1053,8 +1059,8 @@ void SwitchFramesDb(packGenes* pg, int nclass);
 
 void UndoFrames(exonGFF *e, long n);
 
-void BuildSort(dict *D, int nc[], int ne[], int UC[][MAXENTRY], 
-               int DE[][MAXENTRY], int nclass, long km[], 
+void BuildSort(dict *D, int nc[], int ne[], int UC[][MAXENTRY],
+               int DE[][MAXENTRY], int nclass, long km[], long dcap[],
 	       exonGFF* **d, exonGFF *E, long nexons);
 
 void PrintSite(site *s, int type, char Name[], int Strand,

--- a/src/BuildSort.c
+++ b/src/BuildSort.c
@@ -37,6 +37,7 @@ void BuildSort(dict *D,
                int DE[][MAXENTRY],
                int nclass,
                long km[],
+               long dcap[],
                exonGFF* **d,
                exonGFF *E,
                long nexons)
@@ -65,8 +66,24 @@ void BuildSort(dict *D,
 	  for(j=0; j < nc[type]; j++)
 	    {
 	      class = UC[type][j];
+
+	      /* Grow this class's array on demand: the insertion below adds one
+		 entry (writes up to index km[class]), so ensure room for it.
+		 d[class] is pg->d[class], so the realloc propagates to the pack. */
+	      if (km[class] + 1 > dcap[class])
+		{
+		  long ncap = dcap[class] ? dcap[class] : 1;
+		  exonGFF** tmp;
+		  while (ncap < km[class] + 1)
+		    ncap *= 2;
+		  if ((tmp = (exonGFF**) realloc(d[class], ncap * sizeof(exonGFF*))) == NULL)
+		    printError("Not enough memory: growing sort-by-donor array");
+		  d[class] = tmp;
+		  dcap[class] = ncap;
+		}
+
 	      k = km[class]-1;
-			  
+
 	      /* Screening the exons sorted before: sorting by insertion */
 	      while (k>=0 && (((E+i)->Donor->Position + (E+i)->offset2) 
 			      < 

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -729,12 +729,18 @@ packGenes* RequestMemoryGenes()
   /* Memory for the array of sorting by donor functions (one per class) */
   if ((pg->d = (exonGFF* **)calloc(MAXENTRY, sizeof(exonGFF* *))) == NULL)
     printError("Not enough memory: set of d-arrays (sort by donor)");
-  
-  /* Memory for every sorting function (alone) */
-  for(aux=0; aux < MAXENTRY; aux++) 
-    if ((pg->d[aux] = (exonGFF* *)calloc(FDARRAY * NUMEXONS, sizeof(exonGFF*))) == NULL)
+
+  /* Per-class capacity of the d-arrays (grown on demand by BuildSort) */
+  if ((pg->dcap = (long *)calloc(MAXENTRY, sizeof(long))) == NULL)
+    printError("Not enough memory: d-array capacities");
+
+  /* Memory for every sorting function (alone): starts small, grows on demand */
+  for(aux=0; aux < MAXENTRY; aux++) {
+    pg->dcap[aux] = INITDARRAY;
+    if ((pg->d[aux] = (exonGFF* *)calloc(pg->dcap[aux], sizeof(exonGFF*))) == NULL)
       printError("Not enough memory: sort-by-donor functions");
-  
+  }
+
   if ((pg->km = (long *)calloc(MAXENTRY, sizeof(long))) == NULL)
     printError("Not enough memory: total counters of sort-by-donor functions");
 

--- a/src/genamic.c
+++ b/src/genamic.c
@@ -75,9 +75,9 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
   printMess("Sorting exons by donor...");
   
   /* Build a set of sorting exons by donor functions */
-  BuildSort(gp->D, gp->nc, gp->ne, 
-	    gp->UC, gp->DE, gp->nclass, 
-	    pg->km, pg->d, E, nExons);
+  BuildSort(gp->D, gp->nc, gp->ne,
+	    gp->UC, gp->DE, gp->nclass,
+	    pg->km, pg->dcap, pg->d, E, nExons);
   
   /* 2. Genamic Algorithm in linear time (size of input) */
   printMess("Assembling Genes...");


### PR DESCRIPTION
## Phase 2, Target #1c — sort-by-donor (d) arrays

genamic's per-class "sort by donor" arrays (`packGenes->d[class]`) were each `calloc`'d at `FDARRAY*NUMEXONS` and filled by `BuildSort`'s insertion sort with **no bounds check at all** — a latent silent overflow, plus a large up-front reservation (`MAXENTRY` classes × `FDARRAY` × `NUMEXONS` pointers).

### Changes
- Each `d[class]` starts at `INITDARRAY` and **grows on demand** in `BuildSort` before the insertion (realloc-double). Capacity persists per class in a new `packGenes->dcap[]` array.
- `d[class]` is `pg->d[class]`, so the realloc propagates to the pack automatically. The arrays hold `exonGFF*` pointers and **nothing takes the address of a d-array slot**, so growth can't invalidate any reference.
- `FDARRAY` is now unused.

### Verification
- Regression **5/5 byte-identical** (also with `INITDARRAY` forced to **1** — reallocs on nearly every insertion in the DP).
- The **full SUPER_1 chromosome** (20 909 genes) byte-identical before/after.
- **ASan-clean** on the snake and the 153-exon long-protein fixtures.

### On the dumpster (the other half of the request)
I investigated the dumpster (`MAXBACKUP*`) and deliberately did **not** convert it here — it's a fundamentally different structure and the realloc pattern is unsafe for it:
- It's a **ring buffer** (`ndumpExons = IncrMod(..., MAXBACKUPEXONS)`) — it recycles rather than aborting, so it's not a hard ceiling.
- Its entries are **pointer-dense**: `backupGene` builds `PreviousExon` chains that point *within* `dumpExons`, a hash indexes into it, `dumpExons`→`dumpSites` pointers, and the live cross-split gene solution (`Ga`/`d`) holds pointers into it. A `realloc` would move the block and invalidate all of those.

Converting it safely needs a **stable-address (chunked) container** so existing entries never move — a distinct, larger effort. I'd suggest treating that as its own task (or leaving the dumpster as-is, since it's a soft, generously-sized ring buffer). With this PR, every fixed reservation on the *core prediction path* now grows on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)