### PR TITLE
BackupGenes: chunked stable-address dumpster (drop the MAXBACKUP* ring buffer)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -188,6 +188,11 @@ A. DEFINITIONS
 /* reservation (and an unchecked overflow).                                   */
 #define INITDARRAY 256
 
+/* Chunk size (entries) of the growable dumpster backup arrays (BackupGenes.c).*/
+/* Chunks are stable-address: allocated once, never moved, so backed-up        */
+/* exons/sites keep their pointers valid while the dumpster grows on demand.   */
+#define DUMPCHUNK 4096
+
 /* Maximum number of isochores              */
 #define MAXISOCHORES 4           
 
@@ -690,14 +695,21 @@ typedef struct s_dumpHash
 } dumpHash;
 
 typedef struct s_packDump
-{ 
-  site* dumpSites;                     
+{
+  /* Chunked, stable-address backup arrays (see BackupGenes.c). dumpSites and
+     dumpExons are arrays of fixed-size chunks; a chunk is never moved once
+     allocated, so a backed-up site/exon keeps its address for the whole run
+     while the arrays grow on demand -- replacing the old fixed ring buffer
+     that recycled (and could overwrite still-referenced backups). */
+  site** dumpSites;
   long ndumpSites;
-  
-  exonGFF* dumpExons;                  
-  long ndumpExons;
+  long dumpSitesChunks;
 
-  dumpHash* h; 
+  exonGFF** dumpExons;
+  long ndumpExons;
+  long dumpExonsChunks;
+
+  dumpHash* h;
 } packDump;
 
 typedef struct s_account               

--- a/src/BackupGenes.c
+++ b/src/BackupGenes.c
@@ -34,69 +34,116 @@ extern long MAXBACKUPSITES, MAXBACKUPEXONS;
 /* The number of compatible splice classes */
 extern short SPLICECLASSES;
 
-/* Increase counters modulus a long number */
-long IncrMod(long x, long Modulus)
+/* Return a stable-address pointer to exon backup slot i, allocating its chunk
+   on first touch. Chunks are never moved (only the array of chunk pointers may
+   realloc), so a pointer handed out here stays valid for the whole run. */
+static exonGFF* dumpExonAt(packDump* d, long i)
 {
-  long z;
-  
-  z = x+1;
-  if (z == Modulus)
-    z = 0;
-  
-  return(z);
+  long c = i / DUMPCHUNK;
+
+  if (c >= d->dumpExonsChunks)
+    {
+      long ncap = d->dumpExonsChunks ? d->dumpExonsChunks : 1;
+      exonGFF** tmp;
+      long k;
+      while (ncap <= c)
+	ncap *= 2;
+      if ((tmp = (exonGFF**) realloc(d->dumpExons, ncap * sizeof(exonGFF*))) == NULL)
+	printError("Not enough memory: backup exon chunk table");
+      for (k = d->dumpExonsChunks; k < ncap; k++)
+	tmp[k] = NULL;
+      d->dumpExons = tmp;
+      d->dumpExonsChunks = ncap;
+    }
+  if (d->dumpExons[c] == NULL)
+    if ((d->dumpExons[c] = (exonGFF*) calloc(DUMPCHUNK, sizeof(exonGFF))) == NULL)
+      printError("Not enough memory: backup exon chunk");
+
+  return &(d->dumpExons[c][i % DUMPCHUNK]);
+}
+
+/* As dumpExonAt, for the site backup array. */
+static site* dumpSiteAt(packDump* d, long i)
+{
+  long c = i / DUMPCHUNK;
+
+  if (c >= d->dumpSitesChunks)
+    {
+      long ncap = d->dumpSitesChunks ? d->dumpSitesChunks : 1;
+      site** tmp;
+      long k;
+      while (ncap <= c)
+	ncap *= 2;
+      if ((tmp = (site**) realloc(d->dumpSites, ncap * sizeof(site*))) == NULL)
+	printError("Not enough memory: backup site chunk table");
+      for (k = d->dumpSitesChunks; k < ncap; k++)
+	tmp[k] = NULL;
+      d->dumpSites = tmp;
+      d->dumpSitesChunks = ncap;
+    }
+  if (d->dumpSites[c] == NULL)
+    if ((d->dumpSites[c] = (site*) calloc(DUMPCHUNK, sizeof(site))) == NULL)
+      printError("Not enough memory: backup site chunk");
+
+  return &(d->dumpSites[c][i % DUMPCHUNK]);
 }
 
 /* Saving exon information (features) into the dumpster */
 exonGFF* backupExon(exonGFF* E, exonGFF* Prev, packDump* d)
 {
+  exonGFF* de = dumpExonAt(d, d->ndumpExons);
+  site* ds;
+
   /* back-up acceptor */
-  d->dumpSites[d->ndumpSites].Position = E->Acceptor->Position;
-  d->dumpSites[d->ndumpSites].Score = E->Acceptor->Score;
-  d->dumpSites[d->ndumpSites].ScoreAccProfile = E->Acceptor->ScoreAccProfile;
-  d->dumpSites[d->ndumpSites].ScorePPT = E->Acceptor->ScorePPT;
-  d->dumpSites[d->ndumpSites].ScoreBP = E->Acceptor->ScoreBP;
-  d->dumpSites[d->ndumpSites].PositionBP = E->Acceptor->PositionBP;
-  d->dumpSites[d->ndumpSites].PositionPPT = E->Acceptor->PositionPPT;
-  d->dumpSites[d->ndumpSites].class = E->Acceptor->class;
-  strcpy(d->dumpSites[d->ndumpSites].subtype,E->Acceptor->subtype);
-  strcpy(d->dumpSites[d->ndumpSites].type,E->Acceptor->type);
-  d->dumpExons[d->ndumpExons].Acceptor = &(d->dumpSites[d->ndumpSites]); 
-  d->ndumpSites = IncrMod(d->ndumpSites, MAXBACKUPSITES);
-  
+  ds = dumpSiteAt(d, d->ndumpSites);
+  ds->Position = E->Acceptor->Position;
+  ds->Score = E->Acceptor->Score;
+  ds->ScoreAccProfile = E->Acceptor->ScoreAccProfile;
+  ds->ScorePPT = E->Acceptor->ScorePPT;
+  ds->ScoreBP = E->Acceptor->ScoreBP;
+  ds->PositionBP = E->Acceptor->PositionBP;
+  ds->PositionPPT = E->Acceptor->PositionPPT;
+  ds->class = E->Acceptor->class;
+  strcpy(ds->subtype,E->Acceptor->subtype);
+  strcpy(ds->type,E->Acceptor->type);
+  de->Acceptor = ds;
+  d->ndumpSites = d->ndumpSites + 1;
+
   /* back-up donor */
-  d->dumpSites[d->ndumpSites].Position = E->Donor->Position;
-  d->dumpSites[d->ndumpSites].Score = E->Donor->Score;
-  d->dumpSites[d->ndumpSites].ScoreAccProfile = E->Donor->ScoreAccProfile;
-  d->dumpSites[d->ndumpSites].ScorePPT = E->Donor->ScorePPT;
-  d->dumpSites[d->ndumpSites].ScoreBP = E->Donor->ScoreBP;
-  d->dumpSites[d->ndumpSites].PositionBP = E->Donor->PositionBP;
-  d->dumpSites[d->ndumpSites].PositionPPT = E->Donor->PositionPPT;
-  d->dumpSites[d->ndumpSites].class = E->Donor->class;
-  strcpy(d->dumpSites[d->ndumpSites].subtype,E->Donor->subtype);
-  strcpy(d->dumpSites[d->ndumpSites].type,E->Donor->type);
-  d->dumpExons[d->ndumpExons].Donor = &(d->dumpSites[d->ndumpSites]); 
-  d->ndumpSites = IncrMod(d->ndumpSites, MAXBACKUPSITES);
-  
+  ds = dumpSiteAt(d, d->ndumpSites);
+  ds->Position = E->Donor->Position;
+  ds->Score = E->Donor->Score;
+  ds->ScoreAccProfile = E->Donor->ScoreAccProfile;
+  ds->ScorePPT = E->Donor->ScorePPT;
+  ds->ScoreBP = E->Donor->ScoreBP;
+  ds->PositionBP = E->Donor->PositionBP;
+  ds->PositionPPT = E->Donor->PositionPPT;
+  ds->class = E->Donor->class;
+  strcpy(ds->subtype,E->Donor->subtype);
+  strcpy(ds->type,E->Donor->type);
+  de->Donor = ds;
+  d->ndumpSites = d->ndumpSites + 1;
+
   /* back-up exon properties */
-  strcpy(d->dumpExons[d->ndumpExons].Type, E->Type);
-  d->dumpExons[d->ndumpExons].Frame  = E->Frame;
-  d->dumpExons[d->ndumpExons].Strand = E->Strand; 
-  d->dumpExons[d->ndumpExons].Score  = E->Score;
-  d->dumpExons[d->ndumpExons].PartialScore = E->PartialScore;
-  d->dumpExons[d->ndumpExons].HSPScore = E->HSPScore;
-  d->dumpExons[d->ndumpExons].R = E->R;
-  d->dumpExons[d->ndumpExons].GeneScore  = E->GeneScore;
-  d->dumpExons[d->ndumpExons].Remainder = E->Remainder; 
-  strcpy(d->dumpExons[d->ndumpExons].Group,E->Group);
-  d->dumpExons[d->ndumpExons].offset1 = E->offset1;
-  d->dumpExons[d->ndumpExons].offset2 = E->offset2;
-  d->dumpExons[d->ndumpExons].lValue = E->lValue;
-  d->dumpExons[d->ndumpExons].rValue = E->rValue;
-  d->dumpExons[d->ndumpExons].evidence = E->evidence;
-  d->dumpExons[d->ndumpExons].PreviousExon = Prev;
-  
+  strcpy(de->Type, E->Type);
+  de->Frame  = E->Frame;
+  de->Strand = E->Strand;
+  de->Score  = E->Score;
+  de->PartialScore = E->PartialScore;
+  de->HSPScore = E->HSPScore;
+  de->R = E->R;
+  de->GeneScore  = E->GeneScore;
+  de->Remainder = E->Remainder;
+  strcpy(de->Group,E->Group);
+  de->offset1 = E->offset1;
+  de->offset2 = E->offset2;
+  de->lValue = E->lValue;
+  de->rValue = E->rValue;
+  de->evidence = E->evidence;
+  de->PreviousExon = Prev;
+
   /* Returns the new exon recently created */
-  return(&(d->dumpExons[d->ndumpExons]));
+  return(de);
 }
 
 /* Saving all about a gene: exons, sites, properties */
@@ -120,7 +167,7 @@ exonGFF* backupGene(exonGFF* E, packDump* d)
 		  ResExon = backupExon(E,PrevExon,d);
 
 
-		  d->ndumpExons = IncrMod(d->ndumpExons, MAXBACKUPEXONS);
+		  d->ndumpExons = d->ndumpExons + 1;
 		  /* adding this exon at hash table */
 		  setExonDumpHash(ResExon, d->h);       
 		}

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -762,15 +762,13 @@ packDump* RequestMemoryDumpster()
        (struct s_packDump *) malloc(sizeof(struct s_packDump))) == NULL)
     printError("Not enough memory: dumpster");  
 
-  /* 1. Temporary dumpster Sites */
-  if ((d->dumpSites = 
-       (struct s_site *) calloc(MAXBACKUPSITES, sizeof(struct s_site))) == NULL)
-    printError("Not enough memory: backup sites");
-
-  /* 2. Temporary dumpster exons */
-  if ((d->dumpExons = 
-       (exonGFF*) calloc(MAXBACKUPEXONS, sizeof(struct s_exonGFF))) == NULL)
-    printError("Not enough memory: backup exons");  
+  /* 1. + 2. Temporary dumpster sites/exons are now chunked and grown on
+     demand by BackupGenes.c (no fixed MAXBACKUP* reservation, no ring-buffer
+     recycling); start empty. */
+  d->dumpSites = NULL;
+  d->dumpSitesChunks = 0;
+  d->dumpExons = NULL;
+  d->dumpExonsChunks = 0;
 
   /* 3. Dumpster hash to find backup exons quickly */
   if ((d->h = 


### PR DESCRIPTION
## Phase 2, Target #1c — chunked stable-address dumpster (the last fixed table)

The dumpster (cross-split gene-solution backup) was a fixed **ring buffer**: `dumpExons`/`dumpSites` were `calloc`'d at `MAXBACKUP{EXONS,SITES}` and recycled via `IncrMod`. That was both a large up-front reservation **and** a soft correctness ceiling — a backed-up chain longer than the ring would wrap and overwrite still-referenced entries (`dumpExons` hold `PreviousExon` chains *into* `dumpExons`, `Acceptor`/`Donor` into `dumpSites`, and the hash + live `Ga`/`d` solution point in too), silently corrupting the result.

### Approach
As flagged in [#19](https://github.com/guigolab/geneid/pull/19), a plain `realloc` is unsafe here (it would move the block and invalidate all those pointers). So this uses **chunked, stable-address containers**:
- Each of `dumpExons`/`dumpSites` becomes an array of fixed-size (`DUMPCHUNK`) chunks, allocated on first touch and **never moved** — only the (pointer) chunk table may `realloc`.
- New `dumpExonAt()`/`dumpSiteAt()` accessors return a stable pointer to slot `i`, growing chunks as needed, so every backup pointer stays valid for the whole run.
- `IncrMod` → a plain increment: the index is now unbounded (append-only), removing the wrap ceiling. Between loci `cleanGenes` still resets it to 0 and the chunks are reused.

### What's deliberately untouched
The dump **hash** (still sized/indexed by `MAXBACKUPEXONS` via `MAXDUMPHASH`, stores stable exon pointers) — so bucket assignment and chain order, hence output, are identical. `MAXBACKUP*` remain only as the "backup active" (multi-split) flag and the hash size.

### Verification
- Regression **5/5 byte-identical**, incl. the multi-split snake that actually exercises the dumpster (also with `DUMPCHUNK` forced to **2** → a chunk every couple of entries + many chunk-table reallocs).
- The **full SUPER_1 chromosome** (20 909 genes, ~727 splits) byte-identical before/after — and peak RSS dropped **4.18 → 3.54 GB** (the chunked dumpster only allocates what's used).
- **ASan-clean** on the snake.

With this, **every fixed-size table in geneid grows on demand** — the exon-sort table (#14), per-type exon arrays (#15/#16), site-sort buffers (#17), site arrays (#18), the sort-by-donor arrays (#19), and now the dumpster. The `MEM` build profiles are no longer a correctness constraint anywhere on the prediction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)