### PR TITLE
Retire the MEM build profiles now that every array grows on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,52 +14,11 @@ PROGRAM= geneid
 PRODUCT= $(BIN)/$(PROGRAM)
 CC=gcc
 
-#######
-# Memory profile: pick the array-sizing constants for the target machine.
-#   make             -> MEM=auto: detect THIS machine's RAM and pick a profile
-#   make MEM=low      ~5 GB reserved  (small machines; tight on dense genomes)
-#   make MEM=medium   ~13 GB reserved (16-24 GB machines)
-#   make MEM=high     ~45 GB reserved (big servers; lazy alloc, RSS stays ~4 GB)
-# Profiles override the #ifndef'd defaults in include/geneid.h via -D.
-#
-# *** auto detects the BUILD machine's RAM. *** If you build and run on
-# different machines (e.g. a cluster login node vs a fat compute node),
-# auto can guess wrong -- pass an explicit MEM=low|medium|high matching the
-# RUN machine. The resolved profile is printed on every build, and
-# `make print-mem` shows the detected RAM. Always `make clean` when
-# switching profiles (the constants are compile-time).
-#######
-MEM ?= auto
+# geneid's data structures grow on demand, so there are no longer any
+# build-time memory-sizing profiles to choose: just `make`.
 
-# auto -> resolve to low/medium/high from physical RAM (macOS sysctl / Linux /proc)
-ifeq ($(MEM),auto)
-  MEM_BYTES := $(shell sysctl -n hw.memsize 2>/dev/null || awk '/MemTotal/{print $$2*1024}' /proc/meminfo 2>/dev/null || echo 0)
-  MEM_RESOLVED := $(shell b="$(MEM_BYTES)"; \
-    if   [ "$$b" -ge 51539607552 ]; then echo high;   \
-    elif [ "$$b" -ge 17179869184 ]; then echo medium; \
-    elif [ "$$b" -gt 0 ];          then echo low;     \
-    else echo medium; fi)
-else
-  MEM_BYTES := 0
-  MEM_RESOLVED := $(MEM)
-endif
-
-ifeq ($(MEM_RESOLVED),low)
-  MEMFLAGS = -DLENGTHSi=220000 -DREXONS=2 -DFSORT=12 -DFDARRAY=5 -DRBSITES=150 -DRBEXONS=250
-else ifeq ($(MEM_RESOLVED),medium)
-  MEMFLAGS =
-else ifeq ($(MEM_RESOLVED),high)
-  MEMFLAGS = -DLENGTHSi=500000 -DREXONS=0.25 -DFSORT=20 -DFDARRAY=10 -DRBSITES=75 -DRBEXONS=125
-else
-  $(error Unknown MEM='$(MEM)' (resolved '$(MEM_RESOLVED)'). Use one of: auto, low, medium, high)
-endif
-
-$(info geneid memory profile: MEM=$(MEM) -> '$(MEM_RESOLVED)')
-
-OPTS=-I$(INCLUDE) -Wall -O3 $(MEMFLAGS)
-#OPTS=-I$(INCLUDE) -Wall -g $(MEMFLAGS)
-
-# Keep the program the default goal (print-mem is defined after it below)
+OPTS=-I$(INCLUDE) -Wall -O3
+#OPTS=-I$(INCLUDE) -Wall -g
 .DEFAULT_GOAL := $(PRODUCT)
 #######
 
@@ -236,9 +195,5 @@ clean:
 	rm -f $(OBJ)/*.o $(PRODUCT) *~ $(INCLUDE)/*~ $(CDIR)/*~ core;
 	rmdir $(BIN) $(OBJ);
 
-# Show the active memory profile, detected RAM, and the -D flags it injects
-print-mem:
-	@echo "MEM=$(MEM)  resolved=$(MEM_RESOLVED)  detected_RAM_bytes=$(MEM_BYTES)"
-	@echo "MEMFLAGS=$(MEMFLAGS)"
-.PHONY: print-mem clean
+.PHONY: clean
 

--- a/README.md
+++ b/README.md
@@ -106,23 +106,10 @@ to compile geneid.
 
 This will generate the geneid executable file within the bin/ subdirectory. 
 
-** Memory profiles
-
-geneid sizes its working arrays at compile time. How much memory it
-reserves can be selected with the MEM build option:
-
->make             (MEM=auto, the default: detect this machine's RAM and
-                   pick a profile -- low <16 GB, medium <48 GB, high >=48 GB)
->make MEM=low     smaller arrays (~ the original geneid sizing)
->make MEM=medium  ~13 GB reserved on a large, dense genome
->make MEM=high    maximum headroom for very large / prediction-dense genomes
->make print-mem   show the selected profile and the detected RAM
-
-Run "make clean" before switching profiles. Reserved memory is virtual:
-actual resident usage stays far lower (a few GB) thanks to lazy
-allocation. Note that MEM=auto inspects the machine you COMPILE on -- if
-you build and run on different machines (e.g. a cluster), pass an explicit
-MEM=low|medium|high matching the machine geneid will run on.
+geneid's working arrays now grow on demand, so memory follows the data and
+there is nothing to size at compile time -- just "make" (the older
+MEM=low|medium|high build profiles are gone). Resident memory scales with
+the input and stays modest (a few GB even on a large, dense genome).
 
 Type:
 >geneid -h 

--- a/include/geneid.h
+++ b/include/geneid.h
@@ -51,24 +51,19 @@ A. DEFINITIONS
 #define EVIDENCE  "evidence"           
 
 /* -------------------------------------------------------------------------
- * MEMORY PROFILE (build-time tunable)
- * The six constants below dominate the amount of memory geneid reserves
- * (mostly via NUMEXONS = LENGTHSi/REXONS and the FSORT multiplier). The
- * values here are the DEFAULT ("medium") profile, sized for ~16-24 GB
- * machines (~13 GB reserved on a large dense genome). Each is wrapped in
- * #ifndef so the Makefile can override it on the compiler command line:
- *     make MEM=low     (smaller arrays, ~5 GB; may be tight on dense genomes)
- *     make             (medium, the defaults below)
- *     make MEM=high    (max headroom, ~45 GB reserved; lazy, RSS stays low)
- * Do not raise FSORT/REXONS independently without checking: the exon-sort
- * table must hold the sum of all per-type build arrays (~8.2 x NUMEXONS),
- * so FSORT should stay >= ~9.
+ * These constants used to be a build-time "memory profile": geneid reserved
+ * fixed-size arrays up front (NUMSITES/NUMEXONS x FSORT, the per-type build
+ * arrays, the dumpster, ...), and the Makefile tuned them with -D to trade
+ * memory for capacity. All of those arrays now GROW ON DEMAND, so there is no
+ * profile to pick and nothing here is a correctness ceiling any more. What is
+ * left are just derivation constants: LENGTHSi (the fragment window -- an
+ * algorithmic parameter, not a memory knob) and the R* ratios that still feed
+ * NUMSITES/NUMEXONS/MAXBACKUP* in SetRatios (used for the dumpster hash size,
+ * the "backup active" flag, and beggar.c's -B estimate).
  * ---------------------------------------------------------------------- */
 
 /* Length of every processed fragment       */
-#ifndef LENGTHSi
 #define LENGTHSi 500000
-#endif
 
 /* Overlap between 2 fragments              */
 #define OVERLAP 10000
@@ -80,22 +75,16 @@ A. DEFINITIONS
 /* #define RU12SITES 6   */
 
 /* One exon per L / REXONS bp  (divisor: smaller -> more exon headroom) */
-#ifndef REXONS
 #define REXONS 0.75
-#endif
 
 /* /\* One U12 intron-flanking exon per L / RU12EXONS bp               *\/ */
 /* #define RU12EXONS 6  */
 
 /* Estimated amount of backup signals (divisor: smaller -> more backup) */
-#ifndef RBSITES
 #define RBSITES 75
-#endif
 
 /* Estimated amount of backup exons   (divisor: smaller -> more backup) */
-#ifndef RBEXONS
 #define RBEXONS 125
-#endif
 
 /* Ratios for every exon type               */
 #define RFIRST 3
@@ -105,15 +94,8 @@ A. DEFINITIONS
 #define RORF   4
 #define RUTR   0.5
 
-/* Total number of exons/fragment (exon-sort factor; keep >= ~9) */
-#ifndef FSORT
+/* Exon-sort table factor (only used now by beggar.c's -B estimate) */
 #define FSORT 12
-#endif
-
-/* Number of exons to save every fragment   */
-#ifndef FDARRAY
-#define FDARRAY 10
-#endif
 
 /* Basic values (in addition to ratios)     */
 #define BASEVALUESITES_SHORT 100000

--- a/src/BuildInitialExons.c
+++ b/src/BuildInitialExons.c
@@ -31,8 +31,6 @@
 
 /* Maximum allowed number of generic exons (divided by RFIRST) */
 /* Sequence is used to save information to prevent Stop codons in frame */
-/* extern long NUMEXONS; */
-extern long MAXBACKUPSITES;
 
 long BuildInitialExons(site *Start, long nStarts, 
                        site *Donor, long nDonors,

--- a/src/BuildInternalExons.c
+++ b/src/BuildInternalExons.c
@@ -31,8 +31,6 @@
 
 /* Sequence is used to save information to prevent Stop codons in frame */
 /* Maximum allowed number of generic exons (divided by RINTER) */
-/* extern long NUMEXONS; */
-extern long MAXBACKUPSITES;
 extern int RSS;
 
 long BuildInternalExons(site *Acceptor, long nAcceptors, 

--- a/src/BuildORFs.c
+++ b/src/BuildORFs.c
@@ -30,8 +30,6 @@
 #include "geneid.h"
 
 /* Maximum allowed number of generic exons (divided by RSINGL) */
-extern long NUMEXONS;
-extern long MAXBACKUPSITES;
 
 long BuildORFs(site *Start, long nStarts, 
                site *Stop, long nStops,

--- a/src/BuildSingles.c
+++ b/src/BuildSingles.c
@@ -30,8 +30,6 @@
 #include "geneid.h"
 
 /* Maximum allowed number of generic exons (divided by RSINGL) */
-extern long NUMEXONS;
-extern long MAXBACKUPSITES;
 
 long BuildSingles(site *Start, long nStarts, 
                   site *Stop, long nStops,

--- a/src/BuildTerminalExons.c
+++ b/src/BuildTerminalExons.c
@@ -31,8 +31,6 @@
 
 /* Maximum allowed number of generic exons (divided by RTERMI) */
 /* Sequence is used to save information to prevent Stop codons in frame */
-/* extern long NUMEXONS; */
-extern long MAXBACKUPSITES;
 
 long BuildTerminalExons (site *Acceptor, long nAcceptors, 
                          site *Stop, long nStops,

--- a/src/BuildUTRExons.c
+++ b/src/BuildUTRExons.c
@@ -31,8 +31,6 @@
 
 /* Maximum allowed number of generic exons (divided by RFIRST) */
 /* Sequence is used to save information to prevent Stop codons in frame */
-/* extern long NUMEXONS; */
-extern long MAXBACKUPSITES;
 
 long BuildUTRExons(
 				site *Start, long nStarts, 

--- a/src/BuildZeroLengthExons.c
+++ b/src/BuildZeroLengthExons.c
@@ -31,8 +31,6 @@
 
 /* Sequence is used to save information to prevent Stop codons in frame */
 /* Maximum allowed number of generic exons (divided by RINTER) */
-/* extern long NUMEXONS; */
-extern long MAXBACKUPSITES;
 extern int RSS;
 extern float RSSDON;
 extern float RSSACC;

--- a/test/regression/run.sh
+++ b/test/regression/run.sh
@@ -7,7 +7,7 @@
 # This is the guardrail for the Phase 2 cleanup: any change that alters the
 # output of a covered code path shows up here as a FAIL.
 #
-#   ./run.sh            build (MEM=medium) and verify every case
+#   ./run.sh            build and verify every case
 #   ./run.sh --no-build verify using the existing bin/geneid
 #   ./run.sh --bless    (re)generate the goldens from current output
 #   ./run.sh <name>...  run only the named case(s)
@@ -58,12 +58,12 @@ for a in "$@"; do case "$a" in
 esac; done
 
 if [ "$BUILD" = 1 ]; then
-  echo "# building (MEM=medium)..."
+  echo "# building..."
   # bin/geneid is a tracked binary, so a git checkout can leave it with a
   # newer mtime than the objects and make would skip the relink -- running a
   # stale binary against the goldens. Remove it first to force a fresh link.
   rm -f "$BIN"
-  make MEM=medium >/dev/null 2>&1 || { echo "BUILD FAILED"; exit 2; }
+  make >/dev/null 2>&1 || { echo "BUILD FAILED"; exit 2; }
 fi
 [ -x "$BIN" ] || { echo "no binary at $BIN (drop --no-build?)"; exit 2; }
 


### PR DESCRIPTION
## Retire the MEM build profiles

With the growable-arrays work complete (#9–#20), none of geneid's fixed-size tables are reserved up front any more — so the build-time "memory profile" that traded memory for capacity has nothing left to size.

### Changes
- **Makefile**: drop the `MEM=auto|low|medium|high` machinery (RAM detection, `MEMFLAGS`, the `-D` overrides, `print-mem`). Just `make`; `OPTS` is now a plain `-O3`. *(Note: the old `MEM=auto` keyed off the **build** machine's RAM, and `MEM=low` even changed `LENGTHSi` — the fragment window, which affects output — so results could vary by build host. The single default build is now deterministic.)*
- **geneid.h**: rewrite the `MEMORY PROFILE` comment; the constants are no longer `#ifndef`-overridable knobs, just derivation constants (`LENGTHSi` and the `R*` ratios still feed `SetRatios`/`beggar`). Remove **`FDARRAY`** (unused since the sort-by-donor arrays became growable in #19).
- Remove the now-dead `extern long NUMEXONS/MAXBACKUPSITES` in the `Build*` exon builders (unused since those arrays became growable).
- **README** + **test/regression/run.sh**: drop the `MEM=` instructions/flag.

### Behaviour
The default build is unchanged (`medium` == no `MEMFLAGS` == the `#define` defaults), so this is behaviour-preserving: **regression suite 5/5 byte-identical**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)