### PR TITLE
Clear the -Wall compile warnings (portable, behaviour-preserving)

### DIFF
--- a/src/BackupGenes.c
+++ b/src/BackupGenes.c
@@ -153,7 +153,7 @@ exonGFF* backupGene(exonGFF* E, packDump* d)
   exonGFF* ResExon;
 
   /* Ghost exon doesn't need backup */
-  if ((E->Strand == '*')) /* ||(E->Strand != '+')||(E->Strand != '-')) */
+  if (E->Strand == '*') /* ||(E->Strand != '+')||(E->Strand != '-')) */
     ResExon = E; 
   else
 	{

--- a/src/BuildAcceptors.c
+++ b/src/BuildAcceptors.c
@@ -66,12 +66,12 @@ float ComputeU2BranchProfile(char* s,
 	  index = OligoToInt(s + i + j - p->order, p->order+1,5);
 		  
 	  if (index >= p->dimensionTrans)
-	    score = score + -INFI;
+	    score = score + -(float)INFI;
 	  else
 	    score = score + p->transitionValues[j][index];
 	}
 	   
-      score = score - p->penalty_factor * (((float)(abs(i + p->offset -Opt))/((float)(p->acc_context - p->offset - p->opt_dist)))*((float)(abs(i + p->offset
+      score = score - p->penalty_factor * (((float)(labs(i + p->offset -Opt))/((float)(p->acc_context - p->offset - p->opt_dist)))*((float)(labs(i + p->offset
 																			     -Opt))/((float)(p->acc_context - p->offset - p->opt_dist)))); 
       score = p->afactor + (p->bfactor * score);
       if ((score >= maxScore)&&(score > p->cutoff)){
@@ -118,7 +118,7 @@ float ComputeU2PPTProfile(char* s,
 	  index = OligoToInt(s + i + j - p->order, p->order+1,5);
 		  
 	  if (index >= p->dimensionTrans)
-	    score = score + -INFI;
+	    score = score + -(float)INFI;
 	  else
 	    score = score + p->transitionValues[j][index];
 	}
@@ -188,7 +188,7 @@ long  BuildAcceptors(char* s,
 	      index = OligoToInt(s+j, p->order+1,5);
 			  
 	      if (index >= p->dimensionTrans)
-		score = score + -INFI;
+		score = score + -(float)INFI;
 	      else
 		score = score + p->transitionValues[i][index];
 	    }
@@ -250,7 +250,7 @@ long  BuildAcceptors(char* s,
 	      /* i is the position inside the region */
 	      index = TRANS[(int)(*(s + i))];
 	      if (index >= p->dimensionTrans)
-		score = score + -INFI;
+		score = score + -(float)INFI;
 	      else
 		score = score + p->transitionValues[i][index];
 	    }
@@ -303,7 +303,7 @@ long  BuildAcceptors(char* s,
 	      /* i is the position inside the region */
 	      index = 5*TRANS[(int)(*(s + i -1))] + TRANS[(int)(*(s + i))];
 	      if (index >= p->dimensionTrans)
-		score = score + -INFI;
+		score = score + -(float)INFI;
 	      else
 		score = score + p->transitionValues[i][index];
 	    }
@@ -360,7 +360,7 @@ long  BuildAcceptors(char* s,
 	      index = OligoToInt(s + i - p->order, p->order+1,5);
 
 	      if (index >= p->dimensionTrans)
-		score = score + -INFI;
+		score = score + -(float)INFI;
 	      else
 		score = score + p->transitionValues[i][index];
 	    }

--- a/src/BuildDonors.c
+++ b/src/BuildDonors.c
@@ -72,7 +72,7 @@ long  BuildDonors(char* s,
 			  index = OligoToInt(s+j, p->order+1,5);
 			  
 			  if (index >= p->dimensionTrans)
-			    score = score + -INFI;
+			    score = score + -(float)INFI;
 			  else
 			    score = score + p->transitionValues[i][index];
 			}
@@ -112,7 +112,7 @@ long  BuildDonors(char* s,
 			  /* i is the position inside the region */
 			  index = TRANS[(int)(*(s + i))];
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}
@@ -147,7 +147,7 @@ long  BuildDonors(char* s,
 			  /* i is the position inside the region */
 			  index = 5*TRANS[(int)(*(s + i -1))] + TRANS[(int)(*(s + i))];
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}
@@ -185,7 +185,7 @@ long  BuildDonors(char* s,
 			  index = OligoToInt(s + i - p->order, p->order+1,5);
 
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}

--- a/src/BuildU12Acceptors.c
+++ b/src/BuildU12Acceptors.c
@@ -66,12 +66,12 @@ float ComputeU12BranchProfile(char* s,
 	  index = OligoToInt(s + i + j - p->order, p->order+1,5);
 		  
 	  if (index >= p->dimensionTrans)
-	    score = score + -INFI;
+	    score = score + -(float)INFI;
 	  else
 	    score = score + p->transitionValues[j][index];
 	}
 	   
-      score = score - p->penalty_factor * (((float)(abs(i + p->offset -Opt))/((float)(p->acc_context - p->offset - p->opt_dist)))*((float)(abs(i + p->offset
+      score = score - p->penalty_factor * (((float)(labs(i + p->offset -Opt))/((float)(p->acc_context - p->offset - p->opt_dist)))*((float)(labs(i + p->offset
 																			       -Opt))/((float)(p->acc_context - p->offset - p->opt_dist)))); 
       if (score >= maxScore){
 	maxScore = score;
@@ -112,7 +112,7 @@ float ComputePPTProfile(char* s,
 	  index = OligoToInt(s + i + j - p->order, p->order+1,5);
 		  
 	  if (index >= p->dimensionTrans)
-	    score = score + -INFI;
+	    score = score + -(float)INFI;
 	  else
 	    score = score + p->transitionValues[j][index];
 	}
@@ -186,7 +186,7 @@ long  BuildU12Acceptors(char* s,
 		index = OligoToInt(s+j, u12_p->order+1,5);
 
 		if (index >= u12_p->dimensionTrans)
-		  score = score + -INFI;
+		  score = score + -(float)INFI;
 		else
 		  score = score + u12_p->transitionValues[i][index];
 	      }
@@ -252,7 +252,7 @@ long  BuildU12Acceptors(char* s,
 		/* i is the position inside the region */
 		index = TRANS[(int)(*(s + i))];
 		if (index >= u12_p->dimensionTrans)
-		  score = score + -INFI;
+		  score = score + -(float)INFI;
 		else
 		  score = score + u12_p->transitionValues[i][index];
 	      }
@@ -312,7 +312,7 @@ long  BuildU12Acceptors(char* s,
 		/* i is the position inside the region */
 		index = 5*TRANS[(int)(*(s + i -1))] + TRANS[(int)(*(s + i))];
 		if (index >= u12_p->dimensionTrans)
-		  score = score + -INFI;
+		  score = score + -(float)INFI;
 		else
 		  score = score + u12_p->transitionValues[i][index];
 	      }
@@ -372,7 +372,7 @@ long  BuildU12Acceptors(char* s,
 		/* 5 is used because there are A,C,G,T and N */
 		index = OligoToInt(s + i - u12_p->order, u12_p->order+1,5);
 		if (index >= u12_p->dimensionTrans)
-		  score = score + -INFI;
+		  score = score + -(float)INFI;
 		else
 		  score = score + u12_p->transitionValues[i][index];
 	      }

--- a/src/BuildZeroLengthExons.c
+++ b/src/BuildZeroLengthExons.c
@@ -50,14 +50,14 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
     site *Donor;
     int Frame[FRAMES];
   } *LocalExon;
-  int nLocalExons, LowestLocalExon;
+  int nLocalExons;
   float LowestLocalScore;
   /* char mess[MAXSTRING]; */
 
   /* Boolean array of windows: closed or opened */
   int Frame[FRAMES];
 
-  long i, j, js, k;
+  long i, j, k;
   int f, l, ll;
 
   /* Growable output array (grows on demand; capacity tracked by caller) */
@@ -85,15 +85,11 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
       /* Reset the best local exons array */
       nLocalExons = 0;
       LowestLocalScore = INF;
-      LowestLocalExon = 0;
 
       /* Skip previous Stops to current Acceptor */
       while ((j < nStops) && ((Stop+j)->Position+1 < (Acceptor+i)->Position))
 	j++;
-	  
-      /* Save counter j for the next iteration */
-      js=j;
-      
+
       /* Skip previous Donors to current Acceptor */
       while ((k < nDonors) && ((Donor+k)->Position < (Acceptor+i)->Position - 1))
 	k++;
@@ -111,7 +107,6 @@ long BuildZeroLengthExons(site *Acceptor, long nAcceptors,
 	  if ((Donor+k)->Score < LowestLocalScore)
 	    {
 	      LowestLocalScore = (Donor+k)->Score;
-	      LowestLocalExon = nLocalExons;
 	    }
 	  nLocalExons++;
 	}

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -400,9 +400,9 @@ long CookingInfo(exonGFF* eorig,
 		info[igen].score += e->Score;
 	
 	      /* if(!strcmp(e->Type,sUTRFIRSTHALF)||!strcmp(e->Type,sUTR5INTERNALHALF)){ */
-		if(!strcmp(e->Type,sUTRFIRSTHALF)||!strcmp(e->Type,sUTR5INTERNALHALF)||!strcmp(e->Type,sUTRFIRST)){
+	      if(!strcmp(e->Type,sUTRFIRSTHALF)||!strcmp(e->Type,sUTR5INTERNALHALF)||!strcmp(e->Type,sUTRFIRST)){
 		currentIsUTR = 1;
-				    
+
 	      }else{
 		currentIsUTR = 0;
 	      } 			  
@@ -580,7 +580,6 @@ void PrintGene(exonGFF* start,
   int exonnum = 1;
   int cdsnum = 1;
   int utrnum = 1;
-  int featnum =0;
 /*   char mess[MAXSTRING]; */
 /*  if (start != end){ */
    eaux = start->PreviousExon;
@@ -768,7 +767,6 @@ void PrintGene(exonGFF* start,
 	      PrintSite(end->Acceptor,type1,Name,strand,s,p1);
 	      if (!strcmp(end->Type,sFIRST)||!strcmp(start->Type,sINTERNAL)||!strcmp(start->Type,sTERMINAL)||!strcmp(start->Type,sSINGLE)){
 		cdsnum = (start->Strand == '-')? ccds: info[geneindex].ncds - ccds + 1;
-		featnum = (start->Strand == '-')? cfeats: info[geneindex].nfeats - cfeats + 1;
 		PrintGCDS(end,Name,s,dAA,igen,tAA[AAIDX(cfeats)][0],tAA[AAIDX(cfeats)][1],nAA,cdsnum,GenePrefix);
 	      }else{
 		utrnum = (start->Strand == '-')? cutrs: info[geneindex].nutrs - cutrs + 1;

--- a/src/GetSitesWithProfile.c
+++ b/src/GetSitesWithProfile.c
@@ -63,7 +63,7 @@ long  GetSitesWithProfile(char* s,
 			  index = OligoToInt(s+j, p->order+1,5);
 			  
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}
@@ -100,7 +100,7 @@ long  GetSitesWithProfile(char* s,
 			  /* i is the position inside the region */
 			  index = TRANS[(int)(*(s + i))];
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}
@@ -132,7 +132,7 @@ long  GetSitesWithProfile(char* s,
 			  /* i is the position inside the region */
 			  index = 5*TRANS[(int)(*(s + i -1))] + TRANS[(int)(*(s + i))];
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}
@@ -166,7 +166,7 @@ long  GetSitesWithProfile(char* s,
 			  index = OligoToInt(s + i - p->order, p->order+1,5);
 
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}

--- a/src/GetStopCodons.c
+++ b/src/GetStopCodons.c
@@ -73,7 +73,7 @@ long GetStopCodons(char* s,
 			  index = OligoToInt(s+j, p->order+1,5);
 			  
 			  if (index >= p->dimensionTrans)
-				score = score + -INFI;
+				score = score + -(float)INFI;
 			  else
 				score = score + p->transitionValues[i][index];
 			}
@@ -116,7 +116,7 @@ long GetStopCodons(char* s,
 				  /* i is the position inside the region */
 				  index = TRANS[(int)(*(s + i))];
 				  if (index >= p->dimensionTrans)
-					score = score + -INFI;
+					score = score + -(float)INFI;
 				  else
 					score = score + p->transitionValues[i][index];
 				}
@@ -155,7 +155,7 @@ long GetStopCodons(char* s,
 				  /* i is the position inside the region */
 				  index = 5*TRANS[(int)(*(s + i -1))] + TRANS[(int)(*(s + i))];
 				  if (index >= p->dimensionTrans)
-					score = score + -INFI;
+					score = score + -(float)INFI;
 				  else
 					score = score + p->transitionValues[i][index];
 				}
@@ -194,7 +194,7 @@ long GetStopCodons(char* s,
 				  /* i is the position inside the region */
 				  index = OligoToInt(s + i - p->order , p->order+1,5); 
 				  if (index >= p->dimensionTrans)
-					score = score + -INFI;
+					score = score + -(float)INFI;
 				  else
 					score = score + p->transitionValues[i][index];
 				}

--- a/src/ReadHSP.c
+++ b/src/ReadHSP.c
@@ -98,7 +98,6 @@ long ReadHSP (char* FileName, packExternalInformation* external)
   char *line6;
   char *line7;
   char *line8;
-  char *line9;
 
   /* Identifier for a sequence (from dictionary) */
   int a;
@@ -146,8 +145,8 @@ long ReadHSP (char* FileName, packExternalInformation* external)
           line6 = (char *) strtok(NULL,"\t");
           line7 = (char *) strtok(NULL,"\t");
           line8 = (char *) strtok(NULL,"\t");
-          line9 = (char *) strtok(NULL,"\n");
-		  
+          /* the optional 9th column is not used */
+
 		  /* There are 8 mandatory columns and the last one is optional */
 		  if (line1 == NULL || line2 == NULL || line3 == NULL ||
 			  line4 == NULL || line5 == NULL || line6 == NULL ||

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -715,8 +715,8 @@ packGenes* RequestMemoryGenes()
         printError("Not enough memory: 6 frames in Ga array of genes");
 
       for(aux2=0; aux2 < FRAMES; aux2++){
-      if ((pg->Ga[aux][aux2] = (exonGFF* *)calloc(SPLICECLASSES, sizeof(exonGFF*))) == NULL)
-        printError("Not enough memory: 3 splice classes in Ga array of genes");
+	if ((pg->Ga[aux][aux2] = (exonGFF* *)calloc(SPLICECLASSES, sizeof(exonGFF*))) == NULL)
+	  printError("Not enough memory: 3 splice classes in Ga array of genes");
 
 	for(aux3=0; aux3 < SPLICECLASSES; aux3++){
 	  pg->Ga[aux][aux2][aux3] = pg->Ghost;

--- a/src/ScoreExons.c
+++ b/src/ScoreExons.c
@@ -381,7 +381,6 @@ long Score(exonGFF *Exons,
   paramexons* p;
   int OligoLength;
   gparam* gp;
-  int rss = 0;
 /*   char mess[MAXSTRING]; */
 /*   float million = 1000000; */
 /*   int u12correction; */
@@ -396,7 +395,6 @@ long Score(exonGFF *Exons,
       iniExon=(Exons+i)->Acceptor->Position - l1;
       endExon=(Exons+i)->Donor->Position - l1;
       exonLen=endExon-iniExon+1;
-      rss = 0;
       /* 0. Get G+C content of the region around the exon (local) */
       /* selecting the proper isochore to score the exon */
       if (iniExon <= ISOCONTEXT)

--- a/src/beggar.c
+++ b/src/beggar.c
@@ -65,9 +65,10 @@ void beggar(long L)
   memEvi = (MAXEVIDENCES * sizeof(exonGFF)) +
 	(3*MAXEVIDENCES * sizeof(struct s_site));
   
-  /* HSPs */
-  memHSP =  sizeof(struct s_packHSP) +
-	(STRANDS * FRAMES * MAXHSP * sizeof(HSP));
+  /* HSPs (cast: this byte count exceeds float's exact-integer range, but
+     memHSP is only a rough estimate so the rounding is fine) */
+  memHSP =  (float)(sizeof(struct s_packHSP) +
+	(STRANDS * FRAMES * MAXHSP * sizeof(HSP)));
   
   /* G+C INFO */
   memGC = 2 * LENGTHSi * sizeof(long);

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -51,7 +51,7 @@ char* USAGE="NAME\n\tgeneid - a program to annotate genomic sequences\nSYNOPSIS\
 
 void printHelp()
 {
-  printf(USAGE);
+  printf("%s", USAGE);
 
   printf ("OPTIONS\n");
   


### PR DESCRIPTION
## Clear the -Wall compile warnings

A clean `make` now builds with **zero warnings** (was 38 across 6 categories). Every fix is byte-identical — it either makes an implicit conversion explicit or removes dead code. **No identifiers renamed.**

| Warning | Fix |
|---|---|
| `-Wimplicit-const-int-float-conversion` (25) | `-INFI` in the Markov score sums is an `int` (2147483647) the compiler silently rounded to float → `-(float)INFI` (same value). `INFI` stays an `int` for its `long` "infinity" sentinel uses (`Md[]=INFI`, `MaxDist==INFI` in ReadGeneModel/genamic/BackupGenes). beggar.c's HSP byte count cast to float (only a rough `-B` estimate). |
| `-Wabsolute-value` (4) | branch-point penalty called `abs()` on a `long` (int param → truncation risk) → `labs()`. |
| `-Wunused-but-set-variable` (5) | removed dead locals: `featnum` (CookingGenes), `rss` (ScoreExons), `line9` (ReadHSP — the optional 9th HSP column, last `strtok` on the line, never read), `LowestLocalExon`/`js` (BuildZeroLengthExons). |
| `-Wmisleading-indentation` (2) | reindented the UTR `if` in `CookingInfo` and the `Ga` alloc loop in `RequestMemoryGenes`. |
| `-Wparentheses-equality` (1) | `if ((E->Strand == '*'))` → `if (E->Strand == '*')`. |
| `-Wformat-security` (1) | `printf(USAGE)` → `printf("%s", USAGE)` (USAGE has no `%`, so identical output). |

Some of these are clang-specific warning *flags* (macOS), but the fixes (explicit casts, `labs`, `%s`) are good practice on gcc too and introduce no new warnings.

Regression suite **5/5 byte-identical**.

### Not done here (noted for later)
On recent macOS SDKs `sprintf` is flagged deprecated (`-Wdeprecated-declarations`) — but that doesn't appear in the default `-Wall` build, and converting the ~100 `sprintf` call sites to `snprintf` is a large, buffer-sizing-sensitive change better done as its own focused pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)