### PR TITLE
Comment genamic.c, the core structs, and the Markov/coding-potential path

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -471,23 +471,26 @@ typedef struct s_profile
   float*  transitionValues[PROFILEDIM];
 } profile;
 
-typedef struct s_site                  
+/* A single predicted splice site / start / stop / TSS / TES signal. */
+typedef struct s_site
 {
-  long Position;                       
-  float Score;
-  float ScoreAccProfile;                        
-  float ScoreBP;
-  float ScorePPT;
-  int PositionBP;
-  int PositionPPT;
-  char type[MAXSPLICETYPE];
-  char subtype[MAXSUBTYPE];
-  short class;
+  long Position;         /* coordinate in the (fragment-local) sequence */
+  float Score;            /* final signal score (after all sub-profiles below) */
+  float ScoreAccProfile;  /* acceptor PWM/Markov score alone, before adding BP/PPT */
+  float ScoreBP;          /* branch-point sub-profile score (acceptors only) */
+  float ScorePPT;         /* poly-pyrimidine-tract sub-profile score (acceptors only) */
+  int PositionBP;         /* branch point position, relative to this Acceptor */
+  int PositionPPT;        /* poly-pyrimidine-tract position, relative to this Acceptor */
+  char type[MAXSPLICETYPE];    /* e.g. "Acceptor", "Donor", "Start", "Stop" (site kind) */
+  char subtype[MAXSUBTYPE];    /* e.g. "U2", "U12gtag", "U12atac", "GC-AG" (signal flavor) */
+  short class;            /* U2 / U12gtag / U12atac (see #define's above); drives Ga's 3rd axis */
 } site;
 
-typedef struct s_packSites             
+/* All predicted signals for one strand of one fragment, one array per
+   signal kind (TS/TE = transcription start/end sites, UTR-only). */
+typedef struct s_packSites
 {
-  site* StartCodons;                   
+  site* StartCodons;
   site* AcceptorSites;
   site* DonorSites;
   site* StopCodons;
@@ -528,35 +531,42 @@ typedef struct s_packSortSites
   long  tesitescap;
 } packSortSites;
 
+/* A single predicted (or annotated/evidence) exon, and also the node type
+   used to chain exons into genes: genamic's DP walks PreviousExon links to
+   build up a gene, scoring each addition into GeneScore (see genamic.c). */
 typedef struct s_exonGFF *pexonGFF;
 typedef struct s_exonGFF
 {
-  site* Acceptor;
-  site* Donor;
-  char Type[MAXTYPE];
-  short Frame;
-  short Remainder;
-  char Strand;
-  float PartialScore;
-  float HSPScore;
-  float R;
-  float Score;
-  pexonGFF PreviousExon;
-  double GeneScore;
-  char Group[MAXSTRING];
-  int offset1;
-  int offset2;
-  short lValue;
-  short rValue;
-  short evidence;
-  short selected;
-  short three_prime_partial;
-  short five_prime_partial;
+  site* Acceptor;         /* left (5') splice/start signal bounding this exon */
+  site* Donor;            /* right (3') splice/stop signal bounding this exon */
+  char Type[MAXTYPE];     /* "First"/"Internal"/"Terminal"/"Single"/"Intron"/UTR variants/... */
+  short Frame;            /* reading frame this exon starts in (0/1/2) */
+  short Remainder;        /* bases left over from an incomplete trailing codon */
+  char Strand;            /* '+' / '-' / '*' (the Ghost/placeholder exon) */
+  float PartialScore;     /* the coding-potential (Markov) component of Score */
+  float HSPScore;         /* the homology/HSP-support component of Score */
+  float R;                /* RNA-seq coverage evidence (e.g. RPKM) for this exon, if any */
+  float Score;             /* this exon's own score (site + coding + HSP + weight, see ScoreExons) */
+  pexonGFF PreviousExon;  /* best predecessor exon in the assembled gene chain (Ghost if none) */
+  double GeneScore;       /* PreviousExon->GeneScore + Score: best gene score ending at this exon */
+  char Group[MAXSTRING];  /* evidence/annotation group name (NOGROUP if none); see genamic's block rule */
+  int offset1;            /* Acceptor-position correction (fragment-splitting/evidence coordinate offset) */
+  int offset2;            /* Donor-position correction (fragment-splitting/evidence coordinate offset) */
+  short lValue;           /* left split-codon signature (set by ComputeStopInfo; see genamic.c) */
+  short rValue;           /* right split-codon signature (set by ComputeStopInfo; see genamic.c) */
+  short evidence;         /* 1 if this exon comes from external evidence/annotation, 0 if predicted */
+  short selected;         /* scratch mark used by SwitchFrames to track already-processed d-array entries */
+  short three_prime_partial; /* 1 if the gene's 3' end is cut off by the sequence/fragment boundary (GFF3 output) */
+  short five_prime_partial;  /* 1 if the gene's 5' end is cut off by the sequence/fragment boundary (GFF3 output) */
 } exonGFF;
 
-typedef struct s_packExons             
+/* One array per exon type, all built and filled per fragment/strand by the
+   Build*Exons functions (see e.g. BuildInitialExons.c); UTR arrays only
+   used when UTR prediction (-u) is on. Each array grows on demand (see the
+   matching cap* field and GrowExonArray). */
+typedef struct s_packExons
 {
-  exonGFF* InitialExons;               
+  exonGFF* InitialExons;
   exonGFF* InternalExons;
   exonGFF* ZeroLengthExons;
   exonGFF* TerminalExons;
@@ -599,15 +609,18 @@ typedef struct s_packExons
   long capUtrTerminalExons;
 } packExons;
 
+/* The gene-assembly DP state, persisted across all fragments of one locus
+   (reset only when moving to the next input sequence). See the header
+   comment of genamic.c for how these are used together. */
 typedef struct s_packGenes
 {
-  exonGFF* ***Ga;
-  exonGFF* Ghost;
-  exonGFF* GOptim;
-  exonGFF* **d;
-  long* dcap;   /* allocated capacity of each d[class] (grown by BuildSort) */
-  long* km;
-  long* je;
+  exonGFF* ***Ga;   /* Ga[class][frame][spliceclass]: best partial gene ending in that DP cell */
+  exonGFF* Ghost;   /* placeholder "empty gene" every Ga cell starts pointing at (Strand '*') */
+  exonGFF* GOptim;  /* best-scoring complete gene found so far, across the whole locus */
+  exonGFF* **d;     /* d[class]: exons compatible with gene-model class `class`, sorted by Donor position */
+  long* dcap;       /* allocated capacity of each d[class] (grown by BuildSort) */
+  long* km;         /* km[class]: number of exons currently in d[class] */
+  long* je;         /* je[class]: how far d[class] has been folded into Ga so far (forward-only cursor) */
 } packGenes;
 
 typedef struct s_packEvidence
@@ -653,27 +666,35 @@ typedef struct s_packExternalInformation
   float** readcount;
 } packExternalInformation;
 
-typedef struct s_dumpNode *pdumpNode;  
+/* Hash-bucket entry identifying one already-backed-up exon (see DumpHash.c);
+   the key fields mirror exonGFF's Acceptor/Donor/Frame/Strand/Type so
+   getExonDumpHash can recognize a duplicate without re-hashing the exon
+   from scratch. asub/dsub are unused (their fill-in is commented out in
+   setExonDumpHash) -- kept only for the on-disk struct layout. */
+typedef struct s_dumpNode *pdumpNode;
 typedef struct s_dumpNode
 {
-  long acceptor;                      
-  long donor;
-  short aclass;
-  short dclass;
+  long acceptor;    /* the exon's Acceptor->Position */
+  long donor;       /* the exon's Donor->Position */
+  short aclass;     /* the exon's Acceptor->class (U2/U12gtag/U12atac) */
+  short dclass;     /* the exon's Donor->class */
   char asub[MAXSUBTYPE];
   char dsub[MAXSUBTYPE];
-  short frame;
-  char strand;
-  char type[MAXTYPE];
+  short frame;      /* the exon's Frame */
+  char strand;      /* the exon's Strand */
+  char type[MAXTYPE]; /* the exon's Type */
 
-  exonGFF* exon;                      
-  pdumpNode next;
-} dumpNode; 
+  exonGFF* exon;    /* the actual backed-up exon (a stable pointer into a dumpster chunk) */
+  pdumpNode next;   /* next node in this hash bucket's collision chain */
+} dumpNode;
 
-typedef struct s_dumpHash              
+/* Hash table (fixed MAXDUMPHASH buckets, chained) so backupGene can tell in
+   O(1) whether an exon has already been backed up into the dumpster, instead
+   of rescanning it. */
+typedef struct s_dumpHash
 {
-  pdumpNode* T;
-  long total; 
+  pdumpNode* T;   /* T[0..MAXDUMPHASH): bucket array, each a collision chain */
+  long total;     /* total number of exons currently hashed (diagnostic only) */
 } dumpHash;
 
 typedef struct s_packDump

--- a/src/ScoreExons.c
+++ b/src/ScoreExons.c
@@ -27,6 +27,24 @@
 
 #include "geneid.h"
 
+/* This file implements geneid's "coding potential" score for an exon: how
+ * much the exon's own sequence looks like real coding DNA, independent of
+ * its splice/start/stop signal scores (those are scored where they are
+ * predicted, in Build*.c). It is a 2nd-order-ish Markov chain trained per
+ * isochore (see readparam.c, which loads the OligoLogsIni/OligoLogsTran log-
+ * likelihood tables) and applied here in two passes:
+ *   MarkovScan()  pre-scans the WHOLE fragment once per isochore, filling
+ *                 OligoDistIni/OligoDistTran with (accumulated) log-odds
+ *                 for every position and reading frame.
+ *   Score()       then scores each candidate exon in O(1) by taking the
+ *                 difference of two pre-scanned accumulated sums, adds the
+ *                 homology (HSP) and RNA-seq read-count scores, and filters
+ *                 out exons below the isochore's cutoffs.
+ * ScoreExons() is the entry point manager.c calls once per fragment/strand:
+ * it runs MarkovScan for every isochore, then Score for every exon-type
+ * array in allExons. */
+
+
 extern float MRM;
 extern int UTR;
 extern int scanORF;
@@ -66,15 +84,21 @@ int TRANS[] = {
 
 /* Translation from string into integer: for oligonucleotides with this length */
 /* s: sequence; ls: length of sequence; cardinal: length of the alphabet */
+/* Encodes the ls-mer at s as a single base-`cardinal` number (each base's
+   TRANS value, 0..3 for A/C/G/T, is a "digit"; N/other maps to 4, which is
+   why callers check index/intword against the model's dimension and treat
+   an out-of-range result as "unknown oligo" -- see MarkovScan below). This
+   gives every distinct oligomer a unique index into the OligoLogsIni/
+   OligoLogsTran tables. */
 long OligoToInt(char* s, int ls, int cardinal)
-{ 
+{
   long index;
   int weight;
   short i;
-  
+
   index = 0;
   weight = 1;
-  
+
   for ( i=ls-1; i>=0; --i )
     {
       index += weight*TRANS[(int)s[i]];
@@ -193,11 +217,24 @@ void GCScan(char* s, packGC* GCInfo, long l1, long l2)
 /* Compute the coding potential statistic for a sequence: pre-processing */
 /* There are Initial (penta) and Transition (hexa) score matrices: */
 /* Transition scores for every position are accumulated sums */
+/* Precomputes, for one isochore, the per-base coding-potential contribution
+   at every position of the fragment [l1,l2] -- so later, scoring any
+   candidate exon is just a table difference (see Score() below) instead of
+   rescanning its sequence. Two tables are filled:
+     OligoDistIni[codonPosition][pos]  the model's log-odds for the
+        OligoLength-mer (an "initial", order-0 oligomer score) starting at
+        pos, looked up per codon position (0/1/2) since the model is
+        trained separately for each.
+     OligoDistTran[frame][pos]  the RUNNING SUM, up to and including pos, of
+        the model's log-odds for the (OligoLength+1)-mer ending at pos (a
+        higher-order "transition" score), one running sum per reading frame
+        so Score() can get the sum over any sub-range by subtracting two
+        values. */
 void MarkovScan(char* sequence,
                 gparam* gp,
-                float* OligoDistIni[3], 
+                float* OligoDistIni[3],
                 float* OligoDistTran[3],
-                long l1, long l2) 
+                long l1, long l2)
 {
   int OligoLength_1;
   long i;
@@ -211,26 +248,28 @@ void MarkovScan(char* sequence,
       /* Indexing the initialMarkov with the oligonucleotide */
       intword=OligoToInt(sequence+i,gp->OligoLength,4);
 
-      /* Assign the pentanucleotide score depending on the codon position */
+      /* Out-of-range (an N or other ambiguous base was in this oligomer):
+	 use the model's null/unknown-oligo score instead of a table lookup. */
       if (intword>=gp->OligoDim)
 		for (x=0;x<3;x++)
 		  OligoDistIni[x][i-l1] = NULL_OLIGO_SCORE;
-      else 
-		for (x=0;x<3;x++) 
+      else
+		for (x=0;x<3;x++)
 		  OligoDistIni[x][i-l1] = gp->OligoLogsIni[x][intword];
-    }    
-  
+    }
+
   /* Hexanucleotides score: transition values for Markov chains */
   /* Accumulated sum is stored for every position and codon position */
   OligoLength_1=gp->OligoLength+1;
-  
-  /* For every codon position computing the accumulated sum of scores */
+
+  /* For every reading frame, accumulate log-odds along the whole fragment so
+     OligoDistTran[x][pos] holds the running sum from l1 up to pos. */
   for (x=0; x<FRAMES; x++)
     {
       previousScore = 0.0;
       /* Codon position and frame are different properties of exons */
       cp = (3-x) % 3;
-      
+
       /* Screening the whole sequence to accumulate the sum in every base */
       for (i=l1; (i<=l2 && *(sequence+i+OligoLength_1 - 1)) ; i++)
 		{
@@ -255,9 +294,18 @@ void MarkovScan(char* sequence,
 
 
 /* Homology to protein score: using homology information (blast HSPs) */
-float ScoreHSPexon(exonGFF* exon, 
-				   int Strand, 
-				   packExternalInformation* external, 
+/* Like MarkovScan's tables, external->sr[frame][pos] is an accumulated sum
+   (built once per fragment, before scoring begins -- see HSPScan, currently
+   disabled below in ScoreExons) of per-base homology support, indexed by a
+   "true frame" derived from the sequence start so the running sum lines up
+   with codon boundaries; this exon's score is again just the difference of
+   the sum at its two ends. When UTR read-coverage mode is on, it further
+   subtracts a local background level (the average per-base score in a
+   flanking window) so a strong local peak stands out rather than a whole
+   generally-well-covered region scoring high uniformly. */
+float ScoreHSPexon(exonGFF* exon,
+				   int Strand,
+				   packExternalInformation* external,
 				   long l1, long l2)
 {
   int index;
@@ -321,10 +369,14 @@ float ScoreHSPexon(exonGFF* exon,
   }
   return(Score);
 }
-/* Homology to protein score: using homology information (blast HSPs) */
-float GetReadCount(exonGFF* exon, 
-				   int Strand, 
-				   packExternalInformation* external, 
+/* RNA-seq read-support score for this exon (from external->readcount, an
+   accumulated sum over the fragment exactly like external->sr above).
+   Stored into exonGFF.R, which does not itself feed scoreTotal below --
+   it is only used later to report the exon's rpkm= GFF3 attribute
+   (see PrintExons.c). */
+float GetReadCount(exonGFF* exon,
+				   int Strand,
+				   packExternalInformation* external,
 				   long l1, long l2)
 {
   int index;
@@ -354,6 +406,11 @@ float GetReadCount(exonGFF* exon,
   return(Score);
 }
 /* Computing the score of a list of exons from (Sites, Markov, homology) */
+/* Scores every exon in Exons[0..nExons) in place, compacting the survivors
+   (those clearing both cutoffs below) down to Exons[0..n) and returning n --
+   this is how exon arrays get filtered, not just scored. Each exon may pick
+   a DIFFERENT isochore (via its local G+C%), since geneid supports several
+   isochores per input sequence. */
 long Score(exonGFF *Exons,
            long nExons,
            long l1,
@@ -366,21 +423,21 @@ long Score(exonGFF *Exons,
 {
   long iniExon, endExon, i, j;
   int exonLen;
-  long inigc, endgc;
+  long inigc, endgc;        /* the +/-ISOCONTEXT window used to estimate local G+C% */
   short frame;
   short codonPosition;
-  long n;
-  float scoreMarkov;
-  float scoreHSP;
-  float exonR;
-  float scoreTotal;
+  long n;                   /* count of survivor exons written back into Exons[] */
+  float scoreMarkov;        /* this exon's coding-potential score (from MarkovScan's tables) */
+  float scoreHSP;           /* this exon's homology (or, in UTR mode, background-corrected read) score */
+  float exonR;              /* raw RNA-seq read-support value, just for the rpkm= report (see GetReadCount) */
+  float scoreTotal;         /* site + coding + homology, weighted by this isochore/exon-type's paramexons */
   int OligoLength_1;
-  float ExonWeight;
+  float ExonWeight;         /* per-exon-type constant bonus/penalty (tunable via -E, and -V for U12) */
   float percentGC;
-  int currentIsochore;
-  paramexons* p;
+  int currentIsochore;      /* which of the isochores[] this exon's local G+C% selects */
+  paramexons* p;            /* the exon-type-specific score weights/cutoffs for currentIsochore */
   int OligoLength;
-  gparam* gp;
+  gparam* gp;               /* currentIsochore's full parameter set (profiles, Markov tables, ...) */
 /*   char mess[MAXSTRING]; */
 /*   float million = 1000000; */
 /*   int u12correction; */
@@ -441,7 +498,10 @@ long Score(exonGFF *Exons,
 /* 		p = gp->utr; */
       
       /* 1. Coding potential score: initial plus accumulated sums */
-      /* Checkpoint for exons shorter than a minimum value */
+      /* Checkpoint for exons shorter than a minimum value, and for exon
+	 types that carry no real coding sequence of their own (UTR
+	 exons/introns fall through to here, keeping the "default: UTR"
+	 params set above but skipping the lookup below entirely) */
       if ((exonLen < MINEXONLENGTH)
 	  || (strcmp((Exons+i)->Type,sFIRST)&&strcmp((Exons+i)->Type,sINTERNAL)&&strcmp((Exons+i)->Type,sTERMINAL)&&strcmp((Exons+i)->Type,sSINGLE)&&strcmp((Exons+i)->Type,sORF))
 
@@ -451,19 +511,24 @@ long Score(exonGFF *Exons,
       }
       else
 	{
+	  /* This is the payoff of MarkovScan's pre-scan: look up the initial
+	     (OligoLength-mer) score at the exon's start, then add the
+	     transition-table difference between its start and end -- the
+	     accumulated-sum trick turns "sum the per-base score across this
+	     whole exon" into two table reads, regardless of exon length. */
 	  scoreMarkov = 0.0;
 	  frame = (Exons+i)->Frame;
-         
+
 	  /* Translate frame to position into codon */
 	  codonPosition = (3 - frame) % 3;
-   
+
 	  /* Assign initial probability: pentanucleotide */
 	  scoreMarkov += gp->OligoDistIni[codonPosition][iniExon];
-         
+
 	  /* Which one of the three combinations? */
 	  j = (iniExon + (3-codonPosition)) % 3;
-   
-	  /* Accumulating transition probabilities: hexanucleotides */    
+
+	  /* Accumulating transition probabilities: hexanucleotides */
 	  scoreMarkov +=
 	    gp->OligoDistTran[j][(endExon>OligoLength_1)?endExon-OligoLength_1+1 : endExon]
 	    - gp->OligoDistTran[j][(iniExon)? iniExon - 1 : 0];
@@ -513,8 +578,10 @@ long Score(exonGFF *Exons,
 		+ (p->HSPFactor * scoreHSP); 
 	    }
 	  }
-	  /* Second cutoff- final score */
-	  if (scoreTotal >= p->ExonCutoff) 
+	  /* Second cutoff- final score: exons failing this are dropped (n is
+	     not advanced, so Exons[i] is simply overwritten by the next
+	     survivor -- this is the in-place compaction mentioned above). */
+	  if (scoreTotal >= p->ExonCutoff)
 	    {
 	      Exons[n]=Exons[i];
 

--- a/src/SetRatios.c
+++ b/src/SetRatios.c
@@ -32,13 +32,20 @@ extern int BEG;
 /* NUMSITES, NUMEXONS:
 From the defined values RSITES, REXONS (geneid.h) and length of sequence,
 an estimation for the amount of predicted signals and exons (any type) is
-computed in order to ask for enough memory to allocate them */
+computed. Historically this sized the fixed site/exon arrays up front; now
+that those arrays grow on demand (see GrowSiteArray/GrowExonArray), NUMSITES
+and NUMEXONS are only a rough estimate left over for beggar.c's -B memory
+report -- they no longer bound or size anything real. */
 
 /* MAXBACKUPSITES, MAXBACKUPEXONS:
 From the defined values RBSITES, RBEXONS (geneid.h) and length of sequence,
 an estimation for the amount of signals and exons (any type), necessary
-to restore the prediction between 2 splits, is computed in order to ask
-for enough memory to allocate them */
+to restore the prediction between 2 splits, is computed. These two ARE still
+real: MAXBACKUPEXONS sizes the dumpster's hash table (MAXDUMPHASH, see
+DumpHash.c), and both being nonzero is the "multi-split, dumpster active"
+flag checked in BackupGenes.c -- the dumpster's own backup arrays are
+chunked and grow on demand (see BackupGenes.c), but the hash stays a fixed
+table sized from this estimate. */
 
 void SetRatios(long* NUMSITES,
                long* NUMEXONS,
@@ -50,7 +57,9 @@ void SetRatios(long* NUMSITES,
   /* LENGTHSi is the length splitting */
   if (L < LENGTHSi)
     {
-      /* Short sequences processed as a whole: only one split */
+      /* Short sequences processed as a whole: only one split, so there is
+	 no inter-split state to restore -- the 0s below are read as the
+	 "dumpster inactive" flag in BackupGenes.c. */
       *NUMSITES = L / RSITES + BASEVALUESITES_SHORT;
       *NUMEXONS = L / REXONS + BASEVALUEEXONS_SHORT;
 
@@ -62,11 +71,11 @@ void SetRatios(long* NUMSITES,
     {
       /* Long sequences must be divided into several fragments */
       *NUMSITES = LENGTHSi / RSITES;
-      *NUMEXONS = LENGTHSi / REXONS;     
+      *NUMEXONS = LENGTHSi / REXONS;
 
-      /* Information inter-split predictions must be saved */ 
-      *MAXBACKUPSITES = (L / RBSITES) + BASEVALUESITES_LARGE; 
-      *MAXBACKUPEXONS = (L / RBEXONS) + BASEVALUEEXONS_LARGE; 
+      /* Information inter-split predictions must be saved */
+      *MAXBACKUPSITES = (L / RBSITES) + BASEVALUESITES_LARGE;
+      *MAXBACKUPEXONS = (L / RBEXONS) + BASEVALUEEXONS_LARGE;
     }
 
 }

--- a/src/genamic.c
+++ b/src/genamic.c
@@ -29,24 +29,64 @@
 
 #include "geneid.h"
 
+/* This is the dynamic-programming core that chains scored exons into genes.
+ *
+ * Exons arrive in E[0..nExons) sorted by acceptor (left) position (done by
+ * SortExons before this is called). genamic scans them once, left to right,
+ * and for each exon looks up the best-scoring compatible partial gene that
+ * could precede it, using two pieces of state carried in packGenes (pg)
+ * across the whole run (all fragments/splits of one locus, reset only in
+ * cleanGenes at the start of the next locus):
+ *
+ *   pg->d[etype]  - all exons seen so far that may end (via their Donor
+ *                   site) a partial gene of gene-model class `etype`,
+ *                   kept sorted by Donor position (built once per call by
+ *                   BuildSort's insertion sort).
+ *   pg->km[etype] - how many exons are currently in pg->d[etype].
+ *   pg->je[etype] - how far pg->d[etype] has already been scanned into
+ *                   pg->Ga (a forward-only cursor; see step 2 below).
+ *   pg->Ga[etype][frame][spliceclass]
+ *                 - the single best partial gene of class `etype` ending in
+ *                   a given reading frame and acceptor splice class, i.e.
+ *                   the DP table cell this exon will try to extend.
+ *
+ * "gene-model class" (etype, indexed 0..gp->nclass-1) is NOT the same as
+ * exon type (First/Internal/Terminal/Single/...): it is a row of the .gm
+ * gene-model file (read by ReadGeneModel) describing one legal exon-exon
+ * transition, with its own min/max intron distance (gp->md/gp->Md) and
+ * group-blocking rule (gp->block). gp->D maps an exon's "Type+Strand"
+ * string to a dictionary key (the same numbering used by CookingGenes and
+ * SortExons); gp->nc/gp->UC and gp->ne/gp->DE, indexed by that key, list
+ * which gene-model classes an exon of this type may (a) contribute itself
+ * into as a future predecessor (UC, "upstream compatible" -- this is what
+ * BuildSort consults) and (b) look up as a predecessor for itself (DE,
+ * "downstream equivalent" -- this is what the h-loop below iterates over).
+ */
+
 /* Complete gene prediction (sites and exons) or only assembling */
 extern int GENEID;
 extern int RSS;
 extern float U12_SPLICE_SCORE_THRESH;
 extern float U12_EXON_SCORE_THRESH;
 
+/* E        exons to assemble, sorted by acceptor position (in/out: filled
+ *          with GeneScore/PreviousExon chains on return)
+ * nExons   number of exons in E
+ * pg       DP state (Ga/d/km/je) persisted across the whole locus
+ * gp       current isochore's parameters, including the gene model
+ *          (D/nc/ne/UC/DE/md/Md/block/nclass) used to drive the DP */
 void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 {
-  long i,j,j2;
-  short frame,remainder,spliceclass,dclass;
-  int h;
-  char saux[MAXTYPE];
-  int type,etype;
-  long MaxDist;
-  long MinDist;
+  long i,j,j2;                 /* i: current exon in E; j/j2: cursors into pg->d[etype] */
+  short frame,remainder,spliceclass,dclass; /* current exon's / candidate predecessor's DP-cell coordinates */
+  int h;                       /* index over the current exon type's compatible predecessor classes (gp->DE) */
+  char saux[MAXTYPE];          /* scratch "Type+Strand" string, looked up in the gene-model dictionary gp->D */
+  int type,etype;              /* type: current exon's dictionary key; etype: gene-model class being tried */
+  long MaxDist;                /* this class's max allowed intron/gap distance (gp->Md[etype]) */
+  long MinDist;                /* this class's min allowed intron/gap distance (gp->md[etype]) */
   char mess[MAXSTRING];
-  int current_exon_is_u12 = 0;
-  int thresholdmet = 1;
+  int current_exon_is_u12 = 0; /* is the current exon's acceptor a U12 (minor spliceosome) site? */
+  int thresholdmet = 1;        /* does the candidate join clear the U2/U12 score threshold (see step 2c)? */
 
   /* 0. Starting process ... */
   printMess("-- Running gene assembling (genamic) --");
@@ -55,12 +95,17 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
   sprintf(mess,"%ld exons GFF received from geneid",nExons);
   printMess(mess);
 
-  /* Frame/remainder of reverse-strand exons must be exchanged */
+  /* Frame/remainder are stored for the forward (+) reading direction; on the
+     reverse strand the DP below needs them read the other way round, so
+     swap them here and swap back in step 3. Splits across fragments carry
+     state in pg (Da = the previous fragment's leftover Ga/d, done once per
+     call; GENEID off, i.e. -O, means genamic runs standalone on given
+     exons/sites with no fragment history to carry). */
   if (GENEID)
     {
       /* Exons from the current fragment of sequence */
       SwitchFrames(E,nExons);
-	  
+
       /* Exons from the last fragment of sequence */
       SwitchFramesDa(pg,gp->nclass);
     }
@@ -71,14 +116,16 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
       SwitchFrames(E,nExons);
     }
   
-  /* 1. Create a set of sorted by donor array of pointer to exons */
+  /* 1. Add every exon from this fragment into pg->d[]: BuildSort inserts
+     each exon (by insertion sort, by Donor position) into d[class] for
+     every gene-model class it is UC-compatible with (see file header). */
   printMess("Sorting exons by donor...");
-  
+
   /* Build a set of sorting exons by donor functions */
   BuildSort(gp->D, gp->nc, gp->ne,
 	    gp->UC, gp->DE, gp->nclass,
 	    pg->km, pg->dcap, pg->d, E, nExons);
-  
+
   /* 2. Genamic Algorithm in linear time (size of input) */
   printMess("Assembling Genes...");
 
@@ -86,23 +133,29 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
   /* and after this, it might be assemble with the best gene computed */
   for(i=0; i< nExons; i++)
     {
-      /* What is the type of this exon? */
+      /* What is the type of this exon? (skip the ghost/placeholder entries
+         that carry an empty Type -- they are never assembled themselves) */
       if (strcmp((E+i)->Type,"")){
 	saux[0]='\0';
 	strcpy (saux, (E+i)->Type);
 	strcat (saux, &((E+i)->Strand));
 	type = getkeyDict(gp->D,saux);
-	frame = (E+i)->Frame;      
+	frame = (E+i)->Frame;
+	/* Default: a lone exon, scoring just itself with no predecessor;
+	   the h-loop below may improve on this by attaching a predecessor. */
 	(E+i)->PreviousExon = pg->Ghost;
 	(E+i)->GeneScore = (E+i)->Score;
 	current_exon_is_u12 = 0;
 	spliceclass = (E+i)->Acceptor->class;
+	/* Classify by the current exon's acceptor signal: does joining it to a
+	   predecessor cross a minor (U12) splice site, which is held to a
+	   stricter score threshold below (step 2c)? */
 	if (!strcmp((E+i)->Type,sEND) || !strcmp((E+i)->Type,sBEGIN)|| !strcmp((E+i)->Type,sSINGLE)){
 	  current_exon_is_u12 = 0;
-	}else{ 
+	}else{
 	  if ((E+i)->Acceptor->class == U2){
 	    current_exon_is_u12 = 0;
-	  } else { 
+	  } else {
 	    if (((E+i)->Acceptor->class == U12gtag)||((E+i)->Acceptor->class == U12atac)){
 	      current_exon_is_u12 = 1;
 	    }
@@ -110,33 +163,45 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 	}
 	if (type != NOTFOUND)
 	  {
-	    /* For every equivalent class building the best gene ending with it */
+	    /* For every gene-model class this exon type may extend (gp->DE),
+	       try to attach the best compatible predecessor found so far. */
 	    for(h=0; h < gp->ne[type]; h++)
 	      {
 		etype = gp->DE[type][h];
-		j = pg->je[etype];
+		j = pg->je[etype];       /* where the forward scan (2b) left off last time */
 		MaxDist = gp->Md[etype];
 		MinDist = gp->md[etype];
-		thresholdmet = 1;			  
+		thresholdmet = 1;
 
-		/* Checking maximum distance allowed requirement */
+		/* 2a. Has the current best-so-far predecessor for this DP cell
+		   (pg->Ga[etype][frame][spliceclass]) fallen out of range, i.e.
+		   is it now further back than MaxDist allows from this exon's
+		   acceptor? (The "+ evidence - evidence" term nudges the
+		   distance bound by +/-1 when exactly one side is an
+		   evidence/annotation exon, to match their coordinate
+		   convention against predicted signal coordinates.) If so it
+		   can no longer be trusted, so re-derive the best predecessor
+		   for every (remainder,dclass) cell by walking pg->d[etype]
+		   backward from the current scan position (j) down to the
+		   MaxDist boundary, keeping the best-scoring candidate seen
+		   in each cell along the way. */
 		if ((MaxDist != INFI) &&
 		    (pg->Ga[etype][frame][spliceclass]->Strand !='*') &&
-		    (pg->Ga[etype][frame][spliceclass]->Donor->Position 
-		     + 
-		     pg->Ga[etype][frame][spliceclass]->offset2) 
-		    < 
+		    (pg->Ga[etype][frame][spliceclass]->Donor->Position
+		     +
+		     pg->Ga[etype][frame][spliceclass]->offset2)
+		    <
 		    ((E+i)->Acceptor->Position + (E+i)->offset1)
 		    + ((E+i)->evidence - pg->Ga[etype][frame][spliceclass]->evidence)
-		    - MaxDist) 
+		    - MaxDist)
 		  {
 		    /* loop backward searching another best gene matching MAX distance */
-		    pg->Ga[etype][frame][spliceclass] = pg->Ghost; 
+		    pg->Ga[etype][frame][spliceclass] = pg->Ghost;
 		    j2 = j-1;
-		    while (j2>=0 && j2 < pg->km[etype]  && 
-			   ((pg->d[etype][j2]->Donor->Position 
+		    while (j2>=0 && j2 < pg->km[etype]  &&
+			   ((pg->d[etype][j2]->Donor->Position
 			     + pg->d[etype][j2]->offset2)
-			    >= 
+			    >=
 			    ((E+i)->Acceptor->Position + (E+i)->offset1)
 			    + ((E+i)->evidence - pg->d[etype][j2]->evidence)
 			    - MaxDist))
@@ -144,7 +209,7 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 			remainder = pg->d[etype][j2]->Remainder;
 			dclass = pg->d[etype][j2]->Donor->class;
 
-			if ((pg->d[etype][j2]->GeneScore > 
+			if ((pg->d[etype][j2]->GeneScore >
 			     pg->Ga[etype][remainder][dclass] -> GeneScore)
 			    ){
 			  pg->Ga[etype][remainder][dclass] = pg->d[etype][j2];
@@ -152,15 +217,21 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 			j2--;
 		      }
 		  }
-			  
-		/* Loop forward: One scan over each donor-sort array */
-		/* while minimum distance allowed requirement is OK */
-		/* Update best partial genes between current and previous exon */
+
+		/* 2b. Forward scan: pg->d[etype] is sorted by Donor position, and
+		   je[etype] (loaded into j above) remembers where the LAST call
+		   left off, so this only ever advances -- each exon in
+		   pg->d[etype] is folded into Ga exactly once, keeping the
+		   whole outer loop linear in the total number of exons. Any
+		   newly-reachable exon (Donor position now within MinDist of
+		   this exon's acceptor) updates the best-partial-gene table
+		   cell for its own (remainder,dclass), which is how later
+		   exons will find it as a predecessor. */
 		while(j < pg->km[etype] &&
-		      ((pg->d[etype][j]->Donor->Position 
+		      ((pg->d[etype][j]->Donor->Position
 			+ pg->d[etype][j]->offset2)
-		       <= 
-		       ((E+i)->Acceptor->Position + (E+i)->offset1) 
+		       <=
+		       ((E+i)->Acceptor->Position + (E+i)->offset1)
 		       + ((E+i)->evidence - pg->d[etype][j]->evidence)
 		       - MinDist)
 		      )
@@ -187,10 +258,15 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 		      }
 		    j++;
 		  }
-		pg->je[etype] = j;
+		pg->je[etype] = j; /* remember the cursor for the next call */
 
-		/* Assembling the exon with the best compatible gene before it */
+		/* 2c. Assembling the exon with the best compatible gene before it */
 		/* Verify group rules if there are evidence exons (annotations) */
+		/* If this exon's acceptor is a minor (U12) site being joined to a
+		   major (U2) donor, hold the join to a stricter combined score
+		   threshold (unless either side is evidence-backed, which is
+		   trusted outright); U12-to-U12 joins skip this check entirely
+		   (the else branch below, thresholdmet stays 1). */
 		if (current_exon_is_u12){
 		  if (pg->Ga[etype][frame][spliceclass]->Donor->class != U2){				  
 		    if((((pg->Ga[etype][frame][spliceclass]->Donor->Score + (E+i)->Acceptor->Score) > U12_SPLICE_SCORE_THRESH)
@@ -206,15 +282,26 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 		    } else {
 		      thresholdmet = 0;
 		    }
-		  } else {			  
+		  } else {
+		    /* A minor-spliceosome acceptor can never follow a major (U2)
+		       donor without clearing the threshold check above. */
 		    thresholdmet = 0;
-		  }			  	
+		  }
 		} else {
+		  /* Current exon is a normal (U2) acceptor: reject only if the
+		     candidate predecessor's donor is itself minor-spliceosome
+		     (a U12 donor must be matched with a U12 acceptor). */
 		  if (pg->Ga[etype][frame][spliceclass]->Donor->class != U2){
 		    thresholdmet = 0;
 		  }
 		}
 
+		/* Group rule: if this gene-model class is BLOCKing, the two
+		   exons must share the same evidence Group (or both be
+		   NOGROUP) to be joined -- keeps predictions from mixing
+		   incompatible annotation sources. Then require that joining
+		   actually improves this exon's score, and that the U2/U12
+		   threshold above was met. */
 		if ((!(strcmp(pg->Ga[etype][frame][spliceclass]->Group,(E+i)->Group))
 		     || gp->block[etype] == NONBLOCK)
 		    &&
@@ -224,12 +311,20 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 		    )
 		  {
 			  
+		    /* Introns are pure connectors (no sequence of their own to
+		       join across a codon boundary): just inherit the predecessor's
+		       split-codon flags unchanged rather than merging them. */
 		    if (!strcmp((E+i)->Type,sINTRON)||!strcmp((E+i)->Type,sUTRINTRON)||!strcmp((E+i)->Type,sUTR5INTRON)||!strcmp((E+i)->Type,sUTR3INTRON)){			    
 		      (E+i)->GeneScore = pg->Ga[etype][frame][spliceclass]->GeneScore + (E+i)->Score;
 		      (E+i)->PreviousExon = pg->Ga[etype][frame][spliceclass];
 		      (E+i)->lValue = pg->Ga[etype][frame][spliceclass]->lValue;
 		      (E+i)->rValue = pg->Ga[etype][frame][spliceclass]->rValue;
 		    }else
+		      /* Recursive/zero-length splice site: acceptor and donor are
+			 adjacent, so no real coding bases sit between them either --
+			 join unconditionally like the intron case above, but also
+			 carry over Frame/Remainder since this exon added none of
+			 its own. */
 		      {if (RSS && ((E+i)->Donor->Position == (E+i)->Acceptor->Position -1)){
 			  (E+i)->GeneScore = pg->Ga[etype][frame][spliceclass]->GeneScore + (E+i)->Score;
 			  (E+i)->PreviousExon = pg->Ga[etype][frame][spliceclass];
@@ -239,6 +334,13 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 			  (E+i)->rValue = pg->Ga[etype][frame][spliceclass]->rValue;
 			}else{
 
+			 /* Ordinary coding exon: joining splits a codon across the
+			    predecessor's Donor and this exon's Acceptor. lValue/rValue
+			    (set by ComputeStopInfo) encode which partial codon each
+			    side's split leaves behind; if the two halves would spell a
+			    stop codon (TAA/TAG/TGA) once joined, skip the join here and
+			    keep this exon's standalone score from the top of the loop
+			    instead. */
 			 if (((E+i)->Strand == '+') && 
 			     ((pg->Ga[etype][frame][spliceclass]->rValue == 1 && (E+i)->lValue == 1)
 			      ||
@@ -270,7 +372,11 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
 		  }
 	      }
 
-	    /* Updating the best gene assembled (final gene) */
+	    /* Updating the best gene assembled so far for the whole locus:
+	       track the single highest-scoring exon reached by any chain --
+	       except a chain ending on a bare intron/UTR-intron (i.e. nothing
+	       real was ever attached past the Ghost) can't stand alone as a
+	       complete gene. */
 	    if ((((E+i)->GeneScore) > (pg->GOptim -> GeneScore))){
 	      if (((E+i)->PreviousExon->Strand == '*')&&(!strcmp((E+i)->Type,sINTRON) || !strcmp((E+i)->Type,sUTRINTRON) || !strcmp((E+i)->Type,sUTR5INTRON) || !strcmp((E+i)->Type,sUTR3INTRON))){
 	      }else{
@@ -281,12 +387,15 @@ void genamic(exonGFF* E, long nExons, packGenes* pg, gparam* gp)
       }
     }
 
-  /* 3. Undo the change between frame and remainder */
+  /* 3. Undo the frame/remainder swap from the prologue, on both this
+     fragment's exons and the DP state carried over from the previous
+     fragment (Db is SwitchFramesDa's matching undo), so downstream code
+     (CookingGenes, Translate, ...) sees the normal forward-reading values. */
   if (GENEID)
     {
       /* Exons predicted in the current fragment of sequence */
       SwitchFrames(E,nExons);
-	  
+
       /* Only changing exons predicted in the last fragment of sequence */
       SwitchFramesDb(pg,gp->nclass);
     }


### PR DESCRIPTION
First pass of the redefined readability target: **explain, don't rename**. No identifier is touched anywhere in this PR -- verified by stripping all comments from both the old and new version of every touched file and diffing the result: byte-identical in all seven files, every commit.

### `src/genamic.c` -- the gene-assembly DP
A file-header comment explaining the algorithm (`Ga`/`d`/`km`/`je`, gene-model classes vs. exon types, `UC`/`DE`/`md`/`Md`/`block`), plus inline comments through the per-exon loop: the `MaxDist` backward-recovery scan, the forward `MinDist` scan and `je` cursor (why the loop stays linear), U12/U2 threshold gating, evidence-group blocking, the intron/RSS passthrough cases, and the stop-codon-avoidance join logic (`lValue`/`rValue`).

### `include/geneid.h` -- the core structs
Field-by-field comments on `site`, `exonGFF`, `packSites`, `packExons`, `packGenes`, `dumpNode`, `dumpHash`, `profile`, and `paramexons`.

### `src/SetRatios.c`
Clarifies the post-growable-arrays reality: `NUMSITES`/`NUMEXONS` are now only a rough estimate (`beggar.c`'s `-B` report), while `MAXBACKUP{SITES,EXONS}` are still real.

### `src/ScoreExons.c` -- the coding-potential path
A file-header comment on the two-pass scheme (`MarkovScan`'s accumulated-sum pre-scan, then `Score()`'s O(1) table-difference lookup), plus comments on `OligoToInt`, `ScoreHSPexon`/`GetReadCount`, and `Score()`'s two-cutoff filter-and-compact behavior. (Also fixed a stale copy-pasted comment on `GetReadCount` that mislabeled it as a homology function.)

### `src/readparam.c`
A top comment on `SetProfile` explaining the N-containing table-entry synthesis (averaging the pure-ACGT variants read from the file); a top comment on `ReadProfileSpliceSites` describing its header-driven optional/required profile structure and how U12 support gets switched on. Also fixed a copy-paste bug: eight optional score-tuning items were all mislabeled `"1. Read ..."` -- relabeled each with what it actually reads.

### `src/CookingGenes.c`
A top comment on `CookingInfo` explaining that genamic's DP leaves one long `PreviousExon` chain spanning potentially many genes back to back, and how the walk splits it into per-gene records.

### `src/Translate.c`
A comment on `Translate()`'s `fra`/`rmd` parameters, and a top comment on `TranslateGene` explaining the split-codon-at-exon-junction stitching (`currFrame`/`currRmd` + `codon[]`, and the gene-end special case `rmdProt`).

### Verification
- Regression suite **5/5 byte-identical**, both commits.
- Clean build, **no warnings**.
- Comment-stripped diff of every touched file is **byte-identical** to `dev` -- proof this is comments/whitespace only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)