### PR TITLE
Comment the dumpster logic, Output/PrintExons GFF assembly, and Build site-scoring

### DIFF
--- a/src/BackupGenes.c
+++ b/src/BackupGenes.c
@@ -27,6 +27,26 @@
 
 /*  $Id: BackupGenes.c,v 1.11 2011-01-13 11:06:16 talioto Exp $  */
 
+/* geneid processes a long sequence one LENGTHSi-sized fragment at a time
+ * (see manager.c/geneid.c), but genamic's DP state (packGenes: Ga/d/km/je,
+ * see genamic.c) and the exons it points into are only guaranteed to live
+ * for the CURRENT fragment -- the next fragment's Build.../SortExons calls
+ * reuse/overwrite those arrays. This file is what carries a gene assembly
+ * IN PROGRESS across that boundary:
+ *   BackupGenes()   copies every live "best partial gene" cell (all of
+ *                   pg->Ga, plus GOptim) into the dumpster, so they survive
+ *                   the next fragment's array reuse.
+ *   BackupArrayD()  does the same for pg->d[] (the sort-by-donor arrays),
+ *                   but only the TAIL of each one that might still be
+ *                   needed as a predecessor by a FUTURE exon -- see its own
+ *                   comment below for the trimming logic.
+ * Both funnel through backupGene()/backupExon(), which deep-copy an exon
+ * (and its Acceptor/Donor sites) into the dumpster's chunked, stable-address
+ * storage (see BackupGenes.c's dumpExonAt/dumpSiteAt and the packDump
+ * comment in geneid.h) and follow PreviousExon recursively so the WHOLE gene
+ * chain behind a kept exon survives too, deduplicated via the dump hash so
+ * a chain shared by several kept exons is only copied once. */
+
 #include "geneid.h"
 
 /* Maximum allowed number of sites and exons to save */
@@ -147,6 +167,16 @@ exonGFF* backupExon(exonGFF* E, exonGFF* Prev, packDump* d)
 }
 
 /* Saving all about a gene: exons, sites, properties */
+/* Ensures E (and, recursively, its whole PreviousExon chain) has a backed-up,
+   dumpster-resident copy, and returns a pointer to that copy (NOT to E --
+   E itself belongs to the current fragment's soon-to-be-reused arrays).
+   Returns E itself only in the Ghost/placeholder base case (Strand '*'),
+   since the Ghost is a fixed, never-reused sentinel that needs no backup.
+   The hash lookup makes this idempotent and shared: if E was already backed
+   up (e.g. via a different Ga cell, or a previous call to BackupArrayD/
+   BackupGenes), its existing dumpster copy is reused instead of duplicating
+   it -- so a long shared chain only gets copied once no matter how many
+   live cells still reference it. */
 exonGFF* backupGene(exonGFF* E, packDump* d)
 {
   exonGFF* PrevExon;
@@ -154,22 +184,26 @@ exonGFF* backupGene(exonGFF* E, packDump* d)
 
   /* Ghost exon doesn't need backup */
   if (E->Strand == '*') /* ||(E->Strand != '+')||(E->Strand != '-')) */
-    ResExon = E; 
+    ResExon = E;
   else
 	{
 	  /* Ckeckpoint to discover if exon is already in the dumpster */
 	  ResExon  = (exonGFF*) getExonDumpHash(E, d->h);
-	  
+
 	  /* New exon: save it and insert into the hash table */
 	  if (ResExon == NULL)
 		{
+		  /* Recurse toward the gene's start FIRST, so PrevExon is already
+		     the dumpster-resident copy by the time backupExon links to it
+		     (a backed-up exon's PreviousExon must itself point into the
+		     dumpster, never back into the current fragment's arrays). */
 		  PrevExon = backupGene(E->PreviousExon,d);
 		  ResExon = backupExon(E,PrevExon,d);
 
 
 		  d->ndumpExons = d->ndumpExons + 1;
 		  /* adding this exon at hash table */
-		  setExonDumpHash(ResExon, d->h);       
+		  setExonDumpHash(ResExon, d->h);
 		}
 	  /* if this exon exists, finish backup gene */
 	}
@@ -177,6 +211,12 @@ exonGFF* backupGene(exonGFF* E, packDump* d)
 }
 
 /* It saves the information about partial genes (packGenes) */
+/* Backs up every currently-live "best partial gene" DP cell -- all of
+   Ga[class][frame][spliceclass] plus the running optimum GOptim -- so the
+   next fragment can pick up gene assembly where this one left off (see
+   this file's header comment); note Ga/GOptim themselves are NOT reset
+   here, they keep pointing at these same exons, just now via their
+   dumpster-resident copies. */
 void BackupGenes(packGenes* pg, int nclass, packDump* d)
 {
   int i,j,k;
@@ -193,6 +233,30 @@ void BackupGenes(packGenes* pg, int nclass, packDump* d)
 }
 
 /* It saves information about d-exons: exons needed the next iteration */
+/* Called at the END of a fragment, once we know accSearch (the position the
+   NEXT fragment will start scanning acceptors from): shrinks every
+   pg->d[class] down to just the tail that could still be needed as a
+   predecessor once processing resumes, backing up (into the dumpster) and
+   discarding everything else so the array doesn't grow unboundedly across
+   the whole sequence. Three passes per class, mirroring genamic.c's own
+   je/km bookkeeping:
+     1. Any exon between the old je cursor and accSearch-MinDist is now
+        definitely within range of a future acceptor and will never be
+        looked at again by genamic's forward scan -- so fold it into Ga
+        here (exactly like genamic.c's own forward-scan update) before it
+        potentially gets backed up and its d[] slot reused below.
+     2. Walk backward from there to find jMaxdist: the earliest index whose
+        Donor position is still within MaxDist of accSearch (or, if this
+        class has no max-distance limit, jMaxdist = jUpdate -- nothing
+        before jUpdate can matter any more). Everything at or after
+        jMaxdist might still be reachable by a future exon in genamic's
+        MaxDist backward-recovery scan (see genamic.c step 2a) and so must
+        be kept; everything before it never can be and is dropped.
+     3. Back up that surviving tail (jMaxdist..km) into the dumpster, then
+        compact it down to the front of pg->d[i] (index 0..km-jMaxdist) so
+        the array doesn't grow forever -- BuildSort will append the next
+        fragment's exons right after it. je is shifted by the same amount
+        so it still points at the same logical exon after the compaction. */
 void BackupArrayD(packGenes* pg, long accSearch,
                   gparam* gp, packDump* dumpster)
 {
@@ -205,7 +269,7 @@ void BackupArrayD(packGenes* pg, long accSearch,
   short remainder;
   short donorclass;
   char mess[MAXSTRING];
-  
+
   /* Traversing sort-by-donor array to save some genes (assembling rules) */
   /* These exons have to be beyond the point accSearch (preserve ordering) */
   for(i=0; i < gp->nclass ; i++)
@@ -214,13 +278,17 @@ void BackupArrayD(packGenes* pg, long accSearch,
       j = pg->je[i];
       MaxDist = gp->Md[i];
       MinDist = gp->md[i];
-      
+
       /* 1. Update best genes using remaining exons before accSearch - md */
       while(j < pg->km[i] &&
 			((pg->d[i][j]->Donor->Position + pg->d[i][j]->offset2)
 			 <=
 			 accSearch - MinDist))
 		{
+		  /* Ga is indexed by (frame,splice-class) on the FORWARD strand but
+		     by (remainder,acceptor-class) on the reverse strand -- same
+		     axes genamic.c uses, just swapped per-strand like SwitchFrames
+		     does for Frame/Remainder themselves. */
 		  if (pg->d[i][j]->Strand == cFORWARD){
 			remainder = pg->d[i][j]->Remainder;
 			donorclass = pg->d[i][j]->Donor->class;
@@ -228,29 +296,29 @@ void BackupArrayD(packGenes* pg, long accSearch,
 			remainder = pg->d[i][j]->Frame;
 			donorclass = pg->d[i][j]->Acceptor->class;
 		  }
-		  
+
 		  if (pg->d[i][j]->GeneScore > pg->Ga[i][remainder][donorclass]->GeneScore)
 			pg->Ga[i][remainder][donorclass] = pg->d[i][j];
 		  j++;
 		}
       jUpdate = j;
-      
+
       /* 2. Copy exons needed to recompute maximum distance requirement */
-      if (MaxDist == INFI)      
+      if (MaxDist == INFI)
 		jMaxdist = jUpdate;
       else
 		{
 		  /* Loop back until reaching first exon out of range: acc-dMax */
 		  j = jUpdate;
-		  while (j>=0 && j < pg->km[i]  && 
-				 ((pg->d[i][j]->Donor->Position 
+		  while (j>=0 && j < pg->km[i]  &&
+				 ((pg->d[i][j]->Donor->Position
 				   + pg->d[i][j]->offset2)
-				  >= 
+				  >=
 				  accSearch - MaxDist))
 			j--;
 		  jMaxdist = (j < pg->km[i])? j+1 : j;
 		}
-      
+
       /* 3. To save the set of best genes finished in any selected d-exon */
       for(j = jMaxdist; j < pg->km[i]; j++)
 		{
@@ -260,7 +328,7 @@ void BackupArrayD(packGenes* pg, long accSearch,
       pg->km[i] = pg->km[i] - jMaxdist;
       pg->je[i] = jUpdate - jMaxdist;
     }
-  
+
   sprintf(mess,"%ld d-genes saved(%ld real exons)",
 		  nBackups, dumpster->h->total);
   printMess(mess);

--- a/src/BuildAcceptors.c
+++ b/src/BuildAcceptors.c
@@ -137,6 +137,18 @@ float ComputeU2PPTProfile(char* s,
 }
 
 /* Search for acceptor splice sites, using additional profiles */
+/* Scans every candidate window in [l1,l2] for a U2 acceptor site, using the
+   same order-0/1/2 PWM/Markov scoring as ScoreExons.c's GetSitesWithProfile
+   (see that function's comment for how the order cases work; here they are
+   computed directly per-window rather than pre-scanned, since a whole
+   fragment's worth of acceptor windows is not reused the way coding-
+   potential is). Two cutoffs gate a candidate: `cutoff` (== p->cutoff for
+   U2; BuildU12Acceptors.c relaxes it for U12 acceptors) on the RAW signal
+   score alone, cheaply skipping the expensive branch-point/PPT lookups
+   (ComputeU2BranchProfile/ComputeU2PPTProfile -- see the profile struct
+   comment in geneid.h for acc_context/dist/opt_dist/penalty_factor) for
+   windows that could never pass; then p->cutoff again on the COMBINED
+   score (signal + branch point) before actually saving the site. */
 long  BuildAcceptors(char* s,
 		     short class,
 		     char* type,

--- a/src/BuildDonors.c
+++ b/src/BuildDonors.c
@@ -36,6 +36,16 @@ extern int UTR;
 
 
 
+/* Scans every candidate window in [l1,l2] for a donor site, using the same
+   order-0/1/2 PWM/Markov scoring as ScoreExons.c's GetSitesWithProfile
+   (see that function's comment). In UTR mode, PeakEdgeScore's local
+   RNA-seq coverage-change score (a rise vs. drop detector, using the same
+   accumulated-sum external->sr array as ScoreHSPexon in ScoreExons.c) is
+   SUBTRACTED here but ADDED in BuildAcceptors.c: a donor should sit where
+   coverage drops (exon -> intron), which PeakEdgeScore reports as
+   negative, so subtracting it rewards a real drop; an acceptor should sit
+   where coverage rises (intron -> exon), reported as positive, so adding
+   rewards that instead. */
 long  BuildDonors(char* s,
 		  short class,
 		  char* type,

--- a/src/Output.c
+++ b/src/Output.c
@@ -141,6 +141,16 @@ void OutputHeader(char* locus, long l)
 }
 
 /* Display some predictions results according to the options selected */
+/* This is the RAW per-category prediction dump (one block per signal/exon
+   type), controlled by the individual -a/-b/-d/-e/-f/-i/-s/-t/-x/-z flags
+   (see readargv.c's printHelp): S*P flags are "print this SITE category"
+   (SFP=start, SDP=donor, SAP=acceptor, STP=stop), E*P flags are "print this
+   EXON category" (EFP=first/initial, EIP=internal, ETP=terminal, ESP=
+   single, EOP=orf, EXP=all exons together). None of these are needed for
+   normal use -- they exist for inspecting intermediate predictions, e.g.
+   while tuning a parameter file. The actual GENE predictions (the format
+   most users want) come from OutputGene below, which always runs and is
+   unrelated to these flags. */
 void Output(packSites* allSites,
             packSites* allSites_r,
             packExons* allExons,
@@ -270,6 +280,9 @@ void Output(packSites* allSites,
 }
 
 /* Print best genes using selected format */
+/* The real output most users want: recovers and prints the actual gene
+   structure(s) from the DP's optimal solution (pg->GOptim's PreviousExon
+   chain) via CookingGenes -- see that file for the recovery/printing walk. */
 void OutputGene(packGenes* pg,
                 long nExons,
                 char* Locus,

--- a/src/PrintExons.c
+++ b/src/PrintExons.c
@@ -43,6 +43,16 @@ extern float MRM;
 
 
 /* Print a predicted exon from a list of exons */
+/* This is the per-exon printer behind Output()'s raw per-category dump (see
+   Output.c's comment on the S*P/E*P debug flags) -- ONE exon, in whichever
+   of GFF3/GFF2/geneid's own default format was selected. The GFF3 branch
+   builds up a ";key=value" attribute string per exon type, reporting the
+   individual signal/coding-potential/homology/RNA-seq sub-scores that sum
+   into e->Score (see ScoreExons.c's Score()); which site plays which role
+   (start/acceptor/donor) depends on both exon type AND strand, because on
+   the reverse strand the Acceptor and Donor site pointers are swapped
+   relative to reading direction -- hence the forward/reverse blocks below
+   mirror each other with Acceptor and Donor exchanged. */
 void PrintExon(exonGFF *e, char Name[], char* s, dict* dAA, char* GenePrefix)
 {
   char sAux[MAXAA];
@@ -272,6 +282,13 @@ void PrintExons (exonGFF *e,
 }
 
 /* Print a predicted exon from a assembled gene: gff/geneid format */
+/* Prints ONE feature (CDS if coding, UTR otherwise) of an already-assembled
+   gene (called from CookingGenes.c's PrintGene walk), with the same
+   per-signal attribute assembly pattern as PrintExon above. AA1/AA2 are
+   this feature's first/last amino-acid indices as recorded in tAA (set by
+   Translate.c's TranslateGene) -- see the AA1/AA2 usage below for why they
+   need a direction flip on the '+' strand before they are valid "protein
+   N-to-C" coordinates for the GFF3 Target= attribute. */
 void PrintGCDS(exonGFF *e,
                 char Name[],
                 char* s,
@@ -419,6 +436,13 @@ void PrintGCDS(exonGFF *e,
 	      strlen(GenePrefix)>0?"-" : "",
 	      Name,
 	      ngen,
+	      /* TranslateGene fills tAA by walking the gene Terminal->First on
+	         the '+' strand (see Translate.c) -- the OPPOSITE of N-to-C
+	         reading order -- so AA1/AA2 there are counted from the C-
+	         terminus; flipping via nAA-AA2/nAA-AA1 converts them to the
+	         N-to-C protein coordinates Target= expects. On '-' strand,
+	         TranslateGene's First->Terminal walk is already N-to-C, so
+	         AA1/AA2 are used as-is. */
 	      (e->Strand=='+')? nAA-AA2+COFFSET : AA1,
 	      (e->Strand=='+')? nAA-AA1+COFFSET : AA2,
 	      attribute);
@@ -733,6 +757,12 @@ void PrintGmRNA(exonGFF *s,
 }
 
 /* Print a predicted intron from an assembled gene: gff/geneid format */
+/* Introns aren't stored as their own exonGFF records in a coding gene (only
+   the coding exons on either side are, joined via PreviousExon) -- this
+   reconstructs an intron's own boundaries from its flanking donor exon d
+   and acceptor exon a, picks U2 vs U12(gtag/atac) from the donor's
+   subtype, and derives phase from the remainder (which side's Remainder to
+   use depends on strand, same swap pattern as elsewhere in this file). */
 void PrintGIntron(exonGFF *d,
 		  exonGFF *a,
 		  char Name[],
@@ -854,7 +884,13 @@ void PrintGIntron(exonGFF *d,
   }
 
 }
-/* Print a predicted intron from an assembled gene: gff/geneid format */
+/* Print one GFF3 exon feature line, possibly MERGING 1-3 consecutive
+   fused segments (e.g. a coding exon fused with an adjacent half-UTR or
+   zero-length piece via PreviousExon) into a single combined feature: given
+   `a` (the last/rightmost segment) and nSegments, walks nSegments-1 steps
+   back via PreviousExon to `d` (the first/leftmost segment), sums each
+   segment's Score/PartialScore/HSPScore/R, and reports the outermost
+   start (d's Acceptor) to end (a's Donor) as one feature's coordinates. */
 void PrintGExon(  exonGFF *a,
 		  int nSegments,
 		  char Name[],


### PR DESCRIPTION
## Comment the dumpster logic, Output/PrintExons GFF assembly, and Build site-scoring

Continuing the commenting sweep (no renames -- verified by stripping comments from both old and new version of every touched file and diffing: byte-identical in all five).

### `src/BackupGenes.c` -- the dumpster logic
A file-header comment explaining WHY a gene assembly in progress needs backing up at all (genamic's DP state and the exons it points into don't survive past the current fragment). Comments on `backupGene` (the recursive, hash-deduplicated `PreviousExon`-chain copy), `BackupGenes` (backs up every live `Ga` cell + `GOptim`), and `BackupArrayD` (the dense one -- trims each `pg->d[class]` down to just the tail a future exon could still reach, folding the rest into `Ga` first, then backing up and compacting the surviving tail).

### `src/Output.c`
Explains the `S*P`/`E*P` per-category debug-dump flags (`Output()`) versus the actual gene output path (`OutputGene()`, via `CookingGenes`).

### `src/PrintExons.c`
Comments on `PrintExon`/`PrintGCDS`'s per-signal GFF3 attribute assembly (and why forward/reverse swap `Acceptor`/`Donor` roles), `PrintGCDS`'s `AA1`/`AA2` direction-flip for the `Target=` protein coordinates (ties into `Translate.c`'s `tAA`), `PrintGIntron`'s boundary reconstruction from flanking exons, and `PrintGExon`'s 1-3 segment merging. Also fixed a copy-paste comment bug: `PrintGExon` was documented as `"Print a predicted intron..."` (copied from `PrintGIntron` right above it).

### `src/BuildAcceptors.c` / `src/BuildDonors.c`
Cross-reference `ScoreExons.c`'s `GetSitesWithProfile` for the shared order-0/1/2 PWM/Markov scoring pattern, explain `BuildAcceptors`' two-stage cutoff (raw signal, then combined with branch point), and the `PeakEdgeScore` sign asymmetry between donors (subtract, rewarding a coverage drop) and acceptors (add, rewarding a coverage rise).

### Verification
- Regression suite **5/5 byte-identical**.
- Clean build, **no warnings**.
- Comment-stripped diff of every touched file is **byte-identical** to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)