### PR TITLE
Comment remaining utility modules: gene model, stop codons, dictionary, dumpster hash, arg parsing

### DIFF
--- a/src/Dictionary.c
+++ b/src/Dictionary.c
@@ -51,7 +51,12 @@ int f(char s[])
   return(total);
 }
 
-/* Assign a number-key to the new word and store it */
+/* Assign a number-key to the new word and store it. Keys are handed out in
+ * first-seen order (0, 1, 2, ...) via d->nextFree, so e.g. ReadGeneModel.c's
+ * exon-type ids are just "the order each type string first appeared in the
+ * .gm file". Lookup is by exact string match only -- no case-folding, so a
+ * typo'd or mis-cased type string silently becomes a brand-new key instead
+ * of an error (see the pitfalls note above ReadGeneModel). */
 int setkeyDict(dict* d, char s[])
 {
   int key;
@@ -179,7 +184,11 @@ void freeDict(dict* d)
   free(d); 
 }
 
-/* Binding the amino acid (key) to the new codon (word) */
+/* Second, unrelated use of the same hash-table structure: instead of an
+ * auto-assigned sequential key, here the caller supplies the key directly
+ * (the one-letter amino acid code), keyed by codon string. Used to build
+ * the genetic-code table for translation, separate from any feature-type
+ * dictionary built by setkeyDict. */
 void setAADict(dict* d, char s[], char aA)
 {
   node* p;

--- a/src/DumpHash.c
+++ b/src/DumpHash.c
@@ -46,6 +46,14 @@ void resetDumpHash(dumpHash* h)
   h->total = 0;
 }
 
+/* This hash table is the "dumpster" cross-referenced from BackupGenes.c:
+ * as backupGene() recursively walks a gene's PreviousExon chain, the same
+ * exon can be reached from more than one path (it may be shared by several
+ * partial genes). setExonDumpHash/getExonDumpHash let backupGene recognize
+ * an exon it already copied (by acceptor/donor position, frame, strand,
+ * site class and Type -- not by pointer) and reuse that copy instead of
+ * duplicating it, keeping the backup array's memory bounded. */
+
 /* Hash Function:: String -> Integer between 0..MAXDUMPHASH-1 */
 long fDump(exonGFF* E)
 {

--- a/src/GetStopCodons.c
+++ b/src/GetStopCodons.c
@@ -32,6 +32,16 @@
 /* Function TRANS: char -> integer such that A=0, C=1, G=2 and T/U=2 */
 extern int TRANS[];
 
+/* Scans [l1,l2) for in-frame TAA/TAG/TGA stop codons and scores the region
+ * around each with the order-0/1/2 Markov profile p, exactly like the
+ * splice-site scan in ScoreExons.c's GetSitesWithProfile -- the three
+ * order branches below (PWM, order-1 dinucleotide, order>1 via OligoToInt)
+ * are the same technique, just keyed on a fixed codon match instead of a
+ * splice consensus. Part 1 handles the profile's left edge (only when this
+ * is the very first fragment, l1==0); the main loop is Part 2; Part 3 mops
+ * up any stops so close to the fragment's right edge that the profile
+ * window would run off the end (scored 0, since there isn't enough
+ * downstream context to compute a real score). */
 long GetStopCodons(char* s,
                    profile* p,
                    site** scP, long* capP,

--- a/src/ReadGeneModel.c
+++ b/src/ReadGeneModel.c
@@ -29,7 +29,11 @@
 
 #include "geneid.h"
 
-/* Replicating the gene model rules for every isochore */
+/* The gene model (isochores[0]->D/nc/ne/UC/DE/md/Md/block/nclass) is only  */
+/* ever loaded once, from the .gm/param file, into the first isochore's     */
+/* gparam struct (see ReadGeneModel below). Every other isochore uses the   */
+/* exact same assembly rules, so this just points their pointers/arrays at  */
+/* isochore 0's copy instead of re-parsing or duplicating the data.         */
 void shareGeneModel(gparam** isochores, int nIsochores)
 { 
   int i,j,k;
@@ -66,9 +70,56 @@ void shareGeneModel(gparam** isochores, int nIsochores)
     }
 }
 
-/* Loading the gene model rules to build correct genes */
-/* Every rule is identified by the gm line where it has been found */
-/* Returns how many rules have been loaded right */
+/* Loading the gene model rules to build correct genes.
+ *
+ * The gene model section of the parameter file lists, one per (non-comment,
+ * non-blank) line, the legal ways an already-built exon of one type may be
+ * followed by an exon of another type to form part of a gene. Each such
+ * line is a "rule", and the rule's line number (0-based, in file order) IS
+ * its class id ("nlines" below) -- the same class id that genamic.c's DP
+ * uses to index Ga[class]/d[class] and that this function's own md/Md/
+ * block arrays are indexed by. There is no separate class-name column:
+ * the class is simply "the n-th rule in the file".
+ *
+ * Rule syntax (columns separated by literal space characters):
+ *
+ *   UC1:UC2:(...):UCn   DE1:DE2:(...):DEm   dMin:dMax   [block]
+ *
+ * - Column 1 (UC, "upstream compatible"): colon-separated list of exon
+ *   types that may end a partial gene being extended INTO this class, i.e.
+ *   the predecessor exon's type must appear here for genamic to consider
+ *   this rule at all (see UC[][] below, and its use as gp->UC in genamic.c).
+ * - Column 2 (DE, "downstream equivalent"): colon-separated list of exon
+ *   types that may be the new exon completing this class once the distance
+ *   test passes (see DE[][] below, gp->DE in genamic.c).
+ * - Column 3: the allowed gap between the two exons, as dMin:dMax
+ *   (introns use this as the intron-length window). Use the literal string
+ *   SINFI ("Infinity", case-sensitive) in place of dMax to mean unbounded.
+ * - Column 4 (optional): if this column is present AT ALL, its content is
+ *   never inspected -- any token here (traditionally "block") switches this
+ *   rule's block[] entry to BLOCK, meaning genamic must not let the two
+ *   exons belong to different evidence Groups (group checkpoint). Omitting
+ *   the column entirely leaves it NONBLOCK.
+ *
+ * Common parameter-file pitfalls with this format:
+ * - Columns must be separated by literal space characters, not tabs --
+ *   strtok(line," ") only splits on ' ', so a tab between columns leaves
+ *   the whole line stuck together as line1 and triggers the "Wrong format"
+ *   error below (line2/line3 come back NULL).
+ * - A line is only treated as a comment if '#' or '\n' is the very FIRST
+ *   character (line[0]). Leading whitespace before a '#' is NOT recognized
+ *   as a comment and will instead be parsed as a (malformed) rule.
+ * - Feature type names in columns 1-2 (e.g. "First+", "Internal-",
+ *   "Single+", "Terminal-") are matched against the shared type dictionary
+ *   by exact, case-sensitive string comparison (setkeyDict/getkeyDict). A
+ *   typo or wrong case does NOT raise an error -- it silently registers a
+ *   brand-new, never-produced type, so the rule quietly becomes dead/
+ *   unreachable instead of failing loudly. Copy existing type strings
+ *   rather than retyping them.
+ * - dMax must be either a plain integer or exactly the string SINFI; any
+ *   other non-numeric token there is misread as 0 via atol() with no error.
+ *
+ * Returns how many rules (classes) were loaded. */
 long ReadGeneModel (FILE* file, dict* d,
                     int nc[], int ne[],
                     int UC[][MAXENTRY],
@@ -91,10 +142,7 @@ long ReadGeneModel (FILE* file, dict* d,
   
   char mess[MAXSTRING];
   char *t1;
-  
-  /* Format for gene model rules: 
-     F1:F2:(...):Fn   F1:F2:(...):Fm dmin:dMax  [block] */
-  
+
   /* Input lines from parameter file */
   nlines=0;
   while(fgets(line,MAXLINE,file)!=NULL)
@@ -182,9 +230,15 @@ long ReadGeneModel (FILE* file, dict* d,
   return(nlines);
 }
 
-/* Fill in the Gene Model with artificial lines to build only one gene */
-/* Every rule is identified by the gm line where it has been found */
-/* Returns how many rules have been loaded right */
+/* Used instead of ReadGeneModel when forcing single-gene prediction (-S):
+ * hardcodes the same 4 rules (UC/DE/md/Md/block, same field meanings as
+ * documented above ReadGeneModel) that a "normal" one-gene-per-model .gm
+ * file would express, without needing one on disk. Rules 1-2 chain
+ * First->Internal->Terminal exons (forward/reverse) with the usual
+ * 20:40000 intron window and group blocking; rules 3-4 close the gene off
+ * at the fragment boundaries (sBEGINFWD/sBEGINRVS, sENDFWD/sENDRVS) with
+ * an unbounded (0:Infinity) gap and no group check.
+ * Returns how many rules (always 4) were loaded. */
 long ForceGeneModel (dict* d,
                     int nc[], int ne[],
                     int UC[][MAXENTRY],

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -149,9 +149,22 @@ void printDTD()
         printf("\tscore    CDATA   #REQUIRED>\n\n");
 }
 
+/* Parses the command line via getopt into the external flags declared
+ * above (shared with geneid.c/manager.c), then validates the combination.
+ * The pipeline has two stages that can each be switched off: GENEID (the
+ * ab initio exon-prediction stage, turned off by -O <exons_file>, which
+ * supplies exons directly instead) and GENAMIC (the gene-assembly/DP
+ * stage, turned off by -o, exon-prediction-only mode -- see Output.c's
+ * S*P/E*P flags for what gets printed instead). geneidOpts/genamicOpts
+ * tally how many options were given that only make sense when the
+ * corresponding stage actually runs, so the checks below can reject e.g.
+ * -O combined with an exon-only-stage option. printOptions tallies the
+ * single-feature debug print flags (-b/-d/-a/-e/-f/-i/-t/-s/-x/-z, i.e.
+ * SFP/SDP/SAP/STP/EFP/EIP/ETP/ESP/EXP/EOP), which are mutually exclusive
+ * with XML output (-M) below. */
 void readargv (int argc,char* argv[],
 			   char* ParamFile, char* SequenceFile,
-	       char* ExonsFile, char* HSPFile, char* GenePrefix) 
+	       char* ExonsFile, char* HSPFile, char* GenePrefix)
 {
   int c;
   int error=0;
@@ -331,6 +344,9 @@ void readargv (int argc,char* argv[],
 	}
 
   /* Setup Errors (b): Wrong number of filenames */
+  /* The one non-option argument left after getopt is the input FASTA file,
+     required unless -O already disabled GENEID (gene-assembly-only runs
+     from a pre-supplied ExonsFile need no separate sequence input here). */
   /* Read the name of the input fasta file */
   if (optind < argc)
     {


### PR DESCRIPTION
Final round of the comment-only sweep: the remaining files that hadn't been touched yet (`ReadGeneModel.c`, `GetStopCodons.c`, `Dictionary.c`, `DumpHash.c`, `readargv.c`).

**`ReadGeneModel.c`** gets the most thorough treatment, since the gene-model rule syntax is genuinely easy to get wrong when hand-editing a parameter file:
- Documents the `UC1:UC2:(...) DE1:DE2:(...) dMin:dMax [block]` column format and how each column feeds `genamic.c`'s DP (cross-referencing the class/UC/DE/md/Md/block concepts already documented there in #23).
- Calls out concrete pitfalls: columns must be space-delimited (a tab breaks `strtok(line," ")` and triggers the format error); a line is only a comment if `#`/`\n` is the very first byte (leading whitespace before `#` is not recognized); `SINFI` ("Infinity") is the only valid non-numeric `dMax`; and, most insidious, feature-type strings are matched by exact case-sensitive string compare with no validation (`setkeyDict`), so a typo or wrong case silently creates a dead, unreachable rule instead of erroring.
- Also comments `shareGeneModel` and `ForceGeneModel` (the `-S` hardcoded 4-rule model).

**Other files** (light touch):
- `GetStopCodons.c`: cross-references the same order-0/1/2 Markov-scan technique already documented in `ScoreExons.c`/`BuildAcceptors.c`, and explains the three-part structure (left edge, main scan, right-edge fallback).
- `Dictionary.c`: notes `setkeyDict`'s sequential first-seen key assignment (tying back to `ReadGeneModel.c`'s pitfall about silent typos) and that `setAADict`/`getAADict` are an unrelated second use of the same hash structure for the genetic code table.
- `DumpHash.c`: explains this hash table is the dedup mechanism `BackupGenes.c`'s `backupGene()` relies on to avoid copying the same shared exon twice.
- `readargv.c`: documents the two-stage pipeline (`GENEID`/exon-prediction, `GENAMIC`/gene-assembly) that `-O`/`-o` each disable, and what `geneidOpts`/`genamicOpts`/`printOptions` are tallying for the compatibility checks below.

No renames, no logic changes -- verified via clean build (zero warnings), 5/5 regression suite (byte-identical output), and a comment-stripped diff against `origin/dev` proving each touched file is token-identical aside from comments/whitespace.
