### PR TITLE
Recover unmerged readparam.c/CookingGenes.c/Translate.c comments from PR #23

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -454,19 +454,38 @@ typedef struct s_dict
   int nextFree; 
 } dict;
 
-typedef struct s_profile               
+/* One signal-scoring model (start/donor/acceptor/stop/branch-point/PPT/...),
+   loaded directly from one line + matrix block of the .param file by
+   ReadProfile (see readparam.c); BuildAcceptors/BuildDonors/GetSitesWithProfile
+   apply it to score every candidate window of the sequence. */
+typedef struct s_profile
 {
-  int    dimension;
-  int    offset;
-  float  cutoff;
-  int    order;
-  float  afactor;
+  int    dimension;      /* window width scored, in bases */
+  int    offset;         /* position of the actual signal inside the window
+			     (used to convert a window match back to the
+			     signal's true sequence coordinate) */
+  float  cutoff;         /* candidates scoring below this are rejected */
+  int    order;          /* Markov chain order: 0 = plain PWM, 1 = dinucleotide, 2 = higher order */
+  float  afactor;        /* score rescaling: final = afactor + bfactor*raw_loglikelihood */
   float  bfactor;
+  /* The next four are only used when scanning for a branch point (acceptors
+     with a BranchPointProfile): acc_context bounds how far upstream of the
+     acceptor to search; dist/opt_dist give the minimum and the preferred
+     distance from acceptor to branch point; penalty_factor scales a
+     quadratic penalty for straying from opt_dist (see
+     ComputeU2BranchProfile/ComputeU12BranchProfile in BuildAcceptors.c /
+     BuildU12Acceptors.c). */
   int    acc_context;
   int    dist;
   int    opt_dist;
   float    penalty_factor;
 
+  /* transitionValues[pos][oligomer] holds the log-likelihood for that
+     (order+1)-mer occurring at window position pos (0..dimension-1); the
+     oligomer is encoded by OligoToInt with a 5-letter alphabet (A/C/G/T/N),
+     so dimensionTrans = 5^(order+1) always covers every possible index
+     (unlike ScoreExons.c's coding-potential tables, which use a 4-letter
+     alphabet and must explicitly guard against an out-of-range N). */
   long dimensionTrans;
   float*  transitionValues[PROFILEDIM];
 } profile;
@@ -744,19 +763,26 @@ typedef struct s_packGC
   long* N;
 } packGC;
 
-typedef struct s_paramexons            
+/* Per-isochore, per-exon-type score weights and cutoffs, loaded by
+   ReadIsochore (see readparam.c) into gp->Initial/Internal/Terminal/Single/
+   utr; ScoreExons.c's Score() picks one of these (via `p`) per exon and
+   combines them as:
+     scoreTotal = siteFactor*(site scores) + exonFactor*scoreMarkov
+                  + HSPFactor*scoreHSP  (+ ExonWeight, if it clears both
+                  OligoCutoff and ExonCutoff -- see Score()'s two checkpoints) */
+typedef struct s_paramexons
 {
-  float siteFactor;
+  float siteFactor;   /* weight on the bounding splice/start/stop signal score(s) */
 
-  float exonFactor;
-  float OligoCutoff;
+  float exonFactor;   /* weight on the coding-potential (Markov) score */
+  float OligoCutoff;  /* minimum coding-potential score to even consider this exon (1st cutoff) */
 
-  float HSPFactor;
+  float HSPFactor;    /* weight on the homology/RNA-seq evidence score */
 
-  float ExonWeight;
+  float ExonWeight;   /* flat bonus/penalty added after both cutoffs pass (tunable via -E) */
 /*   float U12atacExonWeight; */
 /*   float U12gtagExonWeight; */
-  float ExonCutoff;
+  float ExonCutoff;   /* minimum combined scoreTotal to keep this exon (2nd/final cutoff) */
 } paramexons;
 
 typedef struct s_gparam                

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -319,6 +319,28 @@ void selectFeatures(char* exonType,
 
 /* Processing of genes to make pretty printing afterwards */
 /* artScore is the value that must be substracted from total score (forced evidences) */
+/* genamic's DP leaves behind one long PreviousExon chain: not just one
+   gene's exons, but potentially MANY genes back to back, each one's first
+   exon pointing at a BEGIN/PROMOTER/artificial marker that in turn chains
+   into the next gene, all the way back to the Ghost exon (Strand '*') that
+   terminates the walk. CookingInfo walks that WHOLE chain exactly once,
+   starting from eorig (the optimal solution, pg->GOptim) and following
+   PreviousExon back to the Ghost, splitting it into one gene[] record per
+   gene as it goes: every time it crosses a gene boundary (a First/Single/
+   BEGIN/PROMOTER/UTR-first marker -- see stop1/stop2 below) it starts
+   filling the next info[igen] slot. Per gene it accumulates feature/exon/
+   UTR/CDS/intron counts and the summed score; BEGIN/END pseudo-exons carry
+   a MAXSCORE sentinel instead of a real score and are skipped entirely,
+   with their MAXSCORE refunded via *artScore so the caller can subtract it
+   back out of the reported gene score.
+   Because '-' strand genes are assembled in the OPPOSITE order from how
+   they read (First is added to the chain last), the reverse-strand branch
+   below walks BOTTOM (First) -> TOP (Terminal) while the forward-strand
+   branch walks BOTTOM (Terminal) -> TOP (First); both branches are
+   otherwise the same bookkeeping, just checking the boundary marker for
+   the opposite end of the gene. currentIsUTR remembers whether the feature
+   just visited was a half-UTR piece, so a First/Single exon fused onto a
+   half-UTR isn't mistaken for the start of the NEXT gene. */
 long CookingInfo(exonGFF* eorig,
                  gene** pinfo,
                  long* pcap,

--- a/src/Translate.c
+++ b/src/Translate.c
@@ -48,7 +48,15 @@ static void growStr(char** buf, long* cap, long need)
   *cap = ncap;
 }
 
-/* Obtaining the amino acid sequence from an exon (given a reading frame) */
+/* Translates the WHOLE-CODON interior of one exon, p1..p2 inclusive, into
+   sAux, returning the amino acid count. fra and rmd are the number of
+   leftover bases (0/1/2) at the exon's 5' and 3' ends respectively that do
+   NOT belong to a whole codon within this exon (because the codon they're
+   part of is split across the splice junction with a neighboring exon);
+   those are copied into sAux verbatim, lowercased (+32), as placeholders --
+   TranslateGene (below) is what actually stitches each side's leftover
+   bases together into a real codon and translates it, once both exons on
+   either side of the junction are known. */
 int Translate(long p1,
               long p2,
               short fra,
@@ -111,6 +119,29 @@ int Translate(long p1,
 }
 
 /* Translate gene sequence into the protein */
+/* Walks a gene's PreviousExon chain (like CookingInfo in CookingGenes.c)
+   translating each coding exon's whole-codon interior via Translate(), then
+   stitches the split codon at each exon-exon junction back together and
+   translates THAT too -- so the protein comes out complete even though no
+   single exon's sequence lines up with codon boundaries.
+   The junction bookkeeping: e->Frame is how many bases at this exon's start
+   belong to a codon started in the PREVIOUS exon (0/1/2); e->Remainder is
+   how many bases at this exon's end are left dangling for the NEXT exon to
+   complete. currFrame (forward) / currRmd (reverse) carry the previous
+   iteration's dangling-base count into this one, and codon[] accumulates
+   the actual bases (mixing ends from two different exons) until all 3 are
+   known, at which point it is translated and spliced into the running
+   protein (the two `switch (currFrame)`/`switch (currRmd)` blocks per
+   iteration: one consumes what the PREVIOUS exon left pending using bases
+   from the CURRENT exon, the other stashes what THIS exon leaves pending
+   for the NEXT). rmdProt is the special case at the very ends of the gene
+   (the first exon's leading partial codon, the last exon's trailing
+   partial codon) which have no neighboring exon to complete them, so they
+   are appended untranslated (lowercased, like Translate()'s fra/rmd
+   bases). Forward and reverse strand are mirror images of the same
+   bookkeeping; reverse additionally reverse-complements each exon (via
+   ReverseSubSequence into a scratch buffer rs) before translating it left
+   to right like the forward case. */
 void TranslateGene(exonGFF* e,
                    char* s,
                    dict* dAA,

--- a/src/readparam.c
+++ b/src/readparam.c
@@ -77,6 +77,17 @@ void readHeader(FILE* File, char* line)
     printError("Parameter file: unexpected end of reading");
 }
 
+/* Loads p->transitionValues[0..dimension) from the .param file and fills in
+   the entries for oligomers containing an N. The file only lists scores for
+   the 4^(order+1) pure-ACGT oligomers (in a fixed A,C,G,T order per
+   position); this function reads those, then SYNTHESIZES every entry that
+   involves at least one N as the average of its 4 pure-base variants (e.g.
+   for order 1: AN = avg(AA,AC,AG,AT), NA = avg(AA,CA,GA,TA), NN = avg of all
+   4, ...), so a lookup with OligoToInt's 5-letter (A/C/G/T/N) index is
+   always defined -- see the profile struct comment in geneid.h. The three
+   cases below (order 0/1/2) are the same idea at 5/25/125 combinations per
+   position; order 2's case nests one more level of N-substitution (X.N,
+   .N., N..) to reach all 125. */
 void SetProfile(profile* p, FILE* RootFile, char* signal)
 {
   int i,j,x,y;
@@ -351,6 +362,18 @@ void ReadProfile(FILE* RootFile, profile* p, char* signal, int H)
 }
 
 /* Read information useful to predict Acceptor splice sites */
+/* Reads this isochore's splice-site section of the .param file: a run of
+   OPTIONAL profiles (each introduced by its own header line, in any order,
+   any subset), terminated by a fixed required profile, for each side:
+     acceptor side:  {PPT, BP, U12BP, U12gtagACC, U12atacACC}* then ACC
+     donor side:     {U12gtagDON, U12atacDON, U2gcagDON, U2gtaDON,
+                       U2gtyDON}* then DON
+   (the while loops below just walk headers until they see the fixed one).
+   Finally, U12 splicing is only switched on if ALL THREE of its supporting
+   profiles were present (branch point + both acceptor and donor for that
+   subtype) -- see the u12bp/u12gtagAcc/... counters and the check at the
+   end -- and each subtype enabled adds one more DP splice-class (see
+   SPLICECLASSES / packGenes->Ga in genamic.c). */
 void ReadProfileSpliceSites(FILE* RootFile, gparam* gp)
 {
   char line[MAXLINE];
@@ -364,7 +387,7 @@ void ReadProfileSpliceSites(FILE* RootFile, gparam* gp)
   int u12atacDon=0;
 
 
-  /* A. Optional profiles: U12GTAG, U12ATAC Donor, acceptor and branch points 
+  /* A. Optional profiles: U12GTAG, U12ATAC Donor, acceptor and branch points
   and U2 branch points and Poly Pyrimidine Tract */
   
   readHeader(RootFile,line);
@@ -686,7 +709,8 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 		}
   while(strcasecmp(header,sExon_weights)&& strcmp(header,"Exon_weigths"))
   { 
-	 /* 1. Read RSSMARKOVSCORE for markov score to assign non-exonic recursively spliced elements */
+	 /* Optional: RSSMARKOVSCORE, the coding-potential score assigned to a
+	    zero-length (recursively spliced) element instead of computing one */
 	if(!strcasecmp(header,sRSSMARKOVSCORE)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(RSSMARKOVSCORE)))!=1)
@@ -695,7 +719,7 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 		  sprintf(mess,"RSSMARKOVSCORE: \t%9.2f",RSSMARKOVSCORE);
 		  printMess(mess);
 	}
-	 /* 1. Read Evidence Exon Weight */
+	 /* Optional: EvidenceExonWeight, a flat bonus/penalty for evidence-backed exons */
 	if(!strcasecmp(header,sEVIDENCEW)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(EvidenceEW)))!=1)
@@ -704,7 +728,7 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 		  sprintf(mess,"EvidenceExonWeight: \t%9.2f",EvidenceEW);
 		  printMess(mess);
 	}
-	 /* 1. Read Evidence Exon Factor */
+	 /* Optional: EvidenceFactor, a score-weight multiplier for evidence-backed exons */
 	if(!strcasecmp(header,sEVIDENCEF)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(EvidenceFactor)))!=1)
@@ -713,7 +737,7 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 		  sprintf(mess,"EvidenceFactor: \t%9.2f",EvidenceFactor);
 		  printMess(mess);
 	}
-	 /* 1. Read RSS_Donor_Score_Cutoff */
+	 /* Optional: RSSDON, minimum donor score for a recursive splice site */
 	if(!strcasecmp(header,sRSS_DONOR_SCORE_CUTOFF)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(RSSDON)))!=1)
@@ -722,7 +746,7 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 		  sprintf(mess,"RSSDON: \t%9.2f",RSSDON);
 		  printMess(mess);
 	}
-	 /* 1. Read RSSMARKOVSCORE for markov score to assign non-exonic recursively spliced elements */
+	 /* Optional: RSSACC, minimum acceptor score for a recursive splice site */
 	if(!strcasecmp(header,sRSS_ACCEPTOR_SCORE_CUTOFF)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(RSSACC)))!=1)
@@ -731,7 +755,8 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 		  sprintf(mess,"RSSACC: \t%9.2f",RSSACC);
 		  printMess(mess);
 	}
-	 /* 1. Read U12_SPLICE_SCORE_THRESH for sum of U12 donor and acceptor splice scores */
+	 /* Optional: U12_SPLICE_SCORE_THRESH, minimum combined donor+acceptor
+	    signal score to accept a minor-spliceosome (U12) join (see genamic.c) */
 	if(!strcasecmp(header,sU12_SPLICE_SCORE_THRESH)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(U12_SPLICE_SCORE_THRESH)))!=1)
@@ -741,7 +766,8 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 				  U12_SPLICE_SCORE_THRESH);
 		  printMess(mess);
 	}
-	 /* 1. Read U12_EXON_SCORE_THRESH for sum of U12 donor and acceptor exon scores */
+	 /* Optional: U12_EXON_SCORE_THRESH, minimum combined exon score to accept
+	    a minor-spliceosome (U12) join (see genamic.c) */
 	if(!strcasecmp(header,sU12_EXON_SCORE_THRESH)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(U12_EXON_SCORE_THRESH)))!=1)
@@ -751,7 +777,7 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 				  U12_EXON_SCORE_THRESH);
 		  printMess(mess);
 	}
-	 /* 1. Read U12_EXON_WEIGHT, an additional exon weight that applies to exons flanking U12 introns */
+	 /* Optional: U12_EXON_WEIGHT, an additional exon weight that applies to exons flanking U12 introns */
 	if(!strcasecmp(header,sU12_EXON_WEIGHT)){
 		  readLine(RootFile,line);
 		  if ((sscanf(line,"%f\n", &(U12EW)))!=1)


### PR DESCRIPTION
This PR from PR #23 (`docs/comment-genamic-and-core`) was never actually merged into `dev` -- the merge commit only pulled in the first commit (`b89c6c6`, genamic.c/core-structs comments). The second commit (`aa82789`) sat unmerged on that branch and was about to be silently lost during a branch-cleanup pass.

Recovers that commit's content, cherry-picked onto current `dev`:
- `readparam.c`: fixes a real copy-paste bug -- 8 optional score-tuning items (RSSMARKOVSCORE, EvidenceEW/Factor, RSSDON/ACC, the two U12 thresholds, U12_EXON_WEIGHT) were all mislabeled `/* 1. Read ... */` from being copied from the first one; relabeled each with what it actually reads. Also top comments on `SetProfile` and `ReadProfileSpliceSites`.
- `CookingGenes.c`: top comment on `CookingInfo` explaining the PreviousExon-chain walk / per-gene splitting.
- `Translate.c`: comments on `Translate()`'s fra/rmd params and `TranslateGene`'s split-codon-at-junction stitching.
- `geneid.h`: comments on the `profile` and `paramexons` structs.

No renames, no logic changes -- comment-stripped diff against `origin/dev` is identical aside from comments/whitespace. Clean build (zero warnings), 5/5 regression byte-identical.