### PR TITLE
geneid-train Phase 2: GFF3 core, converters, classify, and the transcripts front-end

### DIFF
--- a/training/DESIGN.md
+++ b/training/DESIGN.md
@@ -45,6 +45,14 @@ The only compiled dependency that remains is the `geneid` predictor itself.
 | Input front-ends | BUSCO **and** RNA-seq/TransDecoder, built in parallel on a shared core |
 | Correctness stance | Redesign freely — legacy output is a *reference*, not a byte-repro gate |
 
+**Annotation format: GFF3 only.** The tool ingests **GFF3 exclusively** as its
+canonical internal format (the most robust flavor). CDS features are grouped into
+transcripts by their `Parent` attribute. Other flavors (GFF2, GTF) are handled by
+explicit converters in `core/convert.py` (`geneid-train convert --from gff2|gtf`),
+which re-emit a well-formed gene→mRNA→CDS hierarchy; the pipeline itself never
+parses them directly. Parsing geneid's own GFF prediction output is a separate
+concern handled at the `engine.py` boundary.
+
 **Two hard constraints survive "redesign freely":**
 
 1. **The `.param` file format is frozen.** The compiled `geneid` binary parses it,
@@ -70,7 +78,8 @@ training/
     config.py             # YAML run config + defaults, seed handling
     core/
       param.py            # Param model: read/write geneid .param (format authority)
-      gff.py              # GFF2/GFF3 read/write, geneid coordinate conventions
+      gff.py              # GFF3 read/write (the one canonical annotation format)
+      convert.py          # GFF2 / GTF -> canonical GFF3 (the only on-ramp for other flavors)
       fasta.py            # FASTA + tbl I/O (replaces FastaToTbl/TblToFasta)
       seq.py              # translation, ORF/completeness checks, reverse-complement
     prepare/

--- a/training/DESIGN.md
+++ b/training/DESIGN.md
@@ -45,6 +45,17 @@ The only compiled dependency that remains is the `geneid` predictor itself.
 | Input front-ends | BUSCO **and** RNA-seq/TransDecoder, built in parallel on a shared core |
 | Correctness stance | Redesign freely — legacy output is a *reference*, not a byte-repro gate |
 
+**Defaults (Tyler, 2026-07-02):**
+
+- **Single isochore by default.** Isochore modelling was essentially a human-only
+  practice; on non-model organisms it needs more data and more training effort, so
+  CNAG stopped doing it. Multi-isochore support stays as an optional/experimental
+  path but is deprioritized.
+- **Genome masking:** *prediction* must run on the masked genome; *training* does
+  not require masking (unmasked is fine). Training candidates are already
+  repeat-filtered upstream, so masking mainly affects flanks — either genome works
+  for the training step.
+
 **Annotation format: GFF3 only.** The tool ingests **GFF3 exclusively** as its
 canonical internal format (the most robust flavor). CDS features are grouped into
 transcripts by their `Parent` attribute. Other flavors (GFF2, GTF) are handled by
@@ -64,6 +75,44 @@ concern handled at the `engine.py` boundary.
 
 The north-star metric is **held-out SN/SP equal-to-or-better than the current Perl
 pipeline** on the test species, not identical intermediate numbers.
+
+### Optional splice-class profiles (GC donors, U12)
+
+geneid natively reads separate profiles for the full splice taxonomy —
+`U2gta_Donor_profile` (bulk GT-AG), `U2gcag_Donor_profile` (GC-AG), the U12 donor/
+acceptor/branch trio, `Poly_Pyrimidine_Tract_profile`, etc. (exact keywords in
+§4). These are **optional**: the legacy trainer emitted only the generic
+`Donor_profile`/`Acceptor_profile`, so geneid was categorically blind to GC-AG and
+U12 introns.
+
+The same optional treatment applies to the **U2 branch-point + poly-pyrimidine
+tract** profiles (`Branch_point_profile`, `Poly_Pyrimidine_Tract_profile`) — these
+are not a rare dinucleotide class (they're trainable from all U2 introns) but are
+especially valuable for **fungal** genomes; reference/transplant source is
+`param/human.070606.u2branch.ppt.param`. Unified rule for **every** optional
+auxiliary profile (GC donor, U2 BP+PPT, the U12 trio(s), finer U2 gtg/gty donors):
+**always train it, then include it only if it improves held-out F1 or SN/SP.**
+Inclusion is decided at the optimize/evaluate stage (a train-and-test toggle), not
+at `classify` — which only does the dinucleotide rare-class tally.
+
+Design stance (Tyler, 2026-07-02): building these profiles is about **coverage,
+not necessarily global accuracy**. Adding a rare-class profile sometimes *lowers*
+overall SN/SP, but it lets geneid predict that class at all instead of leaving it
+out categorically. Therefore the trainer:
+
+- builds each optional class only when there are enough examples (else offers to
+  **transplant** an existing cross-taxa profile — U12 params generalize well; the
+  reference U12 source is `param/human3isoU12.param`, lifting the U12 profiles from
+  isochore 1 as `convertParam2U12.pl` does. Note `human.070606.u2branch.ppt.param`
+  is U2 branch/PPT, **not** U12);
+- honours geneid's rule that a U12 subtype activates only if its **full
+  donor+acceptor+branch trio** is present;
+- treats each optional class as a toggle and **reports held-out SN/SP with vs.
+  without it**, so the choice to include it is an informed, per-species decision
+  rather than an unconditional default.
+
+`prepare`/`classify` report donor-dinucleotide (GT/GC/AT) and U2/U12 candidate
+tallies up front to drive the train-de-novo-vs-transplant-vs-omit decision.
 
 ## 3. Architecture
 

--- a/training/README.md
+++ b/training/README.md
@@ -26,5 +26,14 @@ geneid-train param-info ../param/human1iso.param
 geneid-train param-info ../param/drosophila.U12.070102.param   # U12-aware: yes
 ```
 
-The pipeline subcommands (`prepare`, `train`, `evaluate`, `jackknife`) are
-stubs at this phase and report which phase implements them.
+Build a validated training set from a GFF3 annotation + genomic FASTA:
+
+```bash
+# other flavors go through the converter first (GFF3 is the only ingested format)
+geneid-train convert --from gff2 annotation.gff2 annotation.gff3
+geneid-train prepare --gff annotation.gff3 --fastas genome.fa --min-aa 100 --results out
+```
+
+`convert` accepts `--from gff2` or `--from gtf`. The remaining subcommands
+(`train`, `evaluate`, `jackknife`) are stubs at this phase and report which phase
+implements them.

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -11,7 +11,7 @@ import sys
 
 from . import __version__
 from .core.convert import gff2_to_gff3, gtf_to_gff3
-from .core.fasta import read_fasta, write_fasta
+from .core.fasta import read_fasta, read_fasta_subset, write_fasta
 from .core.gff import GffRecord, read_gff3, write_gff3
 from .core.param import Param
 from .prepare.base import (
@@ -20,6 +20,7 @@ from .prepare.base import (
     filter_min_protein,
     filter_non_overlapping,
 )
+from .prepare.classify import classify_report
 
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
@@ -57,6 +58,27 @@ def _cmd_convert(args: argparse.Namespace) -> int:
         raise ValueError(args.from_)
     write_gff3(records, args.output)
     print(f"wrote {len(records)} GFF3 records to {args.output}")
+    return 0
+
+
+def _cmd_classify(args: argparse.Namespace) -> int:
+    models = build_models(read_gff3(args.gff))
+    if not models:
+        sys.stderr.write("no CDS-grouped gene models found in GFF3\n")
+        return 1
+    genome = read_fasta_subset(args.fastas, {m.seqid for m in models})
+    rep = classify_report(models, genome, min_sites=args.min_sites)
+    print(f"models={rep.n_models} multi-exonic={rep.n_multiexonic} introns={rep.n_introns}")
+    top_d = list(rep.donor_counts.items())[:5]
+    top_a = list(rep.acceptor_counts.items())[:5]
+    print("top donor dinucs:    " + ", ".join(f"{d}={n}" for d, n in top_d))
+    print("top acceptor dinucs: " + ", ".join(f"{a}={n}" for a, n in top_a))
+    print("\nsplice classes:")
+    for c in rep.classes:
+        frac = f"{100 * c.fraction:.2f}%" if c.count >= 0 else "  -  "
+        cnt = str(c.count) if c.count >= 0 else "?"
+        print(f"  {c.name:12} {cnt:>6} {frac:>7}  -> {c.recommendation}")
+        print(f"               profile: {c.profile}")
     return 0
 
 
@@ -126,6 +148,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--results", help="output path prefix; writes validated.{gff,cds.fa,prot.fa}"
     )
     p_prep.set_defaults(func=_cmd_prepare)
+
+    p_cls = sub.add_parser(
+        "classify", help="tally intron splice classes (GT-AG/GC-AG/AT-AC) and recommend profiles"
+    )
+    p_cls.add_argument("--gff", required=True, help="GFF3 of CDS features (Parent = transcript)")
+    p_cls.add_argument("--fastas", required=True, help="genomic multi-FASTA")
+    p_cls.add_argument(
+        "--min-sites", type=int, default=50, help="min sites to train a rare-class profile de novo"
+    )
+    p_cls.set_defaults(func=_cmd_classify)
 
     p_conv = sub.add_parser("convert", help="convert GFF2 or GTF annotation to canonical GFF3")
     p_conv.add_argument("--from", dest="from_", required=True, choices=["gff2", "gtf"])

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -16,6 +16,7 @@ from .core.gff import GffRecord, read_gff3, write_gff3
 from .core.param import Param
 from .prepare.base import (
     build_models,
+    collapse_isoforms,
     filter_complete,
     filter_min_protein,
     filter_non_overlapping,
@@ -62,7 +63,8 @@ def _cmd_convert(args: argparse.Namespace) -> int:
 
 
 def _cmd_classify(args: argparse.Namespace) -> int:
-    models = build_models(read_gff3(args.gff))
+    records = read_gff3(args.gff)
+    models = collapse_isoforms(build_models(records), records)
     if not models:
         sys.stderr.write("no CDS-grouped gene models found in GFF3\n")
         return 1
@@ -84,11 +86,15 @@ def _cmd_classify(args: argparse.Namespace) -> int:
 
 def _cmd_prepare(args: argparse.Namespace) -> int:
     genome = read_fasta(args.fastas)
-    models = build_models(read_gff3(args.gff))
-    print(f"input models:      {len(models)}")
+    records = read_gff3(args.gff)
+    models = build_models(records)
     if not models:
-        sys.stderr.write("no CDS-grouped gene models found in GFF\n")
+        sys.stderr.write("no CDS-grouped gene models found in GFF3\n")
         return 1
+    print(f"transcripts:       {len(models)}")
+    if not args.no_collapse:
+        models = collapse_isoforms(models, records)
+        print(f"genes (collapsed): {len(models)}")
     print(f"  multi-exonic:    {sum(m.is_multiexonic for m in models)}")
 
     kept = filter_complete(models, genome)
@@ -144,6 +150,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_prep.add_argument("--fastas", required=True, help="genomic multi-FASTA")
     p_prep.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
     p_prep.add_argument("--flank", type=int, default=1000, help="flank nt for locus extraction")
+    p_prep.add_argument(
+        "--no-collapse", action="store_true",
+        help="keep every transcript instead of one representative (longest) per gene",
+    )
     p_prep.add_argument(
         "--results", help="output path prefix; writes validated.{gff,cds.fa,prot.fa}"
     )

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -10,8 +10,9 @@ import argparse
 import sys
 
 from . import __version__
+from .core.convert import gff2_to_gff3, gtf_to_gff3
 from .core.fasta import read_fasta, write_fasta
-from .core.gff import read_gff, write_gff
+from .core.gff import GffRecord, read_gff3, write_gff3
 from .core.param import Param
 from .prepare.base import (
     build_models,
@@ -46,9 +47,22 @@ def _cmd_param_info(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_convert(args: argparse.Namespace) -> int:
+    lines = open(args.input).readlines()
+    if args.from_ == "gff2":
+        records = gff2_to_gff3(lines)
+    elif args.from_ == "gtf":
+        records = gtf_to_gff3(lines)
+    else:  # pragma: no cover - argparse restricts choices
+        raise ValueError(args.from_)
+    write_gff3(records, args.output)
+    print(f"wrote {len(records)} GFF3 records to {args.output}")
+    return 0
+
+
 def _cmd_prepare(args: argparse.Namespace) -> int:
     genome = read_fasta(args.fastas)
-    models = build_models(read_gff(args.gff))
+    models = build_models(read_gff3(args.gff))
     print(f"input models:      {len(models)}")
     if not models:
         sys.stderr.write("no CDS-grouped gene models found in GFF\n")
@@ -64,23 +78,23 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
 
     if args.results:
         recs = [r for m in kept for r in _model_records(m)]
-        write_gff(recs, f"{args.results}.validated.gff")
+        write_gff3(recs, f"{args.results}.validated.gff3")
         write_fasta({m.gene_id: m.cds(genome) for m in kept}, f"{args.results}.validated.cds.fa")
         write_fasta(
             {m.gene_id: m.protein(genome).rstrip("*") for m in kept},
             f"{args.results}.validated.prot.fa",
         )
-        print(f"wrote:             {args.results}.validated.{{gff,cds.fa,prot.fa}}")
+        print(f"wrote:             {args.results}.validated.{{gff3,cds.fa,prot.fa}}")
     return 0
 
 
-def _model_records(model):
-    from .core.gff import GffRecord
-
+def _model_records(model) -> list[GffRecord]:
     return [
-        GffRecord(model.seqid, "geneid_train", "CDS", e.start, e.end, ".", model.strand,
-                  e.frame, model.gene_id)
-        for e in model.exons
+        GffRecord(
+            model.seqid, "geneid_train", "CDS", e.start, e.end, ".", model.strand, e.phase,
+            {"ID": f"{model.gene_id}.cds{i}", "Parent": model.gene_id},
+        )
+        for i, e in enumerate(model.exons, start=1)
     ]
 
 
@@ -104,7 +118,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_prep = sub.add_parser(
         "prepare", help="build a validated training set from a GFF + genomic FASTA"
     )
-    p_prep.add_argument("--gff", required=True, help="GFF2 of CDS features grouped by gene id")
+    p_prep.add_argument("--gff", required=True, help="GFF3 of CDS features (Parent = transcript)")
     p_prep.add_argument("--fastas", required=True, help="genomic multi-FASTA")
     p_prep.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
     p_prep.add_argument("--flank", type=int, default=1000, help="flank nt for locus extraction")
@@ -112,6 +126,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--results", help="output path prefix; writes validated.{gff,cds.fa,prot.fa}"
     )
     p_prep.set_defaults(func=_cmd_prepare)
+
+    p_conv = sub.add_parser("convert", help="convert GFF2 or GTF annotation to canonical GFF3")
+    p_conv.add_argument("--from", dest="from_", required=True, choices=["gff2", "gtf"])
+    p_conv.add_argument("input", help="input annotation file (GFF2 or GTF)")
+    p_conv.add_argument("output", help="output GFF3 path")
+    p_conv.set_defaults(func=_cmd_convert)
 
     for name, desc in _STUBS.items():
         sp = sub.add_parser(name, help=desc)

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -10,12 +10,19 @@ import argparse
 import sys
 
 from . import __version__
+from .core.fasta import read_fasta, write_fasta
+from .core.gff import read_gff, write_gff
 from .core.param import Param
+from .prepare.base import (
+    build_models,
+    filter_complete,
+    filter_min_protein,
+    filter_non_overlapping,
+)
 
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
 _STUBS = {
-    "prepare": "build a validated training set from BUSCO or RNA-seq/TransDecoder input (phase 2)",
     "train": "estimate site + coding models and assemble a .param file (phases 3-4)",
     "evaluate": "score a .param against held-out gene models, U2/U12-aware (phase 5)",
     "jackknife": "leave-group-out cross-validation of a training set (phase 7)",
@@ -39,6 +46,44 @@ def _cmd_param_info(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_prepare(args: argparse.Namespace) -> int:
+    genome = read_fasta(args.fastas)
+    models = build_models(read_gff(args.gff))
+    print(f"input models:      {len(models)}")
+    if not models:
+        sys.stderr.write("no CDS-grouped gene models found in GFF\n")
+        return 1
+    print(f"  multi-exonic:    {sum(m.is_multiexonic for m in models)}")
+
+    kept = filter_complete(models, genome)
+    print(f"complete CDS:      {len(kept)}")
+    kept = filter_min_protein(kept, genome, args.min_aa)
+    print(f">= {args.min_aa} aa:{' ' * max(1, 8 - len(str(args.min_aa)))}{len(kept)}")
+    kept = filter_non_overlapping(kept)
+    print(f"non-overlapping:   {len(kept)}")
+
+    if args.results:
+        recs = [r for m in kept for r in _model_records(m)]
+        write_gff(recs, f"{args.results}.validated.gff")
+        write_fasta({m.gene_id: m.cds(genome) for m in kept}, f"{args.results}.validated.cds.fa")
+        write_fasta(
+            {m.gene_id: m.protein(genome).rstrip("*") for m in kept},
+            f"{args.results}.validated.prot.fa",
+        )
+        print(f"wrote:             {args.results}.validated.{{gff,cds.fa,prot.fa}}")
+    return 0
+
+
+def _model_records(model):
+    from .core.gff import GffRecord
+
+    return [
+        GffRecord(model.seqid, "geneid_train", "CDS", e.start, e.end, ".", model.strand,
+                  e.frame, model.gene_id)
+        for e in model.exons
+    ]
+
+
 def _make_stub(name: str, desc: str):
     def _run(_args: argparse.Namespace) -> int:
         sys.stderr.write(f"geneid-train {name}: not implemented yet — {desc}\n")
@@ -55,6 +100,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_info = sub.add_parser("param-info", help="summarize a geneid .param file")
     p_info.add_argument("path", help="path to a .param file")
     p_info.set_defaults(func=_cmd_param_info)
+
+    p_prep = sub.add_parser(
+        "prepare", help="build a validated training set from a GFF + genomic FASTA"
+    )
+    p_prep.add_argument("--gff", required=True, help="GFF2 of CDS features grouped by gene id")
+    p_prep.add_argument("--fastas", required=True, help="genomic multi-FASTA")
+    p_prep.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
+    p_prep.add_argument("--flank", type=int, default=1000, help="flank nt for locus extraction")
+    p_prep.add_argument(
+        "--results", help="output path prefix; writes validated.{gff,cds.fa,prot.fa}"
+    )
+    p_prep.set_defaults(func=_cmd_prepare)
 
     for name, desc in _STUBS.items():
         sp = sub.add_parser(name, help=desc)

--- a/training/src/geneid_train/core/convert.py
+++ b/training/src/geneid_train/core/convert.py
@@ -1,0 +1,131 @@
+"""Converters from other annotation flavors into canonical GFF3.
+
+The pipeline ingests GFF3 only; these converters are the sanctioned on-ramp for
+GFF2 and GTF input. Both are reduced to CDS features carrying a transcript id and
+a gene id, then re-emitted as a well-formed gene -> mRNA -> CDS GFF3 hierarchy so
+downstream code has a single format to reason about.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .gff import GffRecord
+
+
+@dataclass
+class _CdsEntry:
+    seqid: str
+    source: str
+    start: int
+    end: int
+    score: str
+    strand: str
+    phase: str
+    tx_id: str
+    gene_id: str
+
+
+def _assemble_gff3(entries: list[_CdsEntry]) -> list[GffRecord]:
+    """Build gene -> mRNA -> CDS records from flat CDS entries."""
+    # preserve first-seen order of transcripts and genes
+    tx_order: list[str] = []
+    tx_cds: dict[str, list[_CdsEntry]] = {}
+    tx_gene: dict[str, str] = {}
+    for e in entries:
+        if e.tx_id not in tx_cds:
+            tx_cds[e.tx_id] = []
+            tx_order.append(e.tx_id)
+            tx_gene[e.tx_id] = e.gene_id
+        tx_cds[e.tx_id].append(e)
+
+    gene_txs: dict[str, list[str]] = {}
+    for tx in tx_order:
+        gene_txs.setdefault(tx_gene[tx], []).append(tx)
+
+    # keep GFF3 IDs unique: when a gene shares its id with one of its own
+    # transcripts (the GFF2 bare-group case), give the gene feature a suffix.
+    gene_fid = {
+        gene: (f"{gene}.gene" if gene in txs else gene) for gene, txs in gene_txs.items()
+    }
+
+    out: list[GffRecord] = []
+    emitted_gene: set[str] = set()
+    for tx in tx_order:
+        gene = tx_gene[tx]
+        cds = sorted(tx_cds[tx], key=lambda e: e.start)
+        first = cds[0]
+        if gene not in emitted_gene:
+            g_cds = [c for t in gene_txs[gene] for c in tx_cds[t]]
+            out.append(
+                GffRecord(
+                    first.seqid, first.source, "gene",
+                    min(c.start for c in g_cds), max(c.end for c in g_cds),
+                    ".", first.strand, ".", {"ID": gene_fid[gene]},
+                )
+            )
+            emitted_gene.add(gene)
+        out.append(
+            GffRecord(
+                first.seqid, first.source, "mRNA",
+                min(c.start for c in cds), max(c.end for c in cds),
+                ".", first.strand, ".", {"ID": tx, "Parent": gene_fid[gene]},
+            )
+        )
+        for i, c in enumerate(cds, start=1):
+            out.append(
+                GffRecord(
+                    c.seqid, c.source, "CDS", c.start, c.end, c.score, c.strand,
+                    c.phase, {"ID": f"{tx}.cds{i}", "Parent": tx},
+                )
+            )
+    return out
+
+
+def _gff2_group_id(col9: str) -> str:
+    """Extract the transcript id from a GFF2 group column (bare token, or a
+    quoted token, or a ``key "value"`` attribute)."""
+    col9 = col9.strip()
+    m = re.search(r'"([^"]+)"', col9)
+    if m:
+        return m.group(1)
+    return col9.split()[0].strip('"') if col9.split() else col9
+
+
+def gff2_to_gff3(lines: list[str], cds_type: str = "CDS") -> list[GffRecord]:
+    entries: list[_CdsEntry] = []
+    for line in lines:
+        if not line.strip() or line.startswith("#"):
+            continue
+        f = line.rstrip("\n").split("\t")
+        if len(f) < 8 or f[2] != cds_type:
+            continue
+        tx = _gff2_group_id(f[8] if len(f) > 8 else "")
+        entries.append(
+            _CdsEntry(f[0], f[1], int(f[3]), int(f[4]), f[5], f[6], f[7], tx, tx)
+        )
+    return _assemble_gff3(entries)
+
+
+def _gtf_attr(col9: str, key: str) -> str | None:
+    m = re.search(rf'{re.escape(key)}\s+"([^"]+)"', col9)
+    return m.group(1) if m else None
+
+
+def gtf_to_gff3(lines: list[str], cds_type: str = "CDS") -> list[GffRecord]:
+    entries: list[_CdsEntry] = []
+    for line in lines:
+        if not line.strip() or line.startswith("#"):
+            continue
+        f = line.rstrip("\n").split("\t")
+        if len(f) < 9 or f[2] != cds_type:
+            continue
+        tx = _gtf_attr(f[8], "transcript_id")
+        gene = _gtf_attr(f[8], "gene_id") or tx
+        if tx is None:
+            raise ValueError(f"GTF CDS line missing transcript_id: {line!r}")
+        entries.append(
+            _CdsEntry(f[0], f[1], int(f[3]), int(f[4]), f[5], f[6], f[7], tx, gene)
+        )
+    return _assemble_gff3(entries)

--- a/training/src/geneid_train/core/fasta.py
+++ b/training/src/geneid_train/core/fasta.py
@@ -1,0 +1,66 @@
+"""FASTA reading/writing and the two-column ``tbl`` format.
+
+The legacy pipeline shuttled sequences through a ``tbl`` format (``id<TAB>seq``,
+one record per line) via the ``FastaToTbl`` / ``TblToFasta`` shell tools. We keep
+that format for interoperability but treat plain dicts as the in-memory currency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+
+
+def iter_fasta(path: str | Path) -> Iterator[tuple[str, str]]:
+    """Yield ``(id, sequence)`` pairs. The id is the first whitespace-delimited
+    token of the header (matching how geneid's tools key sequences)."""
+    name: str | None = None
+    chunks: list[str] = []
+    with open(path) as fh:
+        for line in fh:
+            if line.startswith(">"):
+                if name is not None:
+                    yield name, "".join(chunks)
+                name = line[1:].split()[0] if line[1:].strip() else ""
+                chunks = []
+            else:
+                chunks.append(line.strip())
+    if name is not None:
+        yield name, "".join(chunks)
+
+
+def read_fasta(path: str | Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name, seq in iter_fasta(path):
+        if name in out:
+            raise ValueError(f"duplicate sequence id {name!r} in {path}")
+        out[name] = seq
+    return out
+
+
+def write_fasta(records: Mapping[str, str], path: str | Path, width: int = 60) -> None:
+    with open(path, "w") as fh:
+        for name, seq in records.items():
+            fh.write(f">{name}\n")
+            if width and width > 0:
+                for i in range(0, len(seq), width):
+                    fh.write(seq[i : i + width] + "\n")
+            else:
+                fh.write(seq + "\n")
+
+
+def read_tbl(path: str | Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    with open(path) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            name, _, seq = line.rstrip("\n").partition("\t")
+            out[name] = seq
+    return out
+
+
+def write_tbl(records: Mapping[str, str], path: str | Path) -> None:
+    with open(path, "w") as fh:
+        for name, seq in records.items():
+            fh.write(f"{name}\t{seq}\n")

--- a/training/src/geneid_train/core/fasta.py
+++ b/training/src/geneid_train/core/fasta.py
@@ -7,16 +7,30 @@ that format for interoperability but treat plain dicts as the in-memory currency
 
 from __future__ import annotations
 
+import gzip
+import io
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 
 
+def open_text(path: str | Path) -> io.TextIOBase:
+    """Open a text file, transparently decompressing gzip (detected by magic
+    bytes, so a mislabeled or extensionless ``.gz`` still works)."""
+    with open(path, "rb") as fh:
+        magic = fh.read(2)
+    if magic == b"\x1f\x8b":
+        return gzip.open(path, "rt")
+    return open(path)
+
+
 def iter_fasta(path: str | Path) -> Iterator[tuple[str, str]]:
     """Yield ``(id, sequence)`` pairs. The id is the first whitespace-delimited
-    token of the header (matching how geneid's tools key sequences)."""
+    token of the header (matching how geneid's tools key sequences).
+
+    Gzip-compressed FASTA (``.fa.gz``) is read transparently."""
     name: str | None = None
     chunks: list[str] = []
-    with open(path) as fh:
+    with open_text(path) as fh:
         for line in fh:
             if line.startswith(">"):
                 if name is not None:

--- a/training/src/geneid_train/core/fasta.py
+++ b/training/src/geneid_train/core/fasta.py
@@ -38,6 +38,18 @@ def read_fasta(path: str | Path) -> dict[str, str]:
     return out
 
 
+def read_fasta_subset(path: str | Path, ids: set[str], upper: bool = True) -> dict[str, str]:
+    """Read only the sequences whose id is in ``ids`` (memory-friendly for large
+    genomes). Stops early once every requested id is found."""
+    out: dict[str, str] = {}
+    for name, seq in iter_fasta(path):
+        if name in ids:
+            out[name] = seq.upper() if upper else seq
+            if len(out) == len(ids):
+                break
+    return out
+
+
 def write_fasta(records: Mapping[str, str], path: str | Path, width: int = 60) -> None:
     with open(path, "w") as fh:
         for name, seq in records.items():

--- a/training/src/geneid_train/core/gff.py
+++ b/training/src/geneid_train/core/gff.py
@@ -1,0 +1,78 @@
+"""Minimal GFF2 reader/writer using geneid's coordinate conventions.
+
+geneid consumes GFF2: nine tab-separated columns, 1-based inclusive coordinates,
+with the ninth column (``group``) naming the gene a feature belongs to. Training
+input is typically CDS features grouped by gene id. We keep the group column as a
+raw string and expose the primary id (its first token, quotes stripped).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class GffRecord:
+    seqid: str
+    source: str
+    type: str
+    start: int  # 1-based inclusive
+    end: int  # 1-based inclusive
+    score: str  # kept as string; often "." or a float
+    strand: str  # "+", "-", or "."
+    frame: str  # "0", "1", "2", or "."
+    group: str
+
+    @property
+    def gene_id(self) -> str:
+        tok = self.group.split()[0] if self.group.split() else self.group
+        return tok.strip().strip('"').strip("'")
+
+    def to_line(self) -> str:
+        return "\t".join(
+            [
+                self.seqid,
+                self.source,
+                self.type,
+                str(self.start),
+                str(self.end),
+                self.score,
+                self.strand,
+                self.frame,
+                self.group,
+            ]
+        )
+
+
+def iter_gff(path: str | Path) -> Iterator[GffRecord]:
+    with open(path) as fh:
+        for line in fh:
+            if not line.strip() or line.startswith("#"):
+                continue
+            f = line.rstrip("\n").split("\t")
+            if len(f) < 8:
+                raise ValueError(f"malformed GFF line ({len(f)} cols): {line!r}")
+            group = f[8] if len(f) > 8 else ""
+            yield GffRecord(
+                seqid=f[0],
+                source=f[1],
+                type=f[2],
+                start=int(f[3]),
+                end=int(f[4]),
+                score=f[5],
+                strand=f[6],
+                frame=f[7],
+                group=group,
+            )
+
+
+def read_gff(path: str | Path) -> list[GffRecord]:
+    return list(iter_gff(path))
+
+
+def write_gff(records: Iterable[GffRecord], path: str | Path) -> None:
+    with open(path, "w") as fh:
+        for rec in records:
+            fh.write(rec.to_line() + "\n")

--- a/training/src/geneid_train/core/gff.py
+++ b/training/src/geneid_train/core/gff.py
@@ -1,16 +1,39 @@
-"""Minimal GFF2 reader/writer using geneid's coordinate conventions.
+"""GFF3 reader/writer — the tool's one canonical annotation format.
 
-geneid consumes GFF2: nine tab-separated columns, 1-based inclusive coordinates,
-with the ninth column (``group``) naming the gene a feature belongs to. Training
-input is typically CDS features grouped by gene id. We keep the group column as a
-raw string and expose the primary id (its first token, quotes stripped).
+geneid-train ingests GFF3 exclusively (it is the most robust flavor). Other
+flavors (GFF2, GTF) are handled by explicit converters in ``core.convert``, never
+parsed directly by the pipeline. Coordinates are 1-based inclusive, matching GFF3
+and geneid conventions.
+
+CDS features are grouped into transcripts by their ``Parent`` attribute.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def parse_attributes(col9: str) -> dict[str, str]:
+    """Parse a GFF3 column-9 ``key=value;key=value`` string into a dict.
+
+    Order is preserved (dict insertion order). Percent-decoding is intentionally
+    not applied; ids in practice are already safe tokens.
+    """
+    attrs: dict[str, str] = {}
+    for field_ in col9.strip().split(";"):
+        field_ = field_.strip()
+        if not field_:
+            continue
+        key, sep, value = field_.partition("=")
+        if sep:
+            attrs[key.strip()] = value.strip()
+    return attrs
+
+
+def format_attributes(attrs: dict[str, str]) -> str:
+    return ";".join(f"{k}={v}" for k, v in attrs.items())
 
 
 @dataclass
@@ -20,15 +43,19 @@ class GffRecord:
     type: str
     start: int  # 1-based inclusive
     end: int  # 1-based inclusive
-    score: str  # kept as string; often "." or a float
+    score: str  # "." or a float, kept as string
     strand: str  # "+", "-", or "."
-    frame: str  # "0", "1", "2", or "."
-    group: str
+    phase: str  # "0", "1", "2", or "."  (GFF3 calls col 8 "phase")
+    attributes: dict[str, str] = field(default_factory=dict)
 
     @property
-    def gene_id(self) -> str:
-        tok = self.group.split()[0] if self.group.split() else self.group
-        return tok.strip().strip('"').strip("'")
+    def id(self) -> str | None:
+        return self.attributes.get("ID")
+
+    @property
+    def parents(self) -> list[str]:
+        raw = self.attributes.get("Parent")
+        return raw.split(",") if raw else []
 
     def to_line(self) -> str:
         return "\t".join(
@@ -40,21 +67,20 @@ class GffRecord:
                 str(self.end),
                 self.score,
                 self.strand,
-                self.frame,
-                self.group,
+                self.phase,
+                format_attributes(self.attributes),
             ]
         )
 
 
-def iter_gff(path: str | Path) -> Iterator[GffRecord]:
+def iter_gff3(path: str | Path) -> Iterator[GffRecord]:
     with open(path) as fh:
         for line in fh:
             if not line.strip() or line.startswith("#"):
                 continue
             f = line.rstrip("\n").split("\t")
             if len(f) < 8:
-                raise ValueError(f"malformed GFF line ({len(f)} cols): {line!r}")
-            group = f[8] if len(f) > 8 else ""
+                raise ValueError(f"malformed GFF3 line ({len(f)} cols): {line!r}")
             yield GffRecord(
                 seqid=f[0],
                 source=f[1],
@@ -63,16 +89,18 @@ def iter_gff(path: str | Path) -> Iterator[GffRecord]:
                 end=int(f[4]),
                 score=f[5],
                 strand=f[6],
-                frame=f[7],
-                group=group,
+                phase=f[7],
+                attributes=parse_attributes(f[8]) if len(f) > 8 else {},
             )
 
 
-def read_gff(path: str | Path) -> list[GffRecord]:
-    return list(iter_gff(path))
+def read_gff3(path: str | Path) -> list[GffRecord]:
+    return list(iter_gff3(path))
 
 
-def write_gff(records: Iterable[GffRecord], path: str | Path) -> None:
+def write_gff3(records: Iterable[GffRecord], path: str | Path, header: bool = True) -> None:
     with open(path, "w") as fh:
+        if header:
+            fh.write("##gff-version 3\n")
         for rec in records:
             fh.write(rec.to_line() + "\n")

--- a/training/src/geneid_train/core/seq.py
+++ b/training/src/geneid_train/core/seq.py
@@ -1,0 +1,86 @@
+"""Sequence utilities: reverse-complement, translation, CDS completeness.
+
+Genetic-code awareness matters here: some geneid target species use non-standard
+codon tables (e.g. ciliates translate TAA/TAG as glutamine), which changes what
+counts as a stop and therefore what counts as a *complete* CDS. ``GeneticCode``
+captures the stop set so completeness checks stay correct per species.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANtgcan")
+
+# NCBI translation table 1 (standard)
+_STANDARD_CODONS = {
+    "TTT": "F", "TTC": "F", "TTA": "L", "TTG": "L",
+    "CTT": "L", "CTC": "L", "CTA": "L", "CTG": "L",
+    "ATT": "I", "ATC": "I", "ATA": "I", "ATG": "M",
+    "GTT": "V", "GTC": "V", "GTA": "V", "GTG": "V",
+    "TCT": "S", "TCC": "S", "TCA": "S", "TCG": "S",
+    "CCT": "P", "CCC": "P", "CCA": "P", "CCG": "P",
+    "ACT": "T", "ACC": "T", "ACA": "T", "ACG": "T",
+    "GCT": "A", "GCC": "A", "GCA": "A", "GCG": "A",
+    "TAT": "Y", "TAC": "Y", "TAA": "*", "TAG": "*",
+    "CAT": "H", "CAC": "H", "CAA": "Q", "CAG": "Q",
+    "AAT": "N", "AAC": "N", "AAA": "K", "AAG": "K",
+    "GAT": "D", "GAC": "D", "GAA": "E", "GAG": "E",
+    "TGT": "C", "TGC": "C", "TGA": "*", "TGG": "W",
+    "CGT": "R", "CGC": "R", "CGA": "R", "CGG": "R",
+    "AGT": "S", "AGC": "S", "AGA": "R", "AGG": "R",
+    "GGT": "G", "GGC": "G", "GGA": "G", "GGG": "G",
+}
+
+
+def revcomp(seq: str) -> str:
+    return seq.translate(_COMPLEMENT)[::-1]
+
+
+@dataclass(frozen=True)
+class GeneticCode:
+    """A codon table, specialized by which codons are stops and starts."""
+
+    codons: dict[str, str]
+    starts: frozenset[str] = frozenset({"ATG"})
+
+    @property
+    def stops(self) -> frozenset[str]:
+        return frozenset(c for c, aa in self.codons.items() if aa == "*")
+
+    def translate(self, seq: str) -> str:
+        s = seq.upper()
+        out = []
+        for i in range(0, len(s) - len(s) % 3, 3):
+            out.append(self.codons.get(s[i : i + 3], "X"))
+        return "".join(out)
+
+    def is_stop(self, codon: str) -> bool:
+        return self.codons.get(codon.upper()) == "*"
+
+    def is_start(self, codon: str) -> bool:
+        return codon.upper() in self.starts
+
+
+STANDARD = GeneticCode(codons=dict(_STANDARD_CODONS))
+
+
+def is_complete_cds(cds: str, code: GeneticCode = STANDARD) -> bool:
+    """A complete CDS: length a multiple of 3, canonical start, terminal stop,
+    and no in-frame internal stop."""
+    s = cds.upper()
+    if len(s) < 6 or len(s) % 3 != 0:
+        return False
+    if not code.is_start(s[:3]):
+        return False
+    if not code.is_stop(s[-3:]):
+        return False
+    internal = code.translate(s[:-3])
+    return "*" not in internal
+
+
+def has_internal_stop(cds: str, code: GeneticCode = STANDARD) -> bool:
+    """In-frame stop before the final codon (ignores a terminal stop)."""
+    s = cds.upper()
+    body = s[:-3] if len(s) >= 3 and code.is_stop(s[-3:]) else s
+    return "*" in code.translate(body)

--- a/training/src/geneid_train/prepare/base.py
+++ b/training/src/geneid_train/prepare/base.py
@@ -21,7 +21,7 @@ from ..core.seq import STANDARD, GeneticCode, revcomp
 class Exon:
     start: int  # 1-based inclusive
     end: int  # 1-based inclusive
-    frame: str = "."
+    phase: str = "."
 
 
 @dataclass
@@ -75,30 +75,32 @@ class GeneModel:
 
 
 def build_models(records: Iterable[GffRecord], cds_type: str = "CDS") -> list[GeneModel]:
-    """Group CDS features by gene id into GeneModels.
+    """Group CDS features into GeneModels by their GFF3 ``Parent`` (transcript id).
 
-    Records whose ``type`` differs from ``cds_type`` are ignored. Raises if a gene
-    has features on mixed seqids or strands.
+    Records whose ``type`` differs from ``cds_type`` are ignored. Raises if a
+    transcript has features on mixed seqids or strands, or a CDS lacks a Parent.
     """
     grouped: dict[str, list[GffRecord]] = {}
     for rec in records:
         if rec.type != cds_type:
             continue
-        grouped.setdefault(rec.gene_id, []).append(rec)
+        if not rec.parents:
+            raise ValueError(f"CDS {rec.id or rec.to_line()!r} has no Parent attribute")
+        grouped.setdefault(rec.parents[0], []).append(rec)
 
     models: list[GeneModel] = []
-    for gene_id, recs in grouped.items():
+    for tx_id, recs in grouped.items():
         seqids = {r.seqid for r in recs}
         strands = {r.strand for r in recs}
         if len(seqids) != 1:
-            raise ValueError(f"gene {gene_id!r} spans multiple seqids: {sorted(seqids)}")
+            raise ValueError(f"transcript {tx_id!r} spans multiple seqids: {sorted(seqids)}")
         if len(strands) != 1:
-            raise ValueError(f"gene {gene_id!r} has mixed strands: {sorted(strands)}")
+            raise ValueError(f"transcript {tx_id!r} has mixed strands: {sorted(strands)}")
         recs_sorted = sorted(recs, key=lambda r: r.start)
-        exons = [Exon(r.start, r.end, r.frame) for r in recs_sorted]
+        exons = [Exon(r.start, r.end, r.phase) for r in recs_sorted]
         models.append(
             GeneModel(
-                gene_id=gene_id,
+                gene_id=tx_id,
                 seqid=recs_sorted[0].seqid,
                 strand=recs_sorted[0].strand,
                 exons=exons,
@@ -180,9 +182,9 @@ def extract_locus(
             end=e.end - shift,
             score=".",
             strand=model.strand,
-            frame=e.frame,
-            group=model.gene_id,
+            phase=e.phase,
+            attributes={"ID": f"{model.gene_id}.cds{i}", "Parent": model.gene_id},
         )
-        for e in model.exons
+        for i, e in enumerate(model.exons, start=1)
     ]
     return Locus(gene_id=model.gene_id, seq=seq, records=recs)

--- a/training/src/geneid_train/prepare/base.py
+++ b/training/src/geneid_train/prepare/base.py
@@ -43,6 +43,11 @@ class GeneModel:
     def is_multiexonic(self) -> bool:
         return len(self.exons) > 1
 
+    @property
+    def coding_length(self) -> int:
+        """Total CDS length in nt (sum of exon lengths) — no genome needed."""
+        return sum(e.end - e.start + 1 for e in self.exons)
+
     def cds(self, genome: Mapping[str, str]) -> str:
         """Spliced CDS in 5'->3' translation orientation."""
         chrom = genome[self.seqid]
@@ -107,6 +112,32 @@ def build_models(records: Iterable[GffRecord], cds_type: str = "CDS") -> list[Ge
             )
         )
     return models
+
+
+def gene_of_transcript(records: Iterable[GffRecord]) -> dict[str, str]:
+    """Map transcript id -> gene id from mRNA/transcript records' Parent."""
+    out: dict[str, str] = {}
+    for r in records:
+        if r.type in ("mRNA", "transcript") and r.id:
+            out[r.id] = r.parents[0] if r.parents else r.id
+    return out
+
+
+def collapse_isoforms(
+    models: Iterable[GeneModel], records: Iterable[GffRecord]
+) -> list[GeneModel]:
+    """Keep one representative model (longest CDS) per gene.
+
+    Must run before ``filter_non_overlapping``: sibling isoforms overlap and would
+    otherwise eliminate each other. Genes are resolved via transcript->gene Parent
+    links; a model whose transcript has no gene record is treated as its own gene.
+    """
+    tx2gene = gene_of_transcript(records)
+    by_gene: dict[str, list[GeneModel]] = {}
+    for m in models:
+        gene = tx2gene.get(m.gene_id, m.gene_id)
+        by_gene.setdefault(gene, []).append(m)
+    return [max(ms, key=lambda x: x.coding_length) for ms in by_gene.values()]
 
 
 # ---- filters --------------------------------------------------------------

--- a/training/src/geneid_train/prepare/base.py
+++ b/training/src/geneid_train/prepare/base.py
@@ -1,0 +1,188 @@
+"""Validated gene-model intermediate representation (IR) and shared filters.
+
+Both training-set front-ends (BUSCO, RNA-seq/TransDecoder) converge on the
+``GeneModel`` IR defined here, so all filtering — completeness, minimum protein
+length, non-overlap, flank extraction — lives in one place and is exercised by one
+test suite.
+
+Coordinates are 1-based inclusive throughout, matching geneid/GFF conventions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from ..core.gff import GffRecord
+from ..core.seq import STANDARD, GeneticCode, revcomp
+
+
+@dataclass
+class Exon:
+    start: int  # 1-based inclusive
+    end: int  # 1-based inclusive
+    frame: str = "."
+
+
+@dataclass
+class GeneModel:
+    gene_id: str
+    seqid: str
+    strand: str
+    exons: list[Exon]  # stored sorted by ascending genomic start
+
+    @property
+    def start(self) -> int:
+        return self.exons[0].start
+
+    @property
+    def end(self) -> int:
+        return self.exons[-1].end
+
+    @property
+    def is_multiexonic(self) -> bool:
+        return len(self.exons) > 1
+
+    def cds(self, genome: Mapping[str, str]) -> str:
+        """Spliced CDS in 5'->3' translation orientation."""
+        chrom = genome[self.seqid]
+        pieces = [chrom[e.start - 1 : e.end] for e in self.exons]
+        joined = "".join(pieces)
+        return revcomp(joined) if self.strand == "-" else joined
+
+    def protein(self, genome: Mapping[str, str], code: GeneticCode = STANDARD) -> str:
+        return code.translate(self.cds(genome))
+
+    def introns(self) -> list[tuple[int, int]]:
+        """Genomic (start, end) of each intron, ascending. Empty if single-exon."""
+        out = []
+        for prev, nxt in zip(self.exons, self.exons[1:]):
+            out.append((prev.end + 1, nxt.start - 1))
+        return out
+
+    def intron_seqs(self, genome: Mapping[str, str]) -> list[str]:
+        """Intron sequences in transcription orientation (donor at the 5' end)."""
+        chrom = genome[self.seqid]
+        seqs = [chrom[s - 1 : e] for s, e in self.introns()]
+        if self.strand == "-":
+            seqs = [revcomp(x) for x in reversed(seqs)]
+        return seqs
+
+    def is_complete(self, genome: Mapping[str, str], code: GeneticCode = STANDARD) -> bool:
+        from ..core.seq import is_complete_cds
+
+        return is_complete_cds(self.cds(genome), code)
+
+
+def build_models(records: Iterable[GffRecord], cds_type: str = "CDS") -> list[GeneModel]:
+    """Group CDS features by gene id into GeneModels.
+
+    Records whose ``type`` differs from ``cds_type`` are ignored. Raises if a gene
+    has features on mixed seqids or strands.
+    """
+    grouped: dict[str, list[GffRecord]] = {}
+    for rec in records:
+        if rec.type != cds_type:
+            continue
+        grouped.setdefault(rec.gene_id, []).append(rec)
+
+    models: list[GeneModel] = []
+    for gene_id, recs in grouped.items():
+        seqids = {r.seqid for r in recs}
+        strands = {r.strand for r in recs}
+        if len(seqids) != 1:
+            raise ValueError(f"gene {gene_id!r} spans multiple seqids: {sorted(seqids)}")
+        if len(strands) != 1:
+            raise ValueError(f"gene {gene_id!r} has mixed strands: {sorted(strands)}")
+        recs_sorted = sorted(recs, key=lambda r: r.start)
+        exons = [Exon(r.start, r.end, r.frame) for r in recs_sorted]
+        models.append(
+            GeneModel(
+                gene_id=gene_id,
+                seqid=recs_sorted[0].seqid,
+                strand=recs_sorted[0].strand,
+                exons=exons,
+            )
+        )
+    return models
+
+
+# ---- filters --------------------------------------------------------------
+
+
+def filter_complete(
+    models: Iterable[GeneModel], genome: Mapping[str, str], code: GeneticCode = STANDARD
+) -> list[GeneModel]:
+    return [m for m in models if m.is_complete(genome, code)]
+
+
+def filter_min_protein(
+    models: Iterable[GeneModel],
+    genome: Mapping[str, str],
+    min_aa: int,
+    code: GeneticCode = STANDARD,
+) -> list[GeneModel]:
+    kept = []
+    for m in models:
+        prot = m.protein(genome, code).rstrip("*")
+        if len(prot) >= min_aa:
+            kept.append(m)
+    return kept
+
+
+def filter_non_overlapping(models: Iterable[GeneModel]) -> list[GeneModel]:
+    """Drop every model whose genomic span overlaps any other model on the same
+    seqid, regardless of strand (a training-set requirement). Both members of an
+    overlapping pair are removed.
+    """
+    mlist = list(models)
+    overlapping: set[int] = set()
+    by_seq: dict[str, list[int]] = {}
+    for i, m in enumerate(mlist):
+        by_seq.setdefault(m.seqid, []).append(i)
+    for idxs in by_seq.values():
+        idxs.sort(key=lambda i: mlist[i].start)
+        for a in range(len(idxs)):
+            ma = mlist[idxs[a]]
+            for b in range(a + 1, len(idxs)):
+                mb = mlist[idxs[b]]
+                if mb.start > ma.end:
+                    break  # no further overlaps for ma (sorted by start)
+                overlapping.add(idxs[a])
+                overlapping.add(idxs[b])
+    return [m for i, m in enumerate(mlist) if i not in overlapping]
+
+
+@dataclass
+class Locus:
+    """A gene placed on a sub-sequence with genomic flanks, coordinates shifted
+    so the locus starts at 1. This is the per-gene training unit geneid sees."""
+
+    gene_id: str
+    seq: str
+    records: list[GffRecord]
+
+
+def extract_locus(
+    model: GeneModel, genome: Mapping[str, str], flank: int, source: str = "geneid_train"
+) -> Locus:
+    chrom = genome[model.seqid]
+    lo = max(0, model.start - 1 - flank)  # 0-based slice start
+    hi = min(len(chrom), model.end + flank)  # 0-based slice end (exclusive)
+    seq = chrom[lo:hi]
+    shift = lo  # subtract from 1-based coords: new = old - lo
+    recs = [
+        GffRecord(
+            seqid=model.gene_id,
+            source=source,
+            type="CDS",
+            start=e.start - shift,
+            end=e.end - shift,
+            score=".",
+            strand=model.strand,
+            frame=e.frame,
+            group=model.gene_id,
+        )
+        for e in model.exons
+    ]
+    return Locus(gene_id=model.gene_id, seq=seq, records=recs)

--- a/training/src/geneid_train/prepare/classify.py
+++ b/training/src/geneid_train/prepare/classify.py
@@ -1,0 +1,110 @@
+"""Splice-class tally and per-class training recommendations.
+
+Given a validated gene set, count intron donor/acceptor dinucleotides and map them
+to the geneid profile classes, then recommend — per rare class — whether to train
+a profile de novo, transplant an existing cross-taxa one, or omit it. This is the
+report that drives the optional-profile decision (GC donors, U12) described in
+DESIGN.md; it is deliberately lightweight and does not attempt full-fidelity
+intron classification.
+
+Note: U12 GT-AG introns are indistinguishable from bulk U2 GT-AG by dinucleotide
+alone — separating them requires scoring against an existing U12 branch/donor/
+acceptor model (bootstrap), which is a separate step. This report flags that
+rather than guessing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from .base import GeneModel
+
+# (donor, acceptor) -> (human-readable class, geneid profile section it feeds)
+_CLASS_MAP = {
+    ("GT", "AG"): ("U2 GT-AG", "U2gta_Donor_profile"),
+    ("GC", "AG"): ("U2 GC-AG", "U2gcag_Donor_profile"),
+    ("AT", "AC"): ("U12 AT-AC", "U12atac_Donor_profile (+acceptor+branch trio)"),
+}
+# rare classes we make an explicit train/transplant/omit call on
+_OPTIONAL = {("GC", "AG"), ("AT", "AC")}
+
+
+@dataclass
+class ClassRecommendation:
+    name: str
+    profile: str
+    count: int
+    fraction: float
+    recommendation: str
+
+
+@dataclass
+class SpliceReport:
+    n_models: int
+    n_multiexonic: int
+    n_introns: int
+    donor_counts: dict[str, int]
+    acceptor_counts: dict[str, int]
+    pair_counts: dict[tuple[str, str], int]
+    classes: list[ClassRecommendation]
+
+
+def _recommend(count: int, min_sites: int) -> str:
+    if count == 0:
+        return "omit (none found)"
+    if count >= min_sites:
+        return f"train de novo (compare held-out SN/SP vs transplant); n={count}"
+    return f"transplant (too few to train: n={count} < {min_sites})"
+
+
+def classify_report(
+    models: Iterable[GeneModel], genome: Mapping[str, str], min_sites: int = 50
+) -> SpliceReport:
+    models = list(models)
+    donor: dict[str, int] = {}
+    acceptor: dict[str, int] = {}
+    pair: dict[tuple[str, str], int] = {}
+    n_introns = 0
+    for m in models:
+        if m.seqid not in genome:
+            continue
+        for iseq in m.intron_seqs(genome):
+            if len(iseq) < 4:
+                continue
+            d, a = iseq[:2], iseq[-2:]
+            if "N" in d or "N" in a:
+                continue
+            n_introns += 1
+            donor[d] = donor.get(d, 0) + 1
+            acceptor[a] = acceptor.get(a, 0) + 1
+            pair[(d, a)] = pair.get((d, a), 0) + 1
+
+    classes: list[ClassRecommendation] = []
+    denom = n_introns or 1
+    for key, (name, profile) in _CLASS_MAP.items():
+        count = pair.get(key, 0)
+        if key in _OPTIONAL:
+            rec = _recommend(count, min_sites)
+        else:
+            rec = "bulk class (always trained)"
+        classes.append(ClassRecommendation(name, profile, count, count / denom, rec))
+    # U12 GT-AG cannot be seen by dinucleotide alone
+    classes.append(
+        ClassRecommendation(
+            "U12 GT-AG",
+            "U12gtag_Donor_profile (+acceptor+branch trio)",
+            -1,
+            0.0,
+            "requires bootstrap scoring of GT-AG introns vs an existing U12 param",
+        )
+    )
+    return SpliceReport(
+        n_models=len(models),
+        n_multiexonic=sum(m.is_multiexonic for m in models),
+        n_introns=n_introns,
+        donor_counts=dict(sorted(donor.items(), key=lambda kv: -kv[1])),
+        acceptor_counts=dict(sorted(acceptor.items(), key=lambda kv: -kv[1])),
+        pair_counts=pair,
+        classes=classes,
+    )

--- a/training/src/geneid_train/prepare/transcripts.py
+++ b/training/src/geneid_train/prepare/transcripts.py
@@ -1,0 +1,27 @@
+"""RNA-seq / TransDecoder front-end.
+
+Ingests a TransDecoder (or PASA) genome GFF3 of predicted ORFs and produces the
+validated gene-model IR, one representative (longest-CDS) model per gene.
+
+Provenance/quality filtering — removing repeat-overlapping candidates and the
+UniProt cross-check (DIAMOND, >=90% coverage) — is done upstream in the annotation
+pipeline (e.g. the CNAG `get_candidates` step yields `good_candidates.1trans.gff3`).
+This adapter therefore does not re-implement the UniProt check; it consumes the
+already-filtered candidate GFF3. Verified against real xgXerMont data: all such
+candidates are complete ORFs (ATG start, terminal stop inside the CDS coordinates,
+in-frame, no internal stops).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..core.gff import read_gff3
+from .base import GeneModel, build_models, collapse_isoforms
+
+
+def load(gff3_path: str | Path, cds_type: str = "CDS") -> list[GeneModel]:
+    """Read a TransDecoder/PASA genome GFF3 -> one GeneModel per gene."""
+    records = read_gff3(gff3_path)
+    models = build_models(records, cds_type=cds_type)
+    return collapse_isoforms(models, records)

--- a/training/tests/test_classify.py
+++ b/training/tests/test_classify.py
@@ -1,0 +1,48 @@
+from geneid_train.prepare.base import Exon, GeneModel
+from geneid_train.prepare.classify import classify_report
+
+# chr1: exon[1-6] GT-AG intron[7-16] exon[17-22] GC-AG intron[23-32] exon[33-38]
+CHR1 = "AAAAAA" + "GTAAAAAAAG" + "CCCCCC" + "GCAAAAAAAG" + "GGGGGG"
+# chr2: exon[1-6] AT-AC intron[7-16] exon[17-22]
+CHR2 = "AAAAAA" + "ATAAAAAAAC" + "GGGGGG"
+GENOME = {"chr1": CHR1, "chr2": CHR2}
+
+M1 = GeneModel("g1", "chr1", "+", [Exon(1, 6), Exon(17, 22), Exon(33, 38)])
+M2 = GeneModel("g2", "chr2", "+", [Exon(1, 6), Exon(17, 22)])
+
+
+def test_tally_counts_each_class():
+    rep = classify_report([M1, M2], GENOME, min_sites=1)
+    assert rep.n_introns == 3
+    assert rep.pair_counts[("GT", "AG")] == 1
+    assert rep.pair_counts[("GC", "AG")] == 1
+    assert rep.pair_counts[("AT", "AC")] == 1
+    assert rep.donor_counts == {"GT": 1, "GC": 1, "AT": 1}
+
+
+def test_recommendation_train_vs_transplant():
+    by_name = {c.name: c for c in classify_report([M1, M2], GENOME, min_sites=1).classes}
+    assert "train de novo" in by_name["U2 GC-AG"].recommendation
+    # bulk class is never gated
+    assert "bulk" in by_name["U2 GT-AG"].recommendation
+    # U12 GT-AG can't be seen by dinucleotide alone
+    assert by_name["U12 GT-AG"].count == -1
+    assert "bootstrap" in by_name["U12 GT-AG"].recommendation
+
+
+def test_recommendation_transplant_when_below_threshold():
+    by_name = {c.name: c for c in classify_report([M1, M2], GENOME, min_sites=50).classes}
+    assert "transplant" in by_name["U2 GC-AG"].recommendation
+    assert "transplant" in by_name["U12 AT-AC"].recommendation
+
+
+def test_n_containing_boundaries_skipped():
+    genome = {"c": "AAAAAA" + "GTNAAAANAG" + "GGGGGG"}
+    m = GeneModel("g", "c", "+", [Exon(1, 6), Exon(17, 22)])
+    rep = classify_report([m], genome, min_sites=1)
+    # donor "GT" ok, acceptor "AG" ok here (Ns are internal), so it counts
+    assert rep.n_introns == 1
+    # now make the acceptor contain N
+    genome2 = {"c": "AAAAAA" + "GTAAAAAANN" + "GGGGGG"}
+    rep2 = classify_report([m], genome2, min_sites=1)
+    assert rep2.n_introns == 0

--- a/training/tests/test_convert.py
+++ b/training/tests/test_convert.py
@@ -1,0 +1,40 @@
+from geneid_train.core.convert import gff2_to_gff3, gtf_to_gff3
+from geneid_train.prepare.base import build_models
+
+GENOME = {"chr1": "CCCCCCCCCC" + "ATGAAA" + "GTAAAAAAAG" + "AAATTTTAA" + "GGGGGGGGGG"}
+
+
+def test_gff2_to_gff3_builds_hierarchy_and_models():
+    lines = [
+        "chr1\ts\tCDS\t11\t16\t.\t+\t0\tgene1\n",
+        "chr1\ts\tCDS\t27\t35\t.\t+\t0\tgene1\n",
+    ]
+    recs = gff2_to_gff3(lines)
+    types = [r.type for r in recs]
+    assert types == ["gene", "mRNA", "CDS", "CDS"]
+    # gene id is suffixed to stay unique vs the same-named transcript
+    assert recs[0].id == "gene1.gene"  # gene
+    assert recs[1].id == "gene1" and recs[1].parents == ["gene1.gene"]  # mRNA -> gene
+    assert all(r.parents == ["gene1"] for r in recs if r.type == "CDS")
+    # feeds the IR cleanly
+    (m,) = build_models(recs)
+    assert m.cds(GENOME) == "ATGAAAAAATTTTAA"
+
+
+def test_gtf_to_gff3_uses_transcript_and_gene_ids():
+    lines = [
+        'chr1\ts\tCDS\t11\t16\t.\t+\t0\ttranscript_id "t1"; gene_id "g1";\n',
+        'chr1\ts\tCDS\t27\t35\t.\t+\t0\ttranscript_id "t1"; gene_id "g1";\n',
+    ]
+    recs = gtf_to_gff3(lines)
+    gene = next(r for r in recs if r.type == "gene")
+    mrna = next(r for r in recs if r.type == "mRNA")
+    assert gene.id == "g1"
+    assert mrna.id == "t1" and mrna.parents == ["g1"]
+    assert [r.type for r in recs if r.type == "CDS"] == ["CDS", "CDS"]
+
+
+def test_gff2_quoted_group_token():
+    lines = ['chr1\ts\tCDS\t11\t16\t.\t+\t0\tgene_id "abc"\n']
+    recs = gff2_to_gff3(lines)
+    assert next(r for r in recs if r.type == "CDS").parents == ["abc"]

--- a/training/tests/test_io.py
+++ b/training/tests/test_io.py
@@ -4,7 +4,12 @@ from geneid_train.core.fasta import (
     write_fasta,
     write_tbl,
 )
-from geneid_train.core.gff import GffRecord, read_gff, write_gff
+from geneid_train.core.gff import (
+    GffRecord,
+    parse_attributes,
+    read_gff3,
+    write_gff3,
+)
 
 
 def test_fasta_roundtrip_and_header_token(tmp_path):
@@ -24,22 +29,32 @@ def test_tbl_roundtrip(tmp_path):
     assert read_tbl(p) == recs
 
 
-def test_gff_roundtrip_and_gene_id(tmp_path):
-    p = tmp_path / "s.gff"
+def test_gff3_read_and_attributes(tmp_path):
+    p = tmp_path / "s.gff3"
     p.write_text(
-        "chr1\tsrc\tCDS\t11\t16\t.\t+\t0\tgene1\n"
-        "chr1\tsrc\tCDS\t27\t35\t.\t+\t0\tgene1\n"
+        "##gff-version 3\n"
+        "chr1\tsrc\tCDS\t11\t16\t.\t+\t0\tID=t1.cds1;Parent=t1\n"
+        "chr1\tsrc\tCDS\t27\t35\t.\t+\t0\tID=t1.cds2;Parent=t1\n"
     )
-    recs = read_gff(p)
+    recs = read_gff3(p)
     assert len(recs) == 2
-    assert recs[0].gene_id == "gene1"
+    assert recs[0].id == "t1.cds1"
+    assert recs[0].parents == ["t1"]
     assert recs[0].start == 11 and recs[0].end == 16
-    out = tmp_path / "out.gff"
-    write_gff(recs, out)
-    assert out.read_text() == p.read_text()
 
 
-def test_gff_gene_id_is_bare_group_token():
-    # geneid training GFF2 uses the bare gene id (optionally quoted) as the group.
-    assert GffRecord("c", "s", "CDS", 1, 9, ".", "+", "0", "abc").gene_id == "abc"
-    assert GffRecord("c", "s", "CDS", 1, 9, ".", "+", "0", '"abc"').gene_id == "abc"
+def test_gff3_roundtrip(tmp_path):
+    recs = [
+        GffRecord("chr1", "src", "CDS", 11, 16, ".", "+", "0", {"ID": "t1.cds1", "Parent": "t1"}),
+    ]
+    out = tmp_path / "out.gff3"
+    write_gff3(recs, out)
+    reread = read_gff3(out)
+    assert reread[0].to_line() == recs[0].to_line()
+
+
+def test_parse_attributes_multi_parent():
+    attrs = parse_attributes("ID=c1;Parent=t1,t2")
+    assert attrs == {"ID": "c1", "Parent": "t1,t2"}
+    rec = GffRecord("c", "s", "CDS", 1, 9, ".", "+", "0", attrs)
+    assert rec.parents == ["t1", "t2"]

--- a/training/tests/test_io.py
+++ b/training/tests/test_io.py
@@ -22,6 +22,15 @@ def test_fasta_roundtrip_and_header_token(tmp_path):
     assert read_fasta(out) == recs
 
 
+def test_fasta_reads_gzip_transparently(tmp_path):
+    import gzip
+
+    p = tmp_path / "s.fa.gz"
+    with gzip.open(p, "wt") as fh:
+        fh.write(">chr1\nACGTACGT\n>chr2\nTTTT\n")
+    assert read_fasta(p) == {"chr1": "ACGTACGT", "chr2": "TTTT"}
+
+
 def test_tbl_roundtrip(tmp_path):
     recs = {"a": "ACGT", "b": "TTTTGGGG"}
     p = tmp_path / "s.tbl"

--- a/training/tests/test_io.py
+++ b/training/tests/test_io.py
@@ -1,0 +1,45 @@
+from geneid_train.core.fasta import (
+    read_fasta,
+    read_tbl,
+    write_fasta,
+    write_tbl,
+)
+from geneid_train.core.gff import GffRecord, read_gff, write_gff
+
+
+def test_fasta_roundtrip_and_header_token(tmp_path):
+    src = tmp_path / "s.fa"
+    src.write_text(">chr1 description here\nACGTACGT\nAAAA\n>chr2\nTTTT\n")
+    recs = read_fasta(src)
+    assert recs == {"chr1": "ACGTACGTAAAA", "chr2": "TTTT"}
+    out = tmp_path / "out.fa"
+    write_fasta(recs, out, width=4)
+    assert read_fasta(out) == recs
+
+
+def test_tbl_roundtrip(tmp_path):
+    recs = {"a": "ACGT", "b": "TTTTGGGG"}
+    p = tmp_path / "s.tbl"
+    write_tbl(recs, p)
+    assert read_tbl(p) == recs
+
+
+def test_gff_roundtrip_and_gene_id(tmp_path):
+    p = tmp_path / "s.gff"
+    p.write_text(
+        "chr1\tsrc\tCDS\t11\t16\t.\t+\t0\tgene1\n"
+        "chr1\tsrc\tCDS\t27\t35\t.\t+\t0\tgene1\n"
+    )
+    recs = read_gff(p)
+    assert len(recs) == 2
+    assert recs[0].gene_id == "gene1"
+    assert recs[0].start == 11 and recs[0].end == 16
+    out = tmp_path / "out.gff"
+    write_gff(recs, out)
+    assert out.read_text() == p.read_text()
+
+
+def test_gff_gene_id_is_bare_group_token():
+    # geneid training GFF2 uses the bare gene id (optionally quoted) as the group.
+    assert GffRecord("c", "s", "CDS", 1, 9, ".", "+", "0", "abc").gene_id == "abc"
+    assert GffRecord("c", "s", "CDS", 1, 9, ".", "+", "0", '"abc"').gene_id == "abc"

--- a/training/tests/test_prepare.py
+++ b/training/tests/test_prepare.py
@@ -1,0 +1,78 @@
+from geneid_train.core.gff import GffRecord
+from geneid_train.prepare.base import (
+    Exon,
+    GeneModel,
+    build_models,
+    extract_locus,
+    filter_complete,
+    filter_min_protein,
+    filter_non_overlapping,
+)
+
+# Synthetic chr1 (1-based): flank[1-10], exon1[11-16]=ATGAAA,
+# intron[17-26]=GTAAAAAAAG, exon2[27-35]=AAATTTTAA, flank[36-45].
+CHROM = "CCCCCCCCCC" + "ATGAAA" + "GTAAAAAAAG" + "AAATTTTAA" + "GGGGGGGGGG"
+GENOME = {"chr1": CHROM}
+
+
+def _gene1_records():
+    return [
+        GffRecord("chr1", "s", "CDS", 11, 16, ".", "+", "0", "gene1"),
+        GffRecord("chr1", "s", "CDS", 27, 35, ".", "+", "0", "gene1"),
+    ]
+
+
+def test_build_and_cds():
+    (m,) = build_models(_gene1_records())
+    assert m.gene_id == "gene1"
+    assert m.is_multiexonic
+    assert m.cds(GENOME) == "ATGAAAAAATTTTAA"
+    assert m.protein(GENOME) == "MKKF*"
+    assert m.introns() == [(17, 26)]
+    assert m.intron_seqs(GENOME) == ["GTAAAAAAAG"]  # donor GT / acceptor AG
+    assert m.is_complete(GENOME)
+
+
+def test_build_rejects_mixed_strand():
+    recs = _gene1_records()
+    recs[1].strand = "-"
+    try:
+        build_models(recs)
+    except ValueError as e:
+        assert "mixed strands" in str(e)
+    else:
+        raise AssertionError("expected ValueError on mixed strands")
+
+
+def test_filters_complete_and_min_protein():
+    models = build_models(_gene1_records())
+    assert len(filter_complete(models, GENOME)) == 1
+    assert len(filter_min_protein(models, GENOME, min_aa=4)) == 1  # MKKF
+    assert len(filter_min_protein(models, GENOME, min_aa=5)) == 0
+
+
+def _model(gid, start, end, seqid="chr1", strand="+"):
+    return GeneModel(gid, seqid, strand, [Exon(start, end, "0")])
+
+
+def test_non_overlapping_drops_both_of_a_pair():
+    a = _model("a", 10, 100)
+    b = _model("b", 90, 200, strand="-")  # overlaps a on opposite strand -> both drop
+    c = _model("c", 300, 400)  # clear
+    kept = filter_non_overlapping([a, b, c])
+    assert [m.gene_id for m in kept] == ["c"]
+
+
+def test_non_overlapping_keeps_different_seqids():
+    a = _model("a", 10, 100, seqid="chr1")
+    b = _model("b", 50, 150, seqid="chr2")
+    kept = filter_non_overlapping([a, b])
+    assert {m.gene_id for m in kept} == {"a", "b"}
+
+
+def test_extract_locus_shifts_coordinates():
+    (m,) = build_models(_gene1_records())
+    locus = extract_locus(m, GENOME, flank=5)
+    assert locus.seq == CHROM[5:40]  # lo=5 (0-based), hi=40
+    assert [(r.start, r.end) for r in locus.records] == [(6, 11), (22, 30)]
+    assert all(r.seqid == "gene1" for r in locus.records)

--- a/training/tests/test_prepare.py
+++ b/training/tests/test_prepare.py
@@ -17,8 +17,8 @@ GENOME = {"chr1": CHROM}
 
 def _gene1_records():
     return [
-        GffRecord("chr1", "s", "CDS", 11, 16, ".", "+", "0", "gene1"),
-        GffRecord("chr1", "s", "CDS", 27, 35, ".", "+", "0", "gene1"),
+        GffRecord("chr1", "s", "CDS", 11, 16, ".", "+", "0", {"ID": "c1", "Parent": "gene1"}),
+        GffRecord("chr1", "s", "CDS", 27, 35, ".", "+", "0", {"ID": "c2", "Parent": "gene1"}),
     ]
 
 

--- a/training/tests/test_seq.py
+++ b/training/tests/test_seq.py
@@ -1,0 +1,43 @@
+from geneid_train.core.seq import (
+    STANDARD,
+    GeneticCode,
+    has_internal_stop,
+    is_complete_cds,
+    revcomp,
+)
+
+
+def test_revcomp():
+    assert revcomp("ATGC") == "GCAT"
+    assert revcomp("aaccggtt") == "aaccggtt"[::-1].translate(str.maketrans("acgt", "tgca"))
+
+
+def test_translate_standard():
+    # ATG AAA TTT TAA -> M K F *
+    assert STANDARD.translate("ATGAAATTTTAA") == "MKF*"
+
+
+def test_is_complete_cds():
+    assert is_complete_cds("ATGAAAAAATTTTAA")  # M K K F *
+    assert not is_complete_cds("ATGAAATTT")  # no terminal stop
+    assert not is_complete_cds("AAAAAATTTTAA")  # no start
+    assert not is_complete_cds("ATGTAAAAATAA")  # internal stop
+    assert not is_complete_cds("ATGAAATT")  # not multiple of 3
+
+
+def test_has_internal_stop_ignores_terminal():
+    assert not has_internal_stop("ATGAAATAA")
+    assert has_internal_stop("ATGTAAAAATAA")
+
+
+def test_alternative_genetic_code_ciliate():
+    # ciliate: TAA/TAG code for Q, only TGA is a stop
+    codons = dict(STANDARD.codons)
+    codons["TAA"] = "Q"
+    codons["TAG"] = "Q"
+    ciliate = GeneticCode(codons=codons)
+    assert ciliate.stops == frozenset({"TGA"})
+    # a CDS with TAA internally is complete under the ciliate code, not the standard one
+    cds = "ATGTAAAAATGA"  # M Q K *  (ciliate)
+    assert is_complete_cds(cds, ciliate)
+    assert not is_complete_cds(cds, STANDARD)

--- a/training/tests/test_transcripts.py
+++ b/training/tests/test_transcripts.py
@@ -1,0 +1,51 @@
+from geneid_train.core.gff import GffRecord
+from geneid_train.prepare.base import build_models, collapse_isoforms
+from geneid_train.prepare.transcripts import load
+
+
+def _rec(type_, start, end, attrs, strand="+"):
+    return GffRecord("chr1", "td", type_, start, end, ".", strand, "0" if type_ == "CDS" else ".",
+                     attrs)
+
+
+def _two_isoform_gff():
+    # gene g1 with two transcripts: t1 (short, 1 CDS) and t2 (long, 2 CDS)
+    return [
+        _rec("gene", 100, 500, {"ID": "g1"}),
+        _rec("mRNA", 100, 200, {"ID": "t1", "Parent": "g1"}),
+        _rec("CDS", 100, 160, {"ID": "t1.c1", "Parent": "t1"}),
+        _rec("mRNA", 100, 500, {"ID": "t2", "Parent": "g1"}),
+        _rec("CDS", 100, 200, {"ID": "t2.c1", "Parent": "t2"}),
+        _rec("CDS", 400, 500, {"ID": "t2.c2", "Parent": "t2"}),
+    ]
+
+
+def test_collapse_picks_longest_cds_per_gene():
+    records = _two_isoform_gff()
+    models = build_models(records)
+    assert len(models) == 2  # two transcripts
+    collapsed = collapse_isoforms(models, records)
+    assert len(collapsed) == 1  # one gene
+    assert collapsed[0].gene_id == "t2"  # longest CDS (61+101 vs 61)
+    assert collapsed[0].coding_length == (200 - 100 + 1) + (500 - 400 + 1)
+
+
+def test_load_transcripts_end_to_end(tmp_path):
+    p = tmp_path / "td.gff3"
+    from geneid_train.core.gff import write_gff3
+
+    write_gff3(_two_isoform_gff(), p)
+    models = load(p)
+    assert len(models) == 1
+    assert models[0].gene_id == "t2"
+
+
+def test_model_without_gene_record_is_its_own_gene():
+    # bare CDS with Parent but no mRNA/gene record
+    recs = [
+        GffRecord("chr1", "td", "CDS", 1, 30, ".", "+", "0", {"ID": "c", "Parent": "orphan"}),
+    ]
+    models = build_models(recs)
+    collapsed = collapse_isoforms(models, recs)
+    assert len(collapsed) == 1
+    assert collapsed[0].gene_id == "orphan"


### PR DESCRIPTION
## Phase 2 of the geneid training overhaul

Builds the shared prepare core that turns real annotation output into a validated training set, standardizes on GFF3, and lands the RNA-seq/TransDecoder front-end. Follows #29 (Phase 1: the `.param` I/O core).

### What's here
- **GFF3 is the one canonical format.** `core/gff.py` is GFF3-native (attributes/ID/Parent; CDS grouped by Parent); `core/convert.py` converts GFF2/GTF -> GFF3 (`geneid-train convert`). Nothing else is parsed inline.
- **Validated gene-model IR + shared filters** (`prepare/base.py`): spliced CDS/protein/introns, completeness, min-protein, non-overlap (both strands), flank extraction, and isoform collapsing (longest CDS per gene, run before non-overlap so sibling isoforms don't eliminate each other).
- **Splice-class tally** (`prepare/classify.py`, `geneid-train classify`): donor/acceptor dinucleotide breakdown mapped to geneid profile classes with per-class train-de-novo / transplant / omit recommendations (GC-AG, U12).
- **Transcripts front-end** (`prepare/transcripts.py`): TransDecoder/PASA genome GFF3 -> IR (UniProt/repeat filtering is upstream).
- **Sequence utilities** (`core/seq.py`, gzip-transparent `core/fasta.py`): genetic-code-aware completeness (per-species stop sets), FASTA/tbl I/O reading `.fa.gz` directly.

### Validated on real data (snail *Xerocrassa montserratensis*, xgXerMont)
- `classify` on `good_candidates.1trans.gff3` + the `.fa.gz` genome: 9776 introns -> GT-AG 99.25%, GC-AG 0.72% (70, de-novo-trainable), AT-AC 0.03% (3, transplant-only) -- matching the legacy run's non-canonical-donor count.
- `prepare` end-to-end: 1000 transcripts -> 997 validated training genes (all complete; terminal stop confirmed inside the TransDecoder CDS coordinates).

### Deferred
- `prepare/busco.py` (the BUSCO fallback front-end) is deferred to a later phase -- the example's BUSCO run dirs were deleted and a BUSCO 6 / mollusca_odb12 rerun is needed for a real fixture.

52 tests pass, ruff-clean. See `training/DESIGN.md` for the full plan, the frozen `.param` format, the U2/U12/GC profile taxonomy, and the optional-profile decision rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)