### PR TITLE
Phase 3: site/coding model estimation + end-to-end geneid-train train

### DIFF
--- a/training/DESIGN.md
+++ b/training/DESIGN.md
@@ -76,6 +76,29 @@ concern handled at the `engine.py` boundary.
 The north-star metric is **held-out SN/SP equal-to-or-better than the current Perl
 pipeline** on the test species, not identical intermediate numbers.
 
+### Start-site scoring is weak by nature -- lean on coding potential, keep it swappable
+
+Start-codon PWMs carry little information (confirmed empirically on xgXerMont:
+order 0, the weakest profile class geneid supports) -- ATG context alone is a
+poor discriminator. Two design consequences (Tyler, 2026-07-02):
+
+- **Training data strategy:** rather than training the start profile to sharply
+  separate real starts from decoys, treat every in-frame ATG in a training CDS as
+  a start candidate and let the coding-potential (Markov) model carry the real
+  discriminating weight; the start profile stays a weak prior on top, not the
+  decision-maker. This matches how geneid's own gene assembly already combines
+  site + coding scores -- it just means the *trainer* shouldn't over-invest in
+  making the start PWM discriminative.
+- **Architecture:** keep each site class (start/donor/acceptor/branch) behind a
+  swappable scorer interface rather than hard-wiring the Markov/PWM math as the
+  only option. The near-term implementation is the Markov/PWM pipeline in
+  `stats/sites.py`; a future start-site scorer (e.g. a small NN) should be able to
+  slot in without changing `stats/model.py`, `optimize.py`, or `evaluate.py` --
+  those only need a profile object (or an external score), not the estimation
+  method that produced it. Do not build this abstraction speculatively ahead of
+  need; keep the interface narrow enough that swapping is possible when it
+  actually comes up.
+
 ### Optional splice-class profiles (GC donors, U12)
 
 geneid natively reads separate profiles for the full splice taxonomy —

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -21,6 +21,9 @@ geneid-train = "geneid_train.cli:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+geneid_train = ["data/*.param"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -26,7 +26,6 @@ from .prepare.classify import classify_report
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
 _STUBS = {
-    "train": "estimate site + coding models and assemble a .param file (phases 3-4)",
     "evaluate": "score a .param against held-out gene models, U2/U12-aware (phase 5)",
     "jackknife": "leave-group-out cross-validation of a training set (phase 7)",
 }
@@ -116,6 +115,33 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_train(args: argparse.Namespace) -> int:
+    from .train import train
+
+    genome = read_fasta(args.fastas)
+    records = read_gff3(args.gff)
+    models = collapse_isoforms(build_models(records), records)
+    if not models:
+        sys.stderr.write("no CDS-grouped gene models found in GFF3\n")
+        return 1
+    models = filter_non_overlapping(
+        filter_min_protein(filter_complete(models, genome), genome, args.min_aa)
+    )
+    sys.stderr.write(f"training on {len(models)} complete, non-overlapping gene models\n")
+    if not models:
+        sys.stderr.write("no models survived filtering\n")
+        return 1
+    try:
+        param_text = train(models, genome, args.species, seed=args.seed)
+    except NotImplementedError as exc:
+        sys.stderr.write(f"geneid-train train: {exc}\n")
+        return 2
+    with open(args.output, "w") as fh:
+        fh.write(param_text)
+    print(f"wrote parameter file: {args.output}")
+    return 0
+
+
 def _model_records(model) -> list[GffRecord]:
     return [
         GffRecord(
@@ -168,6 +194,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--min-sites", type=int, default=50, help="min sites to train a rare-class profile de novo"
     )
     p_cls.set_defaults(func=_cmd_classify)
+
+    p_train = sub.add_parser(
+        "train", help="estimate site + coding models and assemble a geneid .param file"
+    )
+    p_train.add_argument("--gff", required=True, help="GFF3 of CDS features (Parent = transcript)")
+    p_train.add_argument("--fastas", required=True, help="genomic multi-FASTA")
+    p_train.add_argument("--species", required=True, help="species name for the param header")
+    p_train.add_argument("--output", required=True, help="output .param path")
+    p_train.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
+    p_train.add_argument(
+        "--seed", type=int, default=0, help="RNG seed for background sampling (reproducibility)"
+    )
+    p_train.set_defaults(func=_cmd_train)
 
     p_conv = sub.add_parser("convert", help="convert GFF2 or GTF annotation to canonical GFF3")
     p_conv.add_argument("--from", dest="from_", required=True, choices=["gff2", "gtf"])

--- a/training/src/geneid_train/core/param.py
+++ b/training/src/geneid_train/core/param.py
@@ -146,6 +146,21 @@ class Param:
         ending = "\n" if block.raw[di].endswith("\n") else ""
         block.raw[di] = f"{value}{ending}"
 
+    def replace_block_data(self, keyword: str, new_lines: list[str], index: int = 0) -> None:
+        """Replace a section's data lines with ``new_lines`` (each without a
+        trailing newline), keeping the keyword line and any leading/trailing
+        comment or blank lines. Used to swap in a freshly trained profile or
+        Markov matrix while preserving the file's structure around it.
+        """
+        block = self._find(keyword, index)
+        di = block.data_line_indices()
+        if not di:
+            raise ValueError(f"section {keyword!r} has no data to replace")
+        first, last = di[0], di[-1]
+        head = block.raw[:first]
+        tail = block.raw[last + 1 :]
+        block.raw = head + [ln + "\n" for ln in new_lines] + tail
+
     @property
     def num_isochores(self) -> int:
         return int(self.scalar("number_of_isochores"))

--- a/training/src/geneid_train/data/template.param
+++ b/training/src/geneid_train/data/template.param
@@ -1,0 +1,126 @@
+# geneid parameter file: @SPECIES@
+# Comment lines must start with '#'
+
+# Non-homology penalty
+NO_SCORE
+0
+
+# Number of isochores
+number_of_isochores
+1
+
+# PARAMETERS FROM ISOCHORE 1
+
+# %GC
+boundaries_of_isochore
+0 100
+
+# Exons score: cutoffs
+Absolute_cutoff_exons
+-150 -150 -150 -150 0
+
+Coding_cutoff_oligos
+-100 -150 -150 -150
+
+# Exon score: factors
+Site_factor
+0.6 0.6 0.6 0.6 0.6
+
+Exon_factor
+0.4 0.4 0.4 0.4
+
+HSP_factor
+1 1 1 1 1
+
+Evidence_Factor
+1
+
+Evidence_Weight
+0
+
+RSS_Markov_Score
+5.0
+
+RSS_Donor_Score_Cutoff
+3.5
+
+RSS_Acceptor_Score_Cutoff
+3.5
+
+Exon_weights
+-4 -4 -4 -4 0
+
+# Site prediction: Position Weight Arrays
+# Length, Offset, Cutoff and Order (Markov model)
+Start_profile
+@START_PROFILE@
+
+Acceptor_profile
+@ACCEPTOR_PROFILE@
+
+Donor_profile
+@DONOR_PROFILE@
+
+Stop_profile
+4 0 -9999 0
+# Transition probabilities at every position
+1 A 0
+1 C 0
+1 G 0
+1 T 0
+2 A -9999
+2 C -9999
+2 G -9999
+2 T 0
+3 A 0
+3 C -9999
+3 G 0
+3 T -9999
+4 A 0
+4 C -9999
+4 G 0
+4 T -9999
+
+# Exon prediction: Markov model
+# Initial probabilities at every codon position
+Markov_order
+@MARKOV_ORDER@
+Markov_Initial_probability_matrix
+@MARKOV_INITIAL@
+
+# Transition probabilities at every codon position
+Markov_Transition_probability_matrix
+@MARKOV_TRANSITION@
+
+# Donors per acceptor to build exons
+maximum_number_of_donors_per_acceptor_site
+5
+
+# GENE MODEL: Rules about gene assembling (GenAmic)
+General_Gene_Model
+# INTRAgenic connections
+First+:Internal+                           Internal+:Terminal+                        @INTRON_RANGE@        
+Internal-:Terminal-                        First-:Internal-                           @INTRON_RANGE@        
+First+                                     Intron+                                    1:1                    
+Internal+                                  Intron+                                    1:1                    
+Intron+                                    Internal+                                  1:1                    
+Intron+                                    Terminal+                                  1:1                    
+Intron-                                    First-                                     1:1                    
+Internal-                                  Intron-                                    1:1                    
+Intron-                                    Internal-                                  1:1                    
+Terminal-                                  Intron-                                    1:1                    
+# External features
+Promoter+                                  First+:Single+                             50:4000                
+First-:Single-                             Promoter-                                  50:4000                
+Terminal+:Single+                          aataaa+                                    50:4000                
+aataaa-                                    Terminal-:Single-                          50:4000                
+# INTERgenic connections
+aataaa+:Terminal+:Single+                  Single+:First+:Promoter+                   @INTERGENIC_RANGE@           
+aataaa+:Terminal+:Single+                  aataaa-:Terminal-:Single-                  @INTERGENIC_RANGE@           
+Single-:First-:Promoter-                   aataaa-:Terminal-:Single-                  @INTERGENIC_RANGE@           
+Single-:First-:Promoter-                   Single+:First+:Promoter+                   @INTERGENIC_RANGE@           
+# BEGINNING and END of prediction
+Begin+                                     First+:Internal+:Terminal+:Single+         0:Infinity             
+Begin-                                     First-:Internal-:Terminal-:Single-         0:Infinity             
+First+:Internal+:Terminal+:Single+         End+                                       0:Infinity             
+First-:Internal-:Terminal-:Single-         End-                                       0:Infinity             

--- a/training/src/geneid_train/param/__init__.py
+++ b/training/src/geneid_train/param/__init__.py
@@ -1,0 +1,1 @@
+"""Parameter-file assembly from trained components."""

--- a/training/src/geneid_train/param/assemble.py
+++ b/training/src/geneid_train/param/assemble.py
@@ -1,0 +1,58 @@
+"""Assemble a complete geneid parameter file from trained components.
+
+Everything geneid needs that is *not* estimated from the training set — the
+score factors and weights, the RSS/cutoff defaults, the fixed ``Stop_profile``,
+and the GenAmic gene-model rules — lives in a bundled single-isochore template
+(``data/template.param``, a real geneid param with the trained sections stubbed
+out and the variable ranges marked with sentinels). Assembly swaps in the
+trained pieces: the Start/Acceptor/Donor profiles, the two coding Markov
+matrices, and the intron/intergenic gene-model ranges.
+
+Byte-identical reproduction of a legacy param is a non-goal (log values differ
+in the low decimals); the contract is a valid, correctly structured param whose
+trained sections carry our estimates.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+
+from ..core.param import Param
+
+
+def load_template() -> str:
+    """Return the bundled template parameter file as text."""
+    return files("geneid_train").joinpath("data/template.param").read_text()
+
+
+def assemble_param(
+    *,
+    species: str,
+    start_profile: list[str],
+    acceptor_profile: list[str],
+    donor_profile: list[str],
+    markov_order: int,
+    markov_initial: list[str],
+    markov_transition: list[str],
+    intron_range: str,
+    intergenic_range: str,
+    template: str | None = None,
+) -> str:
+    """Build a full geneid param. Profile/Markov args are geneid-format data
+    lines (from ``stats.sites.format_profile`` / ``stats.coding.format_markov_matrix``);
+    ``intron_range``/``intergenic_range`` are ``min:max`` tokens."""
+    p = Param.from_text(template if template is not None else load_template())
+
+    p.replace_block_data("Start_profile", start_profile)
+    p.replace_block_data("Acceptor_profile", acceptor_profile)
+    p.replace_block_data("Donor_profile", donor_profile)
+
+    p.set_scalar("Markov_order", markov_order)
+    p.replace_block_data("Markov_Initial_probability_matrix", markov_initial)
+    p.replace_block_data("Markov_Transition_probability_matrix", markov_transition)
+
+    text = p.to_text()
+    text = text.replace("@INTRON_RANGE@", intron_range)
+    text = text.replace("@INTERGENIC_RANGE@", intergenic_range)
+    text = text.replace("@SPECIES@", species)
+    return text

--- a/training/src/geneid_train/prepare/sites.py
+++ b/training/src/geneid_train/prepare/sites.py
@@ -1,0 +1,112 @@
+"""Splice-site and start-codon window extraction (replaces the legacy SSgff step).
+
+For each gene model this pulls the fixed-length sequence windows the profile
+estimator (``stats.sites``) consumes: a donor window per intron (5' splice), an
+acceptor window per intron (3' splice), and one start-codon window per gene.
+Windows are in transcription orientation with the anchor base at a fixed
+position, matching the geometry of the reference ``*.canonical.*.tbl`` files:
+
+    position 31 (1-based) is the anchor base:
+      donor    -> last coding base of the upstream exon   (intron GT at 32-33)
+      acceptor -> first coding base of the downstream exon (intron AG at 29-30)
+      start    -> the A of the ATG start codon             (ATG at 31-33)
+
+Each window is ``BEFORE`` (30) bases upstream + the anchor + ``AFTER`` (29) bases
+downstream = 60 bp. Sites too close to a sequence end to yield a full window are
+skipped (the estimator requires equal-length windows).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from ..core.seq import revcomp
+from .base import GeneModel
+
+BEFORE = 30  # bases upstream of the anchor (transcription orientation)
+AFTER = 29  # bases downstream of the anchor
+WINDOW = BEFORE + 1 + AFTER  # 60
+
+
+def _window(chrom: str, anchor: int, strand: str) -> str | None:
+    """Extract the 60 bp transcription-oriented window with ``anchor`` (1-based
+    genomic) at profile position 31, or ``None`` if it would run off the end."""
+    if strand == "+":
+        lo, hi = anchor - 1 - BEFORE, anchor + AFTER
+    else:
+        lo, hi = anchor - 1 - AFTER, anchor + BEFORE
+    if lo < 0 or hi > len(chrom):
+        return None
+    seq = chrom[lo:hi]
+    if strand == "-":
+        seq = revcomp(seq)
+    return seq.upper()
+
+
+def donor_windows(model: GeneModel, chrom: str) -> list[str]:
+    """One donor (5' splice) window per intron, transcription-oriented."""
+    out = []
+    for s, e in model.introns():
+        anchor = (s - 1) if model.strand == "+" else (e + 1)
+        w = _window(chrom, anchor, model.strand)
+        if w is not None:
+            out.append(w)
+    return out
+
+
+def acceptor_windows(model: GeneModel, chrom: str) -> list[str]:
+    """One acceptor (3' splice) window per intron, transcription-oriented."""
+    out = []
+    for s, e in model.introns():
+        anchor = (e + 1) if model.strand == "+" else (s - 1)
+        w = _window(chrom, anchor, model.strand)
+        if w is not None:
+            out.append(w)
+    return out
+
+
+def start_window(model: GeneModel, chrom: str) -> str | None:
+    """The start-codon window (anchor = A of the ATG), or ``None`` if truncated."""
+    anchor = model.start if model.strand == "+" else model.end
+    return _window(chrom, anchor, model.strand)
+
+
+def is_canonical_donor(seq: str) -> bool:
+    return seq[31:33] == "GT"  # profile positions 32-33
+
+
+def is_canonical_acceptor(seq: str) -> bool:
+    return seq[28:30] == "AG"  # profile positions 29-30
+
+
+def is_canonical_start(seq: str) -> bool:
+    return seq[30:33] == "ATG"  # profile positions 31-33
+
+
+@dataclass
+class SiteSets:
+    """Canonical vs non-canonical site windows, split for separate estimation."""
+
+    donor: list[str]
+    acceptor: list[str]
+    start: list[str]
+    noncanonical_donor: list[str]
+    noncanonical_acceptor: list[str]
+    noncanonical_start: list[str]
+
+
+def collect_sites(models: Iterable[GeneModel], genome: Mapping[str, str]) -> SiteSets:
+    """Extract every donor/acceptor/start window across ``models`` and partition
+    them into canonical (GT-AG / ATG) and non-canonical bags."""
+    s = SiteSets([], [], [], [], [], [])
+    for m in models:
+        chrom = genome[m.seqid]
+        for w in donor_windows(m, chrom):
+            (s.donor if is_canonical_donor(w) else s.noncanonical_donor).append(w)
+        for w in acceptor_windows(m, chrom):
+            (s.acceptor if is_canonical_acceptor(w) else s.noncanonical_acceptor).append(w)
+        w = start_window(m, chrom)
+        if w is not None:
+            (s.start if is_canonical_start(w) else s.noncanonical_start).append(w)
+    return s

--- a/training/src/geneid_train/stats/background.py
+++ b/training/src/geneid_train/stats/background.py
@@ -1,0 +1,65 @@
+"""Genome-wide background sequence model (replaces the legacy getBackground).
+
+The site profiles are log-ratios of a site model against a background model of
+generic genomic composition. The legacy trainer estimates that background from
+``numseqs`` (100000) random ``k``-mers (k=62) drawn from the genome, then builds
+per-position single-nucleotide frequencies and an order-1 dinucleotide matrix
+from them. Reproduced here; the sampling is seeded so a given genome yields a
+reproducible background (the legacy used an unseeded RNG, so exact byte-repro of
+its background was never possible).
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable
+
+from .sites import Matrix, frequency, position_matrix
+
+DEFAULT_K = 62
+DEFAULT_N = 100_000
+
+
+def sample_kmers(
+    genome_seqs: Iterable[str], k: int = DEFAULT_K, n: int = DEFAULT_N, seed: int = 0
+) -> list[str]:
+    """Draw ``n`` random ``k``-mers from the genome, rejecting any with a non-ACGT
+    base. Sequences are concatenated (matching the legacy) only up to the length
+    needed to supply the samples, then sampled uniformly with a seeded RNG."""
+    need = n * k + 1
+    pieces: list[str] = []
+    total = 0
+    for s in genome_seqs:
+        pieces.append(s)
+        total += len(s)
+        if total >= need:
+            break
+    seq = "".join(pieces).upper()
+    span = len(seq) - k
+    if span <= 0:
+        raise ValueError(f"genome too short ({len(seq)} bp) for {k}-mer background")
+    rng = random.Random(seed)
+    out: list[str] = []
+    while len(out) < n:
+        r = rng.randint(0, span)
+        kmer = seq[r : r + k]
+        if all(c in "ACGT" for c in kmer):
+            out.append(kmer)
+    return out
+
+
+def background_models(kmers: list[str]) -> tuple[Matrix, Matrix]:
+    """Build the ``(order-0 frequency, order-1 dinucleotide)`` background models
+    from a set of equal-length background sequences, using the same estimators as
+    the site profiles (``frequency`` for info content, ``position_matrix`` for the
+    log-ratio denominator)."""
+    freq = frequency(kmers)
+    dimatrix = position_matrix(kmers, order=1)
+    return freq, dimatrix
+
+
+def from_genome(
+    genome_seqs: Iterable[str], k: int = DEFAULT_K, n: int = DEFAULT_N, seed: int = 0
+) -> tuple[Matrix, Matrix]:
+    """Convenience: sample a background from the genome and build both models."""
+    return background_models(sample_kmers(genome_seqs, k=k, n=n, seed=seed))

--- a/training/src/geneid_train/stats/coding.py
+++ b/training/src/geneid_train/stats/coding.py
@@ -1,0 +1,156 @@
+"""Coding-potential Markov models (replaces geneidCEGMA.pm + deriveCodingPotential).
+
+geneid scores an ORF with two log-ratio matrices comparing a codon-phase-specific
+model of coding sequence against a phase-agnostic model of introns:
+
+- ``Markov_Initial_probability_matrix``  — order-4 *frequencies* of 5-mers, one
+  distribution per codon frame (used to seed the first bases of an exon)
+- ``Markov_Transition_probability_matrix`` — order-5 Markov transitions
+  P(base | preceding 5 bases), one per codon frame (used to extend)
+
+Each is ``log(P_coding(oligo|frame) / P_intron(oligo|frame=0))`` (natural log).
+The coding model cycles through frames 0/1/2 as it walks a CDS (which starts
+in-frame at the ATG); the intron model uses a single frame 0.
+
+Faithfully reproduces the legacy estimator, including its quirks: the counting
+loop stops one base early (``i < len - order - 1``); a non-ACGT position is
+skipped *without* advancing the frame; and the FREQ per-frame denominator is
+taken one step after the count (a harmless off-by-one that averages out).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Sequence
+from itertools import product
+
+_ACGT = frozenset("ACGT")
+
+# per-frame pseudocounts from the legacy driver
+CODING_PSEUDO = 0.25
+INTRON_PSEUDO = 10.0
+
+# Model = {(oligo, frame): probability_or_logratio}, oligo = (order+1)-mer.
+Model = dict[tuple[str, int], float]
+
+
+def _kmers(order: int) -> list[str]:
+    return ["".join(p) for p in product("ACGT", repeat=order)]
+
+
+def _counts(seqs: Iterable[str], order: int, pseudo: float, nframes: int) -> dict:
+    """Per-frame (prefix, nt) counts, initialised to ``pseudo``. ``nframes`` is 1
+    (phase-agnostic, intron) or 3 (phase-specific, coding). Returns
+    ``(table, totals)`` where table[(prefix, nt, fr)] is a count and totals[fr]
+    the running per-frame position count used by the FREQ normaliser."""
+    frame = nframes - 1  # legacy "frame" arg: 0 or 2
+    table: dict[tuple[str, str, int], float] = {}
+    for pre in _kmers(order):
+        for nt in "ACGT":
+            for fr in range(frame + 1):
+                table[(pre, nt, fr)] = pseudo
+    totals = [0, 0, 0]
+    for seq in seqs:
+        s = seq.upper()
+        fr = 0
+        for i in range(0, len(s) - order - 1):
+            pre = s[i : i + order]
+            nt = s[i + order]
+            if _ACGT.issuperset(pre) and nt in _ACGT:
+                table[(pre, nt, fr)] += 1
+                fr = 0 if frame == 0 else (fr + 1) % 3
+                totals[fr] += 1
+        # (frame is not advanced on skipped positions — matches the legacy `next`)
+    return table, totals
+
+
+def initial_model(
+    seqs: Iterable[str], order: int, pseudo: float, nframes: int
+) -> Model:
+    """FREQ model: P(oligo | frame) = count / (per-frame total position count)."""
+    seqs = list(seqs)
+    table, totals = _counts(seqs, order, pseudo, nframes)
+    out: Model = {}
+    for (pre, nt, fr), c in table.items():
+        denom = totals[fr]
+        out[(pre + nt, fr)] = c / denom if denom else 0.0
+    return out
+
+
+def transition_model(
+    seqs: Iterable[str], order: int, pseudo: float, nframes: int
+) -> Model:
+    """MM model: P(nt | prefix, frame) = count / sum_nt count over the prefix."""
+    seqs = list(seqs)
+    table, _ = _counts(seqs, order, pseudo, nframes)
+    frame = nframes - 1
+    out: Model = {}
+    prefixes = _kmers(order)
+    for pre in prefixes:
+        for fr in range(frame + 1):
+            denom = sum(table[(pre, nt, fr)] for nt in "ACGT")
+            for nt in "ACGT":
+                out[(pre + nt, fr)] = table[(pre, nt, fr)] / denom if denom else 0.0
+    return out
+
+
+def coding_log_ratio(coding: Model, intron: Model) -> Model:
+    """log(P_coding(oligo|frame) / P_intron(oligo|frame 0)) per coding-model cell."""
+    out: Model = {}
+    for (oligo, fr), pc in coding.items():
+        pi = intron.get((oligo, 0))
+        if pc > 0 and pi:
+            out[(oligo, fr)] = math.log(pc / pi)
+    return out
+
+
+def choose_orders(coding_bases: int, noncoding_bases: int) -> tuple[int, int]:
+    """Return ``(initial_order, transition_order)`` for the training-set size.
+
+    The reference driver always trains order-5 transitions / order-4 initials
+    when it derives a coding potential at all; the size test only gates *whether*
+    to derive one. We mirror that (5/4) whenever there is enough data, and
+    fall back to a smaller model on sparse sets to avoid overfitting.
+    """
+    enough = (
+        (coding_bases > 400_000 and noncoding_bases > 100_000)
+        or (coding_bases > 375_000 and noncoding_bases > 150_000)
+        or (noncoding_bases > 35_000 and coding_bases > 25 * noncoding_bases)
+    )
+    return (4, 5) if enough else (3, 4)
+
+
+def derive_coding_potential(
+    cds_seqs: Sequence[str], intron_seqs: Sequence[str], transition_order: int = 5
+) -> tuple[Model, Model, int, int]:
+    """Build the initial and transition coding-potential log-ratio matrices.
+
+    Returns ``(initial_logs, transition_logs, coding_bases, noncoding_bases)``.
+    The initial model is order ``transition_order - 1``; both compare a
+    3-frame coding model to a 1-frame intron model.
+    """
+    coding_bases = sum(len(s) for s in cds_seqs)
+    noncoding_bases = sum(len(s) for s in intron_seqs)
+    init_order = transition_order - 1
+
+    coding_init = initial_model(cds_seqs, init_order, CODING_PSEUDO, 3)
+    intron_init = initial_model(intron_seqs, init_order, INTRON_PSEUDO, 1)
+    coding_trans = transition_model(cds_seqs, transition_order, CODING_PSEUDO, 3)
+    intron_trans = transition_model(intron_seqs, transition_order, INTRON_PSEUDO, 1)
+
+    initial_logs = coding_log_ratio(coding_init, intron_init)
+    transition_logs = coding_log_ratio(coding_trans, intron_trans)
+    return initial_logs, transition_logs, coding_bases, noncoding_bases
+
+
+def format_markov_matrix(model: Model) -> list[str]:
+    """Render a log-ratio model as geneid param lines: ``oligo index frame value``,
+    index = lexicographic rank of the oligo, ordered oligo then frame."""
+    by_oligo: dict[str, list[int]] = {}
+    for oligo, fr in model:
+        by_oligo.setdefault(oligo, []).append(fr)
+    lines = []
+    for idx, oligo in enumerate(sorted(by_oligo)):
+        for fr in sorted(by_oligo[oligo]):
+            lines.append(f"{oligo} {idx} {fr} {model[(oligo, fr)]:.3f}")
+    return lines

--- a/training/src/geneid_train/stats/genemodel.py
+++ b/training/src/geneid_train/stats/genemodel.py
@@ -1,0 +1,52 @@
+"""Gene-model length statistics for the parameter file's GenAmic rules.
+
+Reproduces the intron/intergenic distance bounds the legacy ``WriteStatsFile``
+injects into the gene model: the intron range gates intron-spanning intragenic
+connections, the intergenic range gates gene-to-gene connections.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def _mean_sd(values: Sequence[float]) -> tuple[float, float]:
+    """Mean and *population* standard deviation (matches geneidCEGMA::average)."""
+    n = len(values)
+    mean = sum(values) / n
+    var = sum((v - mean) ** 2 for v in values) / n
+    return mean, math.sqrt(var)
+
+
+def intron_range(
+    intron_lengths: Sequence[int],
+    *,
+    short_cap: int = 40,
+    long_cap: int = 100_000,
+) -> tuple[float, float]:
+    """Return ``(min_intron, max_intron)`` for the gene model.
+
+    ``min = 0.75 * shortest_intron`` capped at ``short_cap`` (40); ``max =
+    mean + 3*sd`` capped at ``long_cap`` (100000) — the legacy WriteStatsFile
+    heuristic.
+    """
+    shortest = min(intron_lengths)
+    lo = shortest * 0.75
+    if lo > short_cap:
+        lo = float(short_cap)
+    mean, sd = _mean_sd(list(intron_lengths))
+    hi = mean + 3 * sd
+    if hi > long_cap:
+        hi = float(long_cap)
+    return lo, hi
+
+
+def format_range(lo: float, hi: float | str) -> str:
+    """Render a ``min:max`` distance token (``Infinity`` passes through)."""
+    def one(x: float | str) -> str:
+        if isinstance(x, str):
+            return x
+        return str(int(x)) if x == int(x) else f"{x:.10g}"
+
+    return f"{one(lo)}:{one(hi)}"

--- a/training/src/geneid_train/stats/sites.py
+++ b/training/src/geneid_train/stats/sites.py
@@ -29,6 +29,8 @@ Matrix = dict[tuple[int, str], float]
 
 _ACGT = frozenset("ACGT")
 
+MASK = -9999.0  # geneid sentinel for a forbidden PWM cell
+
 # Dirichlet pseudocount per k+1-tuple, matching legacy Getkmatrix.awk. Every
 # oligo gets +PCOUNT and every prefix +4*PCOUNT, so unobserved oligos still get a
 # defined (non-zero) probability and every position has a complete matrix.
@@ -72,6 +74,29 @@ def position_matrix(seqs: Iterable[str], order: int = 1, pcount: float = PCOUNT)
     return out
 
 
+def log_ratio_zero_order(site: Matrix, background: Matrix) -> Matrix:
+    """Log-ratio for order-0 (single-nucleotide) profiles, matching legacy
+    ``logratio_zero_order.awk``.
+
+    Order-0 site matrices are built with no pseudocounts (see ``position_matrix``
+    with ``pcount=0``), so a base that never occurs at a position has an exact raw
+    frequency of 0 -- and a base that occurs at every site has frequency exactly
+    1. Those two cases are special-cased to -9999 / 0 rather than computing
+    ``log(0/bg)`` or ``log(1/bg)``; this is what naturally masks an invariant
+    position (e.g. the A of ATG) without a separate explicit masking step.
+    """
+    out: Matrix = {}
+    for key, fg in site.items():
+        bg = background.get(key) or background.get((1, key[1]))
+        if fg == 0:
+            out[key] = MASK
+        elif fg == 1:
+            out[key] = 0.0
+        elif bg:
+            out[key] = math.log(fg / bg)
+    return out
+
+
 def log_ratio(site: Matrix, background: Matrix) -> Matrix:
     """Natural-log ratio of a site matrix against a background matrix, per cell.
 
@@ -87,9 +112,6 @@ def log_ratio(site: Matrix, background: Matrix) -> Matrix:
         if bg:
             out[(pos, oligo)] = math.log(fg / bg)
     return out
-
-
-MASK = -9999.0  # geneid sentinel for a forbidden PWM cell
 
 
 def submatrix(matrix: Matrix, start: int, end: int) -> Matrix:
@@ -130,11 +152,22 @@ def mask_invariant_dinuc(matrix: Matrix, st: int, nd: int, rd: int, anchor: str)
 
 
 def read_matrix(path: str | Path) -> Matrix:
-    """Read a geneid ``.di-matrix`` / profile-style file: ``<pos> <oligo> <value>``."""
+    """Read a geneid ``.di-matrix`` / profile-style file.
+
+    Accepts either column order: ``<pos> <oligo> <value>`` (the profile / order>=1
+    ``.di-matrix`` convention) or ``<oligo> <pos> <value>`` (the legacy order-0
+    ``*.order-0-matrix`` files use base-first columns)."""
     out: Matrix = {}
     with open(path) as fh:
         for line in fh:
             parts = line.split()
-            if len(parts) >= 3 and parts[0].isdigit():
-                out[(int(parts[0]), parts[1])] = float(parts[2])
+            if len(parts) < 3:
+                continue
+            if parts[0].isdigit():
+                pos, oligo = int(parts[0]), parts[1]
+            elif parts[1].isdigit():
+                oligo, pos = parts[0], int(parts[1])
+            else:
+                continue
+            out[(pos, oligo)] = float(parts[2])
     return out

--- a/training/src/geneid_train/stats/sites.py
+++ b/training/src/geneid_train/stats/sites.py
@@ -89,6 +89,46 @@ def log_ratio(site: Matrix, background: Matrix) -> Matrix:
     return out
 
 
+MASK = -9999.0  # geneid sentinel for a forbidden PWM cell
+
+
+def submatrix(matrix: Matrix, start: int, end: int) -> Matrix:
+    """Restrict to positions [start, end] and renumber them to 1..(end-start+1),
+    matching the legacy ``submatrix.awk``."""
+    return {
+        (pos - start + 1, oligo): v for (pos, oligo), v in matrix.items() if start <= pos <= end
+    }
+
+
+def mask_invariant_dinuc(matrix: Matrix, st: int, nd: int, rd: int, anchor: str) -> Matrix:
+    """Apply the invariant splice-dinucleotide constraint to an order-1 profile
+    (replaces preparedimatrix{donor,acceptor}4parameter.awk).
+
+    ``anchor`` is the invariant dinucleotide ("GT" for donors, "AG" for acceptors)
+    sitting at profile positions ``nd``/``nd+1``. Across the three order-1 columns
+    overlapping it:
+
+    - ``st`` (=nd-1): cell kept as ``0`` if its oligo ends in anchor[0], else masked
+    - ``nd``:         cell kept as ``0`` if its oligo == anchor, else masked
+    - ``rd`` (=nd+1): cell keeps its log value if its oligo starts with anchor[1],
+      else masked
+
+    Every other cell keeps its log-ratio value.
+    """
+    a, b = anchor[0], anchor[1]
+    out: Matrix = {}
+    for (pos, oligo), v in matrix.items():
+        if pos == st:
+            out[(pos, oligo)] = 0.0 if oligo.endswith(a) else MASK
+        elif pos == nd:
+            out[(pos, oligo)] = 0.0 if oligo == anchor else MASK
+        elif pos == rd:
+            out[(pos, oligo)] = v if oligo.startswith(b) else MASK
+        else:
+            out[(pos, oligo)] = v
+    return out
+
+
 def read_matrix(path: str | Path) -> Matrix:
     """Read a geneid ``.di-matrix`` / profile-style file: ``<pos> <oligo> <value>``."""
     out: Matrix = {}

--- a/training/src/geneid_train/stats/sites.py
+++ b/training/src/geneid_train/stats/sites.py
@@ -289,6 +289,34 @@ def select_window(
     return SiteWindow(start, end, off, end - start + 1, st, nd, rd)
 
 
+def _fmt(value: float) -> str:
+    """Format a matrix value as geneid does: 6 significant figures, integers bare."""
+    if value == int(value):
+        return str(int(value))
+    return f"{value:g}"
+
+
+def profile_header(window: SiteWindow, order: int, cutoff: float = -7.0) -> list[str]:
+    """The geneid profile header ``len offset cutoff order [a b]`` for a window.
+
+    Order>=1 profiles carry the trailing ``0 1`` pair (the dinucleotide-context
+    flags geneid expects); order-0 profiles omit it.
+    """
+    fields = [window.length, window.offset, cutoff, order]
+    if order >= 1:
+        fields += [0, 1]
+    return [_fmt(float(f)) for f in fields]
+
+
+def format_profile(matrix: Matrix, header: list[str]) -> list[str]:
+    """Render a site profile as geneid param lines: a header line, the standard
+    comment, then ``pos oligo value`` rows sorted by position then oligo."""
+    lines = [" ".join(header), "# Transition probabilities at every position"]
+    for (pos, oligo), v in sorted(matrix.items()):
+        lines.append(f"{pos} {oligo} {_fmt(v)}")
+    return lines
+
+
 def read_matrix(path: str | Path) -> Matrix:
     """Read a geneid ``.di-matrix`` / profile-style file.
 

--- a/training/src/geneid_train/stats/sites.py
+++ b/training/src/geneid_train/stats/sites.py
@@ -1,0 +1,100 @@
+"""Position weight arrays / order-k Markov site matrices.
+
+Replaces the legacy AWK chain (Getkmatrix / logratio_kmatrix / information /
+submatrix). A site profile is built in stages, each of which is validated against
+the reference xgXerMont run:
+
+1. ``position_matrix`` — per-position order-k conditional probabilities P(next|prev)
+   from a set of aligned site windows  (reference: ``*.canonical.<site>.di-matrix``)
+2. ``log_ratio`` — natural-log ratio of the site matrix vs a background model
+   (reference: ``*-log.di-matrix``)
+3. information-weighting + boundary selection -> the profile rows written into the
+   parameter file  (reference: ``*-log-info.di-matrix`` == the ``*_profile`` block)
+
+Stage 3 is not yet implemented. Matrices are dicts keyed by ``(position, oligo)``
+with 1-based positions, matching the geneid ``.param`` profile layout.
+
+geneid profile "order" k means oligos of length k+1 (order 1 = dinucleotides).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterable
+from itertools import product
+from pathlib import Path
+
+Matrix = dict[tuple[int, str], float]
+
+_ACGT = frozenset("ACGT")
+
+# Dirichlet pseudocount per k+1-tuple, matching legacy Getkmatrix.awk. Every
+# oligo gets +PCOUNT and every prefix +4*PCOUNT, so unobserved oligos still get a
+# defined (non-zero) probability and every position has a complete matrix.
+PCOUNT = 0.25
+
+
+def position_matrix(seqs: Iterable[str], order: int = 1, pcount: float = PCOUNT) -> Matrix:
+    """Per-position order-k conditional probabilities from aligned site windows.
+
+    For each position ``i`` (1-based) the value for oligo ``prefix+base`` is the
+    smoothed conditional P(base | prefix):
+    ``(pcount + count(oligo)) / (4*pcount + count(prefix))``. Positions run
+    1..L-order and the matrix is complete (all 4**(order+1) oligos per position).
+
+    A whole window containing any non-ACGT character is skipped (matching the
+    legacy estimator), not just the offending column.
+    """
+    seqs = [s.upper() for s in seqs]
+    if not seqs:
+        return {}
+    length = min(len(s) for s in seqs)
+    counts: dict[tuple[int, str], int] = defaultdict(int)
+    prefix_counts: dict[tuple[int, str], int] = defaultdict(int)
+    for s in seqs:
+        window = s[:length]
+        if set(window) - _ACGT:
+            continue
+        for i in range(1, length - order + 1):
+            counts[(i, window[i - 1 : i - 1 + order + 1])] += 1
+            prefix_counts[(i, window[i - 1 : i - 1 + order])] += 1
+
+    out: Matrix = {}
+    denom_pseudo = 4 * pcount
+    for pos in range(1, length - order + 1):
+        for prefix in ("".join(p) for p in product("ACGT", repeat=order)):
+            denom = denom_pseudo + prefix_counts.get((pos, prefix), 0)
+            for base in "ACGT":
+                oligo = prefix + base
+                num = pcount + counts.get((pos, oligo), 0)
+                out[(pos, oligo)] = num / denom if denom else 0.0
+    return out
+
+
+def log_ratio(site: Matrix, background: Matrix) -> Matrix:
+    """Natural-log ratio of a site matrix against a background matrix, per cell.
+
+    Background may be keyed per-position (matching keys) or position-independent
+    (keyed by position 1); the latter is broadcast across positions.
+    """
+    pos_independent = all(p == 1 for p, _ in background) and background
+    out: Matrix = {}
+    for (pos, oligo), fg in site.items():
+        bg = background.get((pos, oligo))
+        if bg is None and pos_independent:
+            bg = background.get((1, oligo))
+        if bg:
+            out[(pos, oligo)] = math.log(fg / bg)
+    return out
+
+
+def read_matrix(path: str | Path) -> Matrix:
+    """Read a geneid ``.di-matrix`` / profile-style file: ``<pos> <oligo> <value>``."""
+    out: Matrix = {}
+    with open(path) as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) >= 3 and parts[0].isdigit():
+                out[(int(parts[0]), parts[1])] = float(parts[2])
+    return out

--- a/training/src/geneid_train/stats/sites.py
+++ b/training/src/geneid_train/stats/sites.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from collections.abc import Iterable
+from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 
@@ -149,6 +150,143 @@ def mask_invariant_dinuc(matrix: Matrix, st: int, nd: int, rd: int, anchor: str)
         else:
             out[(pos, oligo)] = v
     return out
+
+
+# --- boundary selection (replaces frequency.awk / information.awk / BitScoreGraph) ---
+
+# Per-site defaults from the legacy driver (geneidTRAINer1_3.pl): the anchor
+# ``offset`` seed, the information-content threshold (bits) above which a position
+# joins the profile window, and the raw-position clip range the info graph is
+# restricted to before selection.
+SITE_DEFAULTS: dict[str, dict] = {
+    "donor": {"offset": 30, "info_thresh": 0.15, "clip": (25, 38)},
+    "acceptor": {"offset": 30, "info_thresh": 0.04, "clip": (2, 33)},
+    "start": {"offset": 30, "info_thresh": 0.15, "clip": (25, 37)},
+    "branch": {"offset": 32, "info_thresh": 0.30, "clip": (28, 41)},
+}
+
+
+def frequency(seqs: Iterable[str]) -> dict[tuple[int, str], float]:
+    """Per-position single-nucleotide frequencies (replaces ``frequency.awk`` k=1).
+
+    Returns ``{(pos, base): count/total}`` with 1-based positions. Unlike
+    :func:`position_matrix`, a non-ACGT character masks only its own column at
+    that position (not the whole window), and the denominator is the per-position
+    count of valid ACGT observations. No pseudocounts.
+    """
+    seqs = [s.upper() for s in seqs]
+    if not seqs:
+        return {}
+    length = min(len(s) for s in seqs)
+    counts: dict[tuple[int, str], int] = defaultdict(int)
+    totals: dict[int, int] = defaultdict(int)
+    for s in seqs:
+        for i in range(1, length + 1):
+            base = s[i - 1]
+            if base in _ACGT:
+                counts[(i, base)] += 1
+                totals[i] += 1
+    out: dict[tuple[int, str], float] = {}
+    for pos in range(1, length + 1):
+        tot = totals.get(pos, 0)
+        for base in "ACGT":
+            out[(pos, base)] = counts.get((pos, base), 0) / tot if tot else 0.0
+    return out
+
+
+def info_content(
+    site: dict[tuple[int, str], float], background: dict[tuple[int, str], float]
+) -> dict[int, float]:
+    """Per-position information content in bits (replaces ``information.awk`` k=1).
+
+    ``info[pos] = sum_base p*log2(p/bg)`` over the four nucleotides, where ``p`` is
+    the site frequency and ``bg`` the background frequency; a term is dropped when
+    either ``p`` or ``bg`` is zero. This is the relative entropy of the site vs
+    background distribution at each position — the quantity the boundary selector
+    thresholds on.
+    """
+    out: dict[int, float] = defaultdict(float)
+    positions = {pos for pos, _ in site}
+    for pos in positions:
+        for base in "ACGT":
+            p = site.get((pos, base), 0.0)
+            bg = background.get((pos, base), 0.0)
+            if p > 0 and bg > 0:
+                out[pos] += p * math.log(p / bg) / math.log(2)
+    return dict(out)
+
+
+@dataclass(frozen=True)
+class SiteWindow:
+    """A selected profile window plus the invariant-dinucleotide anchor columns.
+
+    ``start``/``end`` are raw (pre-submatrix) positions passed to :func:`submatrix`;
+    ``length`` is the resulting profile length. ``st``/``nd``/``rd`` are the
+    profile-local (1-based, post-renumber) columns overlapping the invariant
+    splice/start motif, ready for :func:`mask_invariant_dinuc`; they are ``None``
+    for order-0 profiles, which carry no dinucleotide anchor.
+    """
+
+    start: int
+    end: int
+    offset: int
+    length: int
+    st: int | None
+    nd: int | None
+    rd: int | None
+
+
+def select_window(
+    info: dict[int, float],
+    *,
+    site: str,
+    order: int,
+    offset: int | None = None,
+    info_thresh: float | None = None,
+    clip: tuple[int, int] | None = None,
+) -> SiteWindow:
+    """Select the profile window and anchor columns from per-position info content.
+
+    Reproduces the legacy ``BitScoreGraph`` + post-processing in the Perl driver:
+    seed the candidate set with the anchor's flanking positions (``offset-1`` and
+    ``offset+1``), add every clipped position whose info content exceeds
+    ``info_thresh``, then take ``start = min`` (floored at 1) and ``end = max``.
+    The offset is then renumbered into profile-local coordinates and the
+    site-specific anchor columns are derived from it.
+
+    ``site`` is one of ``donor``/``acceptor``/``start``/``branch``; the remaining
+    keyword args default to :data:`SITE_DEFAULTS` for that site.
+    """
+    d = SITE_DEFAULTS.get(site, {})
+    if offset is None:
+        offset = d["offset"]
+    if info_thresh is None:
+        info_thresh = d["info_thresh"]
+    if clip is None:
+        clip = d["clip"]
+    lo, hi = clip
+
+    candidates = {offset - 1, offset + 1}
+    for pos, bits in info.items():
+        if lo <= pos <= hi and bits > info_thresh:
+            candidates.add(pos)
+    start = max(1, min(candidates))
+    end = max(candidates)
+
+    # renumber the anchor offset into the submatrix's 1-based coordinates
+    off = offset - order
+    end = end - order
+    off = off - start + 1
+
+    st = nd = rd = None
+    if site == "donor" and order >= 1:
+        st, nd, rd = off + 2, off + 3, off + 4
+    elif site == "acceptor" and order >= 1:
+        st, nd, rd = off - 1, off, off + 1
+    elif site == "start" and order >= 2:
+        st, nd, rd = off - 2, off - 1, off
+
+    return SiteWindow(start, end, off, end - start + 1, st, nd, rd)
 
 
 def read_matrix(path: str | Path) -> Matrix:

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -1,0 +1,145 @@
+"""End-to-end training orchestration: gene models + genome -> geneid .param.
+
+Ties the validated stages together — background model, site profiles (start /
+donor / acceptor), coding-potential Markov matrices, gene-model length stats —
+and assembles them into a complete parameter file. Each stage lives in its own
+module and is validated independently against the reference run; this module is
+the wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from .param.assemble import assemble_param
+from .prepare.base import GeneModel
+from .prepare.sites import collect_sites
+from .stats.background import from_genome
+from .stats.coding import choose_orders, derive_coding_potential, format_markov_matrix
+from .stats.genemodel import format_range, intron_range
+from .stats.sites import (
+    Matrix,
+    format_profile,
+    frequency,
+    info_content,
+    log_ratio,
+    log_ratio_zero_order,
+    mask_invariant_dinuc,
+    position_matrix,
+    profile_header,
+    select_window,
+    submatrix,
+)
+
+# order-selection thresholds for site profiles (from the legacy driver)
+_MIN_SITES_ORDER1 = 1400  # donor/acceptor: order 1 above this, else order 0
+_MIN_STARTS_ORDER2 = 5500  # start: order 2 above this, else order 0
+
+
+def build_site_profile(
+    seqs: Sequence[str],
+    *,
+    site: str,
+    anchor: str,
+    order: int,
+    bg_freq: Matrix,
+    bg_dimatrix: Matrix,
+) -> list[str]:
+    """Estimate one site profile and return its geneid param data lines.
+
+    Order>=1 (donor/acceptor): dinucleotide log-ratio over the background matrix,
+    windowed by information content, with the invariant ``anchor`` masked.
+    Order 0 (start): single-nucleotide log-ratio (log_ratio_zero_order), windowed,
+    no explicit mask (the invariant base masks itself via its 0/1 frequency).
+    """
+    freq = frequency(seqs)
+    info = info_content(freq, bg_freq)
+    window = select_window(info, site=site, order=order)
+    if order >= 1:
+        logm = log_ratio(position_matrix(seqs, order=order), bg_dimatrix)
+        prof = mask_invariant_dinuc(
+            submatrix(logm, window.start, window.end),
+            window.st,
+            window.nd,
+            window.rd,
+            anchor,
+        )
+    else:
+        prof = submatrix(log_ratio_zero_order(freq, bg_freq), window.start, window.end)
+    return format_profile(prof, profile_header(window, order))
+
+
+def _site_order(n_donor: int, n_acceptor: int, n_start: int) -> tuple[int, int, int]:
+    donor = 1 if n_donor >= _MIN_SITES_ORDER1 else 0
+    acceptor = 1 if n_acceptor >= _MIN_SITES_ORDER1 else 0
+    start = 2 if n_start >= _MIN_STARTS_ORDER2 else 0
+    if donor == 0 or acceptor == 0:
+        raise NotImplementedError(
+            "order-0 donor/acceptor profiles are not yet supported "
+            f"(donor={n_donor}, acceptor={n_acceptor} sites; need >= {_MIN_SITES_ORDER1}); "
+            "provide a larger training set"
+        )
+    if start == 2:
+        raise NotImplementedError(
+            f"order-2 start profiles are not yet supported ({n_start} starts); "
+            "order-2 masking is unvalidated against the reference"
+        )
+    return donor, acceptor, start
+
+
+def train(
+    models: Sequence[GeneModel],
+    genome: Mapping[str, str],
+    species: str,
+    *,
+    background: tuple[Matrix, Matrix] | None = None,
+    seed: int = 0,
+) -> str:
+    """Train a geneid parameter file from complete, filtered gene ``models``.
+
+    ``background`` may be supplied as ``(freq, dimatrix)`` to make a run fully
+    deterministic (and to validate against a reference background); otherwise it
+    is sampled from the genome.
+    """
+    if not models:
+        raise ValueError("no gene models to train on")
+
+    sites = collect_sites(models, genome)
+    n_donor, n_acceptor, n_start = len(sites.donor), len(sites.acceptor), len(sites.start)
+    donor_order, acceptor_order, start_order = _site_order(n_donor, n_acceptor, n_start)
+
+    bg_freq, bg_dimatrix = background if background is not None else from_genome(
+        genome.values(), seed=seed
+    )
+
+    start_lines = build_site_profile(
+        sites.start, site="start", anchor="ATG", order=start_order,
+        bg_freq=bg_freq, bg_dimatrix=bg_dimatrix,
+    )
+    donor_lines = build_site_profile(
+        sites.donor, site="donor", anchor="GT", order=donor_order,
+        bg_freq=bg_freq, bg_dimatrix=bg_dimatrix,
+    )
+    acceptor_lines = build_site_profile(
+        sites.acceptor, site="acceptor", anchor="AG", order=acceptor_order,
+        bg_freq=bg_freq, bg_dimatrix=bg_dimatrix,
+    )
+
+    cds_seqs = [m.cds(genome) for m in models]
+    intron_seqs = [s for m in models for s in m.intron_seqs(genome)]
+    init_logs, trans_logs, cbases, nbases = derive_coding_potential(cds_seqs, intron_seqs)
+    _, transition_order = choose_orders(cbases, nbases)
+
+    lo, hi = intron_range([len(s) for s in intron_seqs])
+
+    return assemble_param(
+        species=species,
+        start_profile=start_lines,
+        acceptor_profile=acceptor_lines,
+        donor_profile=donor_lines,
+        markov_order=transition_order,
+        markov_initial=format_markov_matrix(init_logs),
+        markov_transition=format_markov_matrix(trans_logs),
+        intron_range=format_range(lo, hi),
+        intergenic_range="200:Infinity",
+    )

--- a/training/tests/conftest.py
+++ b/training/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -18,3 +19,10 @@ def real_param_files() -> list[Path]:
     if not REAL_PARAM_DIR.is_dir():
         return []
     return sorted(REAL_PARAM_DIR.glob("*.param"))
+
+
+def ref_dir() -> Path | None:
+    """Reference legacy-training run dir (xgXerMont train_geneid), from
+    $GENEID_TRAIN_REFDIR. Used by opt-in integration tests; None -> skip."""
+    p = os.environ.get("GENEID_TRAIN_REFDIR")
+    return Path(p) if p and Path(p).is_dir() else None

--- a/training/tests/test_assemble.py
+++ b/training/tests/test_assemble.py
@@ -1,0 +1,161 @@
+import pytest
+
+from geneid_train.core.param import Param
+from geneid_train.param.assemble import assemble_param, load_template
+from geneid_train.stats.coding import format_markov_matrix
+from geneid_train.stats.genemodel import format_range, intron_range
+from geneid_train.stats.sites import SiteWindow, _fmt, format_profile, profile_header
+
+from .conftest import ref_dir
+
+
+def test_profile_header_order0_and_order1():
+    w0 = SiteWindow(start=25, end=32, offset=3, length=8, st=None, nd=None, rd=None)
+    assert profile_header(w0, order=0) == ["8", "3", "-7", "0"]
+    w1 = SiteWindow(start=29, end=36, offset=1, length=8, st=3, nd=4, rd=5)
+    assert profile_header(w1, order=1) == ["8", "1", "-7", "1", "0", "1"]
+
+
+def test_format_profile_structure():
+    matrix = {(1, "A"): 0.5, (1, "C"): -1.25413, (2, "G"): -9999.0}
+    lines = format_profile(matrix, ["8", "3", "-7", "0"])
+    assert lines[0] == "8 3 -7 0"
+    assert lines[1] == "# Transition probabilities at every position"
+    assert lines[2] == "1 A 0.5"
+    assert lines[3] == "1 C -1.25413"
+    assert lines[4] == "2 G -9999"
+
+
+def test_fmt_integers_bare():
+    assert _fmt(-9999.0) == "-9999"
+    assert _fmt(0.0) == "0"
+    assert _fmt(0.729033) == "0.729033"
+
+
+def test_replace_block_data_preserves_surroundings():
+    text = "Foo\n1\n# a comment\nBar\nx y z\n"
+    p = Param.from_text(text)
+    p.replace_block_data("Foo", ["9", "9", "9"])
+    out = p.to_text()
+    # keyword kept, data replaced, the Bar block untouched
+    assert out == "Foo\n9\n9\n9\n# a comment\nBar\nx y z\n"
+
+
+def _tiny_template():
+    return (
+        "# geneid parameter file: @SPECIES@\n"
+        "Start_profile\n@START_PROFILE@\n"
+        "Acceptor_profile\n@ACCEPTOR_PROFILE@\n"
+        "Donor_profile\n@DONOR_PROFILE@\n"
+        "Markov_order\n@MARKOV_ORDER@\n"
+        "Markov_Initial_probability_matrix\n@MARKOV_INITIAL@\n"
+        "Markov_Transition_probability_matrix\n@MARKOV_TRANSITION@\n"
+        "General_Gene_Model\n"
+        "A B @INTRON_RANGE@\n"
+        "C D @INTERGENIC_RANGE@\n"
+    )
+
+
+def test_assemble_param_injects_all_sections():
+    out = assemble_param(
+        species="Testus_specius",
+        start_profile=["8 3 -7 0", "1 A 0.5"],
+        acceptor_profile=["30 28 -7 1 0 1", "1 AA 0.1"],
+        donor_profile=["8 1 -7 1 0 1", "1 AA 0.2"],
+        markov_order=5,
+        markov_initial=["AAAAA 0 0 -0.5"],
+        markov_transition=["AAAAAA 0 0 -0.8"],
+        intron_range="24.75:25394.023",
+        intergenic_range="200:Infinity",
+        template=_tiny_template(),
+    )
+    assert "@" not in out  # every sentinel filled
+    assert "# geneid parameter file: Testus_specius" in out
+    p = Param.from_text(out)
+    assert p.scalar("Markov_order") == "5"
+    assert p.profile("Donor_profile").header == [8, 1, -7, 1, 0, 1]
+    assert "A B 24.75:25394.023" in out
+    assert "C D 200:Infinity" in out
+
+
+def test_bundled_template_has_all_sentinels():
+    t = load_template()
+    for s in (
+        "@START_PROFILE@",
+        "@ACCEPTOR_PROFILE@",
+        "@DONOR_PROFILE@",
+        "@MARKOV_ORDER@",
+        "@MARKOV_INITIAL@",
+        "@MARKOV_TRANSITION@",
+        "@INTRON_RANGE@",
+        "@INTERGENIC_RANGE@",
+        "@SPECIES@",
+    ):
+        assert s in t, s
+    assert t.count("@INTRON_RANGE@") == 2
+    assert t.count("@INTERGENIC_RANGE@") == 4
+
+
+# ---- full assembly against the reference param ------------------------------
+
+REF = ref_dir()
+SP = "Xerocrassa_montserratensis"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_assembled_param_matches_reference():
+    refp = Param.read(REF / f"{SP}.geneid.param")
+
+    def prof_lines(name):
+        pr = refp.profile(name)
+        matrix = {(p, o): v for p, o, v in pr.rows}
+        return format_profile(matrix, [_fmt(x) for x in pr.header])
+
+    def markov_lines(name):
+        blk = refp._find(name)
+        model = {}
+        for i in blk.data_line_indices():
+            parts = blk.raw[i].split()
+            model[(parts[0], int(parts[2]))] = float(parts[3])
+        return format_markov_matrix(model)
+
+    lens = [len(ln.split("\t")[1].strip()) for ln in open(REF / f"{SP}.train.intron.tbl")]
+    lo, hi = intron_range(lens)
+
+    out = assemble_param(
+        species=SP,
+        start_profile=prof_lines("Start_profile"),
+        acceptor_profile=prof_lines("Acceptor_profile"),
+        donor_profile=prof_lines("Donor_profile"),
+        markov_order=5,
+        markov_initial=markov_lines("Markov_Initial_probability_matrix"),
+        markov_transition=markov_lines("Markov_Transition_probability_matrix"),
+        intron_range=format_range(lo, hi),
+        intergenic_range="200:Infinity",
+    )
+    assert "@" not in out
+    asm = Param.from_text(out)
+
+    # identical section structure and Markov order
+    assert asm.keywords() == refp.keywords()
+    assert asm.scalar("Markov_order") == "5"
+
+    # every trained profile reproduces the reference exactly
+    for name in ("Start_profile", "Acceptor_profile", "Donor_profile"):
+        a = {(p, o): v for p, o, v in asm.profile(name).rows}
+        b = {(p, o): v for p, o, v in refp.profile(name).rows}
+        assert set(a) == set(b)
+        assert max(abs(a[k] - b[k]) for k in b) < 1e-6
+
+    # both Markov matrices identical (string-exact)
+    for name in ("Markov_Initial_probability_matrix", "Markov_Transition_probability_matrix"):
+        ba, bb = asm._find(name), refp._find(name)
+        da = {tuple(ba.raw[i].split()[:3]): ba.raw[i].split()[3] for i in ba.data_line_indices()}
+        db = {tuple(bb.raw[i].split()[:3]): bb.raw[i].split()[3] for i in bb.data_line_indices()}
+        assert da == db
+
+    # gene-model ranges landed
+    gm = "".join(asm._find("General_Gene_Model").raw)
+    assert format_range(lo, hi) in gm
+    assert "200:Infinity" in gm

--- a/training/tests/test_background.py
+++ b/training/tests/test_background.py
@@ -1,0 +1,50 @@
+import pytest
+
+from geneid_train.stats.background import background_models, from_genome, sample_kmers
+
+
+def test_sample_kmers_shape_and_alphabet():
+    genome = ["ACGT" * 500]  # 2000 bp, all ACGT
+    kmers = sample_kmers(genome, k=10, n=20, seed=0)
+    assert len(kmers) == 20
+    assert all(len(km) == 10 for km in kmers)
+    assert all(set(km) <= set("ACGT") for km in kmers)
+
+
+def test_sample_kmers_is_seeded_reproducible():
+    genome = ["ACGTACGTAC" * 200]
+    a = sample_kmers(genome, k=8, n=15, seed=42)
+    b = sample_kmers(genome, k=8, n=15, seed=42)
+    c = sample_kmers(genome, k=8, n=15, seed=43)
+    assert a == b
+    assert a != c
+
+
+def test_sample_kmers_rejects_non_acgt():
+    # only a short ACGT stretch is long enough for an 8-mer; N regions rejected
+    genome = ["N" * 50 + "ACGTACGTACGT" + "N" * 50]
+    kmers = sample_kmers(genome, k=8, n=5, seed=0)
+    assert all("N" not in km for km in kmers)
+
+
+def test_sample_kmers_raises_when_too_short():
+    with pytest.raises(ValueError):
+        sample_kmers(["ACGT"], k=62, n=10)
+
+
+def test_background_models_shapes():
+    genome = ["ACGTACGTAC" * 300]
+    freq, dimatrix = from_genome(genome, k=20, n=200, seed=0)
+    # order-0 freq keyed (pos, base); order-1 dimatrix keyed (pos, dinuc)
+    assert all(len(o) == 1 for _, o in freq)
+    assert all(len(o) == 2 for _, o in dimatrix)
+    # each position's single-base frequencies sum to ~1
+    by_pos: dict[int, float] = {}
+    for (pos, _), v in freq.items():
+        by_pos[pos] = by_pos.get(pos, 0.0) + v
+    assert all(abs(s - 1.0) < 1e-9 for s in by_pos.values())
+
+
+def test_background_models_direct():
+    freq, dimatrix = background_models(["ACGTACGT", "TGCATGCA"])
+    assert freq and dimatrix

--- a/training/tests/test_coding.py
+++ b/training/tests/test_coding.py
@@ -1,0 +1,110 @@
+import math
+
+import pytest
+
+from geneid_train.stats.coding import (
+    choose_orders,
+    coding_log_ratio,
+    derive_coding_potential,
+    format_markov_matrix,
+    initial_model,
+    transition_model,
+)
+
+from .conftest import ref_dir
+
+
+def test_transition_model_conditional_probabilities():
+    # ACGTACGT (order 1, single frame): A->C, C->G, G->T, T->A observed
+    m = transition_model(["ACGTACGT"], order=1, pseudo=0.0, nframes=1)
+    assert m[("AC", 0)] == 1.0
+    assert m[("CG", 0)] == 1.0
+    assert m[("GT", 0)] == 1.0
+    # unobserved prefix falls to 0 (no counts, no pseudo)
+    assert m[("AA", 0)] == 0.0
+
+
+def test_transition_model_frames_sum_to_one():
+    seqs = ["ACGTACGTACGTACGTACGT"]
+    m = transition_model(seqs, order=1, pseudo=0.25, nframes=3)
+    for fr in range(3):
+        for pre in "ACGT":
+            s = sum(m[(pre + nt, fr)] for nt in "ACGT")
+            assert s == pytest.approx(1.0)
+
+
+def test_initial_model_is_a_frequency_distribution():
+    seqs = ["ACGTACGTACGTACGT"]
+    # without pseudocounts the per-frame oligo frequencies form a distribution
+    m = initial_model(seqs, order=1, pseudo=0.0, nframes=1)
+    total = sum(v for (o, fr), v in m.items() if fr == 0)
+    assert total == pytest.approx(1.0)
+
+
+def test_coding_log_ratio_natural_log():
+    coding = {("AAAAA", 0): 0.5, ("AAAAA", 1): 0.4}
+    intron = {("AAAAA", 0): 0.25}
+    out = coding_log_ratio(coding, intron)
+    assert out[("AAAAA", 0)] == pytest.approx(math.log(2.0))
+    assert out[("AAAAA", 1)] == pytest.approx(math.log(1.6))
+
+
+def test_choose_orders():
+    assert choose_orders(500_000, 200_000) == (4, 5)
+    assert choose_orders(1_300_000, 30_000_000) == (4, 5)
+    assert choose_orders(1_000, 1_000) == (3, 4)
+
+
+def test_format_markov_matrix_indexing():
+    model = {("AAAA", 0): 1.234, ("AAAA", 1): -0.5, ("AAAC", 0): 0.1}
+    lines = format_markov_matrix(model)
+    assert lines[0] == "AAAA 0 0 1.234"
+    assert lines[1] == "AAAA 0 1 -0.500"
+    assert lines[2] == "AAAC 1 0 0.100"
+
+
+# ---- validation against the trained xgXerMont param -------------------------
+
+REF = ref_dir()
+
+
+def _read_param_markov(path, header):
+    """Parse a Markov matrix block (oligo index frame value) from a param file."""
+    out = {}
+    active = False
+    for ln in open(path):
+        s = ln.strip()
+        if s == header:
+            active = True
+            continue
+        if active:
+            p = s.split()
+            if len(p) == 4 and p[0].isalpha():
+                out[(p[0], int(p[2]))] = float(p[3])
+            elif out:  # first non-data line after the block ends it
+                break
+    return out
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_coding_potential_matches_param():
+    def read_seqs(name):
+        return [ln.split("\t")[1].strip() for ln in open(REF / name)]
+
+    cds = read_seqs("Xerocrassa_montserratensis.train.cds.tbl")
+    introns = read_seqs("Xerocrassa_montserratensis.train.intron.tbl")
+    init, trans, cbases, nbases = derive_coding_potential(cds, introns, transition_order=5)
+
+    assert choose_orders(cbases, nbases) == (4, 5)  # this training set warrants 5/4
+
+    param = REF / "Xerocrassa_montserratensis.geneid.param"
+    ref_init = _read_param_markov(param, "Markov_Initial_probability_matrix")
+    ref_trans = _read_param_markov(param, "Markov_Transition_probability_matrix")
+    assert len(ref_init) == 3072 and len(ref_trans) == 12288
+
+    # both matrices reproduce the param exactly at its 3-decimal precision
+    worst_init = max(abs(round(init[k], 3) - ref_init[k]) for k in ref_init)
+    worst_trans = max(abs(round(trans[k], 3) - ref_trans[k]) for k in ref_trans)
+    assert worst_init == 0.0, f"initial max dev {worst_init}"
+    assert worst_trans == 0.0, f"transition max dev {worst_trans}"

--- a/training/tests/test_extract_sites.py
+++ b/training/tests/test_extract_sites.py
@@ -1,0 +1,131 @@
+import random
+import re
+
+import pytest
+
+from geneid_train.core.seq import revcomp
+from geneid_train.prepare.base import Exon, GeneModel
+from geneid_train.prepare.sites import (
+    acceptor_windows,
+    collect_sites,
+    donor_windows,
+    is_canonical_acceptor,
+    is_canonical_donor,
+    is_canonical_start,
+    start_window,
+)
+
+from .conftest import ref_dir
+
+
+def _synthetic_chrom():
+    """A 200 bp chromosome with a 2-exon + gene: exons [41,70] and [121,150],
+    intron [71,120] (GT..AG), start codon ATG at 41-43."""
+    random.seed(1)
+    c = [random.choice("ACGT") for _ in range(200)]
+
+    def put(pos1, s):
+        for i, ch in enumerate(s):
+            c[pos1 - 1 + i] = ch
+
+    put(41, "ATG")  # start codon
+    put(71, "GT")  # donor: first intron bases
+    put(119, "AG")  # acceptor: last intron bases
+    return "".join(c)
+
+
+def test_plus_strand_geometry():
+    chrom = _synthetic_chrom()
+    m = GeneModel("g+", "chr", "+", [Exon(41, 70), Exon(121, 150)])
+    d = donor_windows(m, chrom)
+    a = acceptor_windows(m, chrom)
+    s = start_window(m, chrom)
+    assert len(d) == 1 and len(a) == 1
+    assert len(d[0]) == len(a[0]) == len(s) == 60
+    # anchor at profile position 31; invariant motifs at their fixed offsets
+    assert is_canonical_donor(d[0]) and d[0][31:33] == "GT"
+    assert is_canonical_acceptor(a[0]) and a[0][28:30] == "AG"
+    assert is_canonical_start(s) and s[30:33] == "ATG"
+    # windows equal the exact genomic slices, computed independently of _window
+    assert d[0] == chrom[39:99]  # donor anchor 70 (last exon base)
+    assert a[0] == chrom[90:150]  # acceptor anchor 121 (first exon base)
+    assert s == chrom[10:70]  # start anchor 41 (A of ATG)
+
+
+def test_minus_strand_matches_plus():
+    """Mirroring the genome and the gene onto the minus strand must yield the
+    identical transcription-oriented windows."""
+    chrom = _synthetic_chrom()
+    n = len(chrom)
+    mp = GeneModel("g+", "chr", "+", [Exon(41, 70), Exon(121, 150)])
+    dp, ap, sp = donor_windows(mp, chrom), acceptor_windows(mp, chrom), start_window(mp, chrom)
+
+    cm = revcomp(chrom)
+
+    def mirror(a, b):
+        return Exon(n + 1 - b, n + 1 - a)
+
+    mm = GeneModel("g-", "chr", "-", sorted(
+        [mirror(41, 70), mirror(121, 150)], key=lambda e: e.start
+    ))
+    dm, am, sm = donor_windows(mm, cm), acceptor_windows(mm, cm), start_window(mm, cm)
+    assert dm == dp
+    assert am == ap
+    assert sm == sp
+
+
+def test_windows_skipped_at_sequence_ends():
+    chrom = _synthetic_chrom()
+    # a gene whose start codon is at position 5 has no room for 30 bp upstream
+    m = GeneModel("edge", "chr", "+", [Exon(5, 40)])
+    assert start_window(m, chrom) is None
+
+
+# ---- real-data validation: canonical fraction on Xerocrassa eval genes -------
+
+REF = ref_dir()
+GENOME = REF.parents[2] / "xgXerMont_curated.no_mt.scrubbed.fa.gz" if REF else None
+
+
+def _load_geneid_gff(path, seqid_prefixes):
+    """Parse a geneid-format gff (First/Internal/Terminal/Single, genome coords)
+    into GeneModels, renaming SUPERn -> SUPER_n to match the genome headers."""
+    tx: dict[tuple[str, str, str], list[tuple[int, int]]] = {}
+    for ln in open(path):
+        f = ln.rstrip("\n").split("\t")
+        if f[0] not in seqid_prefixes:
+            continue
+        seqid = re.sub(r"^SUPER", "SUPER_", f[0])
+        key = (f[8].strip(), seqid, f[6])
+        tx.setdefault(key, []).append((int(f[3]), int(f[4])))
+    return [
+        GeneModel(gene_id=t, seqid=s, strand=st, exons=[Exon(a, b) for a, b in sorted(ex)])
+        for (t, s, st), ex in tx.items()
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    REF is None or not (GENOME and GENOME.exists()),
+    reason="set GENEID_TRAIN_REFDIR and provide the xgXerMont genome",
+)
+def test_real_extraction_canonical_fraction():
+    from geneid_train.core.fasta import read_fasta_subset
+
+    gff = REF / "Xerocrassa_montserratensis.eval.geneid.gff_sorted"
+    models = _load_geneid_gff(gff, {"SUPER1", "SUPER2"})
+    seqids = {m.seqid for m in models}
+    genome = read_fasta_subset(str(GENOME), seqids)
+    s = collect_sites(models, genome)
+
+    ndon = len(s.donor) + len(s.noncanonical_donor)
+    nacc = len(s.acceptor) + len(s.noncanonical_acceptor)
+    assert ndon > 100 and nacc > 100  # a meaningful sample
+    # real introns are overwhelmingly GT-AG; a 1-off geometry error collapses this
+    assert len(s.donor) / ndon > 0.95
+    assert len(s.acceptor) / nacc > 0.98
+    # every annotated CDS starts with ATG under the standard code
+    assert len(s.noncanonical_start) == 0 and len(s.start) == len(models)
+    # geometry sanity on the extracted windows themselves
+    assert all(len(w) == 60 for w in s.donor)
+    assert all(w[31:33] == "GT" for w in s.donor)

--- a/training/tests/test_genemodel.py
+++ b/training/tests/test_genemodel.py
@@ -1,0 +1,36 @@
+import pytest
+
+from geneid_train.stats.genemodel import format_range, intron_range
+
+from .conftest import ref_dir
+
+
+def test_intron_range_caps_short_at_40():
+    # shortest intron 1000 -> 0.75*1000 = 750, capped at 40
+    lo, hi = intron_range([1000, 1000, 1000, 1000])
+    assert lo == 40.0
+
+
+def test_intron_range_short_below_cap():
+    lo, _ = intron_range([20, 100, 200])  # 0.75*20 = 15 < 40
+    assert lo == 15.0
+
+
+def test_format_range():
+    assert format_range(40.0, "Infinity") == "40:Infinity"
+    assert format_range(24.75, 25394.023) == "24.75:25394.023"
+
+
+REF = ref_dir()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_intron_range_matches_reference():
+    name = "Xerocrassa_montserratensis.train.intron.tbl"
+    lens = [len(ln.split("\t")[1].strip()) for ln in open(REF / name)]
+    lo, hi = intron_range(lens)
+    # reference gene model uses 24.75:25394.023; lo is exact, hi matches to <1 bp
+    # (the last-decimal difference is float-printing noise on a coarse bound)
+    assert lo == 24.75
+    assert abs(hi - 25394.023) < 1.0

--- a/training/tests/test_sites.py
+++ b/training/tests/test_sites.py
@@ -3,11 +3,14 @@ import math
 import pytest
 
 from geneid_train.stats.sites import (
+    frequency,
+    info_content,
     log_ratio,
     log_ratio_zero_order,
     mask_invariant_dinuc,
     position_matrix,
     read_matrix,
+    select_window,
     submatrix,
 )
 
@@ -120,18 +123,111 @@ def test_mask_invariant_dinuc_donor():
     assert out[(6, "AA")] == -0.3  # untouched
 
 
+# ---- boundary selection (info content -> profile window + anchor) -----------
+
+
+def read_freq(path):
+    """Parse a legacy ``.freq`` file (``base pos count freq``) -> {(pos, base): freq}."""
+    out = {}
+    for ln in open(path):
+        p = ln.split()
+        if len(p) >= 4:
+            out[(int(p[1]), p[0])] = float(p[3])
+    return out
+
+
+def read_info(path):
+    """Parse a legacy tempinfolog file (``pos bits``) -> {pos: bits}."""
+    out = {}
+    for ln in open(path):
+        p = ln.split()
+        if len(p) == 2 and p[0].lstrip("-").isdigit():
+            out[int(p[0])] = float(p[1])
+    return out
+
+
+def test_frequency_per_position_denominator():
+    # N masks only its own column: pos1 sees A twice + one N -> total 2
+    f = frequency(["AC", "AG", "NC"])
+    assert f[(1, "A")] == 1.0  # 2/2 valid
+    assert f[(2, "C")] == pytest.approx(2 / 3)
+    assert f[(2, "G")] == pytest.approx(1 / 3)
+
+
+def test_info_content_relative_entropy_bits():
+    # one position, site all-A vs uniform background -> log2(4) = 2 bits
+    site = {(1, b): (1.0 if b == "A" else 0.0) for b in "ACGT"}
+    bg = {(1, b): 0.25 for b in "ACGT"}
+    info = info_content(site, bg)
+    assert info[1] == pytest.approx(2.0)
+
+
+def test_select_window_donor_from_info():
+    # peaks at 30..37; seed 29/31. -> start 29, end 37-order=36, anchor 3/4/5
+    info = {p: (1.0 if 30 <= p <= 37 else 0.01) for p in range(25, 39)}
+    w = select_window(info, site="donor", order=1)
+    assert (w.start, w.end) == (29, 36)
+    assert (w.st, w.nd, w.rd) == (3, 4, 5)
+
+
+def test_select_window_acceptor_from_info():
+    # everything above 0.04 from pos 2..32 -> start 2, end 31, anchor 27/28/29
+    info = {p: 0.5 for p in range(2, 33)}
+    w = select_window(info, site="acceptor", order=1)
+    assert (w.start, w.end) == (2, 31)
+    assert (w.st, w.nd, w.rd) == (27, 28, 29)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_frequency_matches_reference():
+    seqs = [ln.split("\t")[1].strip() for ln in open(REF / f"{SP}.canonical.donor.tbl")]
+    ours = frequency(seqs)
+    ref = read_freq(REF / f"{SP}.canonical.donor.freq")
+    worst = max(abs(ours[k] - ref[k]) for k in ref)
+    assert worst < 1e-3, f"max deviation {worst}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_info_content_matches_reference():
+    site = read_freq(REF / f"{SP}.canonical.donor.freq")
+    bg = read_freq(REF / f"{SP}_background.info.freq")
+    ours = info_content(site, bg)
+    ref = read_info(REF / f"{SP}.canonical.donor-{SP}_background.info")
+    shared = set(ours) & set(ref)
+    assert len(shared) > 5
+    worst = max(abs(ours[k] - ref[k]) for k in shared)
+    assert worst < 1e-4, f"max deviation {worst}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_select_window_matches_reference_donor_and_acceptor():
+    dinfo = read_info(REF / f"{SP}.canonical.donor-{SP}_background.info")
+    dw = select_window(dinfo, site="donor", order=1)
+    assert (dw.start, dw.end, dw.st, dw.nd, dw.rd) == (29, 36, 3, 4, 5)
+    ainfo = read_info(REF / f"{SP}.canonical.acceptor-{SP}_background.info")
+    aw = select_window(ainfo, site="acceptor", order=1)
+    assert (aw.start, aw.end, aw.st, aw.nd, aw.rd) == (2, 31, 27, 28, 29)
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
 def test_full_donor_profile_matches_param():
-    """End-to-end: donor site sequences -> the trained param's Donor_profile block.
-
-    Window [29,36] and GT anchor at profile positions 3/4/5 are the values the
-    reference run selected; boundary selection lands them automatically later.
-    """
+    """End-to-end: donor site sequences -> the trained param's Donor_profile block,
+    with the window and GT-anchor columns selected automatically from info content."""
     seqs = [ln.split("\t")[1].strip() for ln in open(REF / f"{SP}.canonical.donor.tbl")]
     site = position_matrix(seqs, order=1)
     bg = read_matrix(REF / f"{SP}_background.info.di-matrix")
-    prof = mask_invariant_dinuc(submatrix(log_ratio(site, bg), 29, 36), 3, 4, 5, "GT")
+    info = info_content(
+        read_freq(REF / f"{SP}.canonical.donor.freq"),
+        read_freq(REF / f"{SP}_background.info.freq"),
+    )
+    w = select_window(info, site="donor", order=1)
+    prof = mask_invariant_dinuc(
+        submatrix(log_ratio(site, bg), w.start, w.end), w.st, w.nd, w.rd, "GT"
+    )
     ref = read_matrix(REF / f"{SP}.canonical.donor-log-info.di-matrix")  # == param Donor_profile
     assert set(prof) == set(ref)
     worst = max(abs(prof[k] - ref[k]) for k in ref)
@@ -141,12 +237,19 @@ def test_full_donor_profile_matches_param():
 @pytest.mark.integration
 @pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
 def test_full_acceptor_profile_matches_param():
-    """Same pipeline as the donor test, with the AG anchor at acceptor positions
-    27/28/29 (the reference run's automatically-selected window [1,30])."""
+    """Same pipeline as the donor test, with the AG anchor and window selected
+    automatically from acceptor info content."""
     seqs = [ln.split("\t")[1].strip() for ln in open(REF / f"{SP}.canonical.acceptor.tbl")]
     site = position_matrix(seqs, order=1)
     bg = read_matrix(REF / f"{SP}_background.info.di-matrix")
-    prof = mask_invariant_dinuc(submatrix(log_ratio(site, bg), 2, 31), 27, 28, 29, "AG")
+    info = info_content(
+        read_freq(REF / f"{SP}.canonical.acceptor.freq"),
+        read_freq(REF / f"{SP}_background.info.freq"),
+    )
+    w = select_window(info, site="acceptor", order=1)
+    prof = mask_invariant_dinuc(
+        submatrix(log_ratio(site, bg), w.start, w.end), w.st, w.nd, w.rd, "AG"
+    )
     ref = read_matrix(REF / f"{SP}.canonical.acceptor-log-info.di-matrix")
     assert set(prof) == set(ref)
     worst = max(abs(prof[k] - ref[k]) for k in ref)

--- a/training/tests/test_sites.py
+++ b/training/tests/test_sites.py
@@ -2,7 +2,13 @@ import math
 
 import pytest
 
-from geneid_train.stats.sites import log_ratio, position_matrix, read_matrix
+from geneid_train.stats.sites import (
+    log_ratio,
+    mask_invariant_dinuc,
+    position_matrix,
+    read_matrix,
+    submatrix,
+)
 
 from .conftest import ref_dir
 
@@ -73,4 +79,33 @@ def test_donor_log_ratio_matches_reference():
     shared = set(ours) & set(ref)
     assert len(shared) > 100
     worst = max(abs(ours[k] - ref[k]) for k in shared)
+    assert worst < 1e-3, f"max deviation {worst}"
+
+
+def test_mask_invariant_dinuc_donor():
+    # profile positions 3/4/5 carry the invariant GT
+    m = {(3, "AG"): 1.5, (3, "AA"): 1.5, (4, "GT"): 2.0, (4, "AA"): 2.0,
+         (5, "TA"): 0.7, (5, "AA"): 0.7, (6, "AA"): -0.3}
+    out = mask_invariant_dinuc(m, st=3, nd=4, rd=5, anchor="GT")
+    assert out[(3, "AG")] == 0.0 and out[(3, "AA")] == -9999.0  # ends in G -> 0
+    assert out[(4, "GT")] == 0.0 and out[(4, "AA")] == -9999.0  # == GT -> 0
+    assert out[(5, "TA")] == 0.7 and out[(5, "AA")] == -9999.0  # starts T -> keep
+    assert out[(6, "AA")] == -0.3  # untouched
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_full_donor_profile_matches_param():
+    """End-to-end: donor site sequences -> the trained param's Donor_profile block.
+
+    Window [29,36] and GT anchor at profile positions 3/4/5 are the values the
+    reference run selected; boundary selection lands them automatically later.
+    """
+    seqs = [ln.split("\t")[1].strip() for ln in open(REF / f"{SP}.canonical.donor.tbl")]
+    site = position_matrix(seqs, order=1)
+    bg = read_matrix(REF / f"{SP}_background.info.di-matrix")
+    prof = mask_invariant_dinuc(submatrix(log_ratio(site, bg), 29, 36), 3, 4, 5, "GT")
+    ref = read_matrix(REF / f"{SP}.canonical.donor-log-info.di-matrix")  # == param Donor_profile
+    assert set(prof) == set(ref)
+    worst = max(abs(prof[k] - ref[k]) for k in ref)
     assert worst < 1e-3, f"max deviation {worst}"

--- a/training/tests/test_sites.py
+++ b/training/tests/test_sites.py
@@ -1,0 +1,76 @@
+import math
+
+import pytest
+
+from geneid_train.stats.sites import log_ratio, position_matrix, read_matrix
+
+from .conftest import ref_dir
+
+
+def test_position_matrix_order1_conditionals():
+    m = position_matrix(["ACGT", "ACGA"], order=1, pcount=0.0)  # unsmoothed for exact fractions
+    assert m[(1, "AC")] == 1.0  # A always followed by C at pos 1
+    assert m[(2, "CG")] == 1.0
+    assert m[(3, "GT")] == 0.5  # G -> T or A at pos 3
+    assert m[(3, "GA")] == 0.5
+    # positions run 1..L-order
+    assert max(p for p, _ in m) == 3
+
+
+def test_position_matrix_pseudocounts():
+    # single AC: P(AC) = (0.25+1)/(1.0+1) = 0.625; unobserved P(AA) = 0.25/2 = 0.125
+    m = position_matrix(["AC"], order=1, pcount=0.25)
+    assert m[(1, "AC")] == 0.625
+    assert m[(1, "AA")] == 0.125
+    # complete matrix: all 16 dinucleotides present at position 1
+    assert len([k for k in m if k[0] == 1]) == 16
+
+
+def test_position_matrix_skips_whole_window_with_non_acgt():
+    m = position_matrix(["ANGT", "ACGT"], order=1, pcount=0.0)
+    # ANGT dropped entirely -> only ACGT contributes
+    assert m[(1, "AC")] == 1.0
+    assert m[(1, "AA")] == 0.0
+
+
+def test_log_ratio_natural_log():
+    out = log_ratio({(1, "AA"): 0.5}, {(1, "AA"): 0.25})
+    assert out[(1, "AA")] == pytest.approx(math.log(2.0))
+
+
+def test_log_ratio_broadcasts_position_independent_background():
+    site = {(2, "AA"): 0.4}
+    bg = {(1, "AA"): 0.2}  # position-independent background
+    out = log_ratio(site, bg)
+    assert out[(2, "AA")] == pytest.approx(math.log(2.0))
+
+
+# ---- validation against the real xgXerMont reference run -------------------
+
+REF = ref_dir()
+SP = "Xerocrassa_montserratensis"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_donor_position_matrix_matches_reference():
+    seqs = [ln.split("\t")[1].strip() for ln in open(REF / f"{SP}.canonical.donor.tbl")]
+    ours = position_matrix(seqs, order=1)
+    ref = read_matrix(REF / f"{SP}.canonical.donor.di-matrix")
+    shared = set(ours) & set(ref)
+    assert len(shared) > 100
+    worst = max(abs(ours[k] - ref[k]) for k in shared)
+    assert worst < 1e-3, f"max deviation {worst}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_donor_log_ratio_matches_reference():
+    site = read_matrix(REF / f"{SP}.canonical.donor.di-matrix")
+    bg = read_matrix(REF / f"{SP}_background.info.di-matrix")
+    ours = log_ratio(site, bg)
+    ref = read_matrix(REF / f"{SP}.canonical.donor-log.di-matrix")
+    shared = set(ours) & set(ref)
+    assert len(shared) > 100
+    worst = max(abs(ours[k] - ref[k]) for k in shared)
+    assert worst < 1e-3, f"max deviation {worst}"

--- a/training/tests/test_sites.py
+++ b/training/tests/test_sites.py
@@ -4,6 +4,7 @@ import pytest
 
 from geneid_train.stats.sites import (
     log_ratio,
+    log_ratio_zero_order,
     mask_invariant_dinuc,
     position_matrix,
     read_matrix,
@@ -82,6 +83,32 @@ def test_donor_log_ratio_matches_reference():
     assert worst < 1e-3, f"max deviation {worst}"
 
 
+def test_log_ratio_zero_order_natural_masking():
+    # freq==0 -> -9999 (never observed); freq==1 -> 0 (invariant); else log ratio
+    site = {(4, "A"): 1.0, (4, "C"): 0.0, (7, "G"): 0.4}
+    bg = {(4, "A"): 0.3, (4, "C"): 0.2, (7, "G"): 0.2}
+    out = log_ratio_zero_order(site, bg)
+    assert out[(4, "A")] == 0.0
+    assert out[(4, "C")] == -9999.0
+    assert out[(7, "G")] == pytest.approx(math.log(0.4 / 0.2))
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_start_order0_masking_matches_reference_shape():
+    """Order-0 (Start) profile: no explicit masking step -- the ATG anchor falls
+    out naturally from exact 0/1 raw frequencies (no pseudocounts). The reference
+    log-ratio's 0 / -9999 cells are exactly where our raw frequency is 1 / 0,
+    independent of the background model used."""
+    seqs = [ln.split()[1].strip() for ln in open(REF / f"{SP}.canonical.start.tbl")]
+    site = position_matrix(seqs, order=0, pcount=0.0)
+    ref = read_matrix(REF / f"{SP}.canonical.start-log.order-0-matrix")
+    zero_cells = {k for k, v in ref.items() if v == 0.0}
+    masked_cells = {k for k, v in ref.items() if v == -9999.0}
+    assert zero_cells == {k for k, v in site.items() if v == 1.0}
+    assert masked_cells == {k for k, v in site.items() if v == 0.0}
+
+
 def test_mask_invariant_dinuc_donor():
     # profile positions 3/4/5 carry the invariant GT
     m = {(3, "AG"): 1.5, (3, "AA"): 1.5, (4, "GT"): 2.0, (4, "AA"): 2.0,
@@ -106,6 +133,21 @@ def test_full_donor_profile_matches_param():
     bg = read_matrix(REF / f"{SP}_background.info.di-matrix")
     prof = mask_invariant_dinuc(submatrix(log_ratio(site, bg), 29, 36), 3, 4, 5, "GT")
     ref = read_matrix(REF / f"{SP}.canonical.donor-log-info.di-matrix")  # == param Donor_profile
+    assert set(prof) == set(ref)
+    worst = max(abs(prof[k] - ref[k]) for k in ref)
+    assert worst < 1e-3, f"max deviation {worst}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_full_acceptor_profile_matches_param():
+    """Same pipeline as the donor test, with the AG anchor at acceptor positions
+    27/28/29 (the reference run's automatically-selected window [1,30])."""
+    seqs = [ln.split("\t")[1].strip() for ln in open(REF / f"{SP}.canonical.acceptor.tbl")]
+    site = position_matrix(seqs, order=1)
+    bg = read_matrix(REF / f"{SP}_background.info.di-matrix")
+    prof = mask_invariant_dinuc(submatrix(log_ratio(site, bg), 2, 31), 27, 28, 29, "AG")
+    ref = read_matrix(REF / f"{SP}.canonical.acceptor-log-info.di-matrix")
     assert set(prof) == set(ref)
     worst = max(abs(prof[k] - ref[k]) for k in ref)
     assert worst < 1e-3, f"max deviation {worst}"

--- a/training/tests/test_train.py
+++ b/training/tests/test_train.py
@@ -1,0 +1,116 @@
+import pytest
+
+from geneid_train.train import _site_order, build_site_profile, train
+
+from .conftest import ref_dir
+
+REF = ref_dir()
+SP = "Xerocrassa_montserratensis"
+GENOME = REF.parents[2] / "xgXerMont_curated.no_mt.scrubbed.fa.gz" if REF else None
+
+
+def test_site_order_standard_case():
+    # plenty of donor/acceptor sites, few starts -> order (1, 1, 0)
+    assert _site_order(9000, 9000, 800) == (1, 1, 0)
+
+
+def test_site_order_raises_on_sparse_splice_sites():
+    with pytest.raises(NotImplementedError, match="order-0 donor/acceptor"):
+        _site_order(500, 9000, 800)
+
+
+def test_site_order_raises_on_order2_start():
+    with pytest.raises(NotImplementedError, match="order-2 start"):
+        _site_order(9000, 9000, 6000)
+
+
+# ---- orchestration validated against the reference --------------------------
+
+
+def _ref_background():
+    freq = {}
+    for ln in open(REF / f"{SP}_background.info.freq"):
+        p = ln.split()
+        if len(p) >= 4:
+            freq[(int(p[1]), p[0])] = float(p[3])
+    from geneid_train.stats.sites import read_matrix
+
+    dimatrix = read_matrix(REF / f"{SP}_background.info.di-matrix")
+    return freq, dimatrix
+
+
+def _ref_site_seqs(name):
+    delim = "\t" if name != "start" else None
+    path = REF / f"{SP}.canonical.{name}.tbl"
+    return [
+        (ln.split(delim)[1] if delim else ln.split()[1]).strip() for ln in open(path)
+    ]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
+def test_build_site_profile_matches_reference():
+    from geneid_train.core.param import Param
+
+    bg_freq, bg_dimatrix = _ref_background()
+    refp = Param.read(REF / f"{SP}.geneid.param")
+
+    def rows_of(lines):
+        out = {}
+        for ln in lines[2:]:  # skip header + comment
+            p = ln.split()
+            out[(int(p[0]), p[1])] = float(p[2])
+        return out
+
+    cases = [
+        ("donor", "Donor_profile", "GT", 1, 1e-3),
+        ("acceptor", "Acceptor_profile", "AG", 1, 1e-3),
+        ("start", "Start_profile", "ATG", 0, 5e-2),
+    ]
+    for name, kw, anchor, order, tol in cases:
+        lines = build_site_profile(
+            _ref_site_seqs(name), site=name, anchor=anchor, order=order,
+            bg_freq=bg_freq, bg_dimatrix=bg_dimatrix,
+        )
+        got = rows_of(lines)
+        ref = {(p, o): v for p, o, v in refp.profile(kw).rows}
+        assert set(got) == set(ref)
+        assert max(abs(got[k] - ref[k]) for k in ref) < tol, name
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    REF is None or not (GENOME and GENOME.exists()),
+    reason="set GENEID_TRAIN_REFDIR and provide the xgXerMont genome",
+)
+def test_train_end_to_end_produces_valid_param():
+    from geneid_train.core.fasta import read_fasta_subset
+    from geneid_train.core.gff import read_gff3
+    from geneid_train.core.param import Param
+    from geneid_train.prepare.base import (
+        build_models,
+        collapse_isoforms,
+        filter_complete,
+        filter_non_overlapping,
+    )
+
+    gff = REF.parent / "get_candidates" / "good_candidates.1trans.gff3"
+    records = read_gff3(gff)
+    models = collapse_isoforms(build_models(records), records)
+    # scope to a handful of scaffolds (enough to clear the order-1 site threshold)
+    want = {f"SUPER_{i}" for i in range(1, 6)}
+    models = [m for m in models if m.seqid in want]
+    genome = read_fasta_subset(str(GENOME), {m.seqid for m in models})
+    models = filter_non_overlapping(filter_complete(models, genome))
+
+    text = train(models, genome, SP, seed=1)
+    assert "@" not in text  # every sentinel filled
+
+    p = Param.from_text(text)
+    assert p.scalar("Markov_order") == "5"
+    for kw in ("Start_profile", "Acceptor_profile", "Donor_profile"):
+        assert p.profile(kw).rows
+    assert p.has("Markov_Initial_probability_matrix")
+    assert p.has("Markov_Transition_probability_matrix")
+    gm = "".join(p._find("General_Gene_Model").raw)
+    assert "200:Infinity" in gm  # intergenic range injected


### PR DESCRIPTION
## Phase 3 — site/coding model estimation + end-to-end `geneid-train train`

Builds on the Phase 1 (#29) `.param` core and Phase 2 (#30) gene-model IR. This phase reproduces the whole statistical core of the legacy Perl/AWK trainer in pure Python, each stage **validated numerically against the real xgXerMont training run**, and wires it into a working `geneid-train train` command that turns a GFF3 + genome into a complete geneid parameter file.

### What's here
- **Site profiles** (`stats/sites.py`): per-position order-k matrices, log-ratio vs background, information-content **boundary selection** (replaces BitScoreGraph — auto-picks the profile window + invariant-anchor columns instead of hardcoding), and geneid-format profile serialization.
- **Site extraction** (`prepare/sites.py`, replaces SSgff): donor/acceptor/start 60 bp windows from gene models + genome, transcription-oriented with the anchor at a fixed position; canonical GT-AG / AG / ATG partitioning.
- **Coding potential** (`stats/coding.py`, replaces geneidCEGMA): order-4 initial + order-5 transition per-frame Markov log-ratio matrices.
- **Background model** (`stats/background.py`, replaces getBackground): seeded sampling of random genomic k-mers → frequency + dinucleotide models.
- **Gene-model stats** (`stats/genemodel.py`): intron/intergenic length ranges.
- **Assembly** (`param/assemble.py` + bundled `data/template.param`): injects trained profiles, Markov matrices, and gene-model ranges into a single-isochore default template.
- **Orchestration** (`train.py`) + CLI: `geneid-train train --gff --fastas --species --output`.

### Validation (opt-in integration tests, `GENEID_TRAIN_REFDIR`)
- Donor/acceptor profiles reproduce the trained param **< 1e-3**; start (order 0) **< 5e-2**; headers exact.
- Coding Markov matrices match the param **exactly** at its 3-decimal precision (3072 initial + 12288 transition cells).
- Boundary selection auto-lands the reference windows (donor `[29,36]`, acceptor `[2,31]`) and anchor columns.
- Real-data extraction: 98.6% GT-AG / 100% AG / 100% ATG on eval genes (both strands).
- Full `train()` on 272 real gene models → well-formed 23-section param.
- Assembling from the reference's own components → identical section structure, Markov order, profiles (worst 0.0), and Markov matrices (string-exact).

**98 tests pass, ruff clean.** Byte-identical repro of a legacy param is a non-goal (log values differ in the low decimals); the contract is a valid, correctly structured param whose sections carry our estimates.

### Not in this PR (Phase 4)
Python SN/SP `evaluate.py`, `optimize.py` (eWF/oWF/AccCtx/minBranch grid via the compiled `geneid`), jackknife CV, and the optional GC/U12/branch+PPT aux profiles (train-and-toggle-if-F1-improves). Also deferred: the rare order-0-splice / order-2-start paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
