### PR TITLE
Fix stale version display (banner v1.4) and normalize GFF source tags to v1.5

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -45,10 +45,15 @@ A. DEFINITIONS
 *************************************************************************/
 
 /* The name of the game                     */
+/* VERSION/SITES/EXONS are the GFF source-column tags geneid writes for
+   predicted genes/sites/exons; they track the minor version. GENEID_RELEASE
+   is the human-facing release string (patch level) shown in the usage banner
+   and credits -- keep it as the single source so they cannot drift again.   */
 #define VERSION   "geneid_v1.5"
 #define SITES     "geneid_v1.5"
-#define EXONS     "geneid_v1.4"       
-#define EVIDENCE  "evidence"           
+#define EXONS     "geneid_v1.5"
+#define GENEID_RELEASE "geneid v1.5.1"
+#define EVIDENCE  "evidence"
 
 /* -------------------------------------------------------------------------
  * These constants used to be a build-time "memory profile": geneid reserved

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -47,7 +47,7 @@ extern long LOW,HI;
 extern char* optarg;
 extern int optind;
 
-char* USAGE="NAME\n\tgeneid - a program to annotate genomic sequences\nSYNOPSIS\n\tgeneid\t[-bdaefitnxszru]\n\t\t[-TDAZU]\n\t\t[-p gene_prefix]\n\t\t[-G] [-3] [-X] [-M] [-m]\n\t\t[-WCF] [-o]\n\t\t[-j lower_bound_coord]\n\t\t[-k upper_bound_coord]\n\t\t[-N numer_nt_mapped]\n\t\t[-O <gff_exons_file>]\n\t\t[-R <gff_annotation-file>]\n\t\t[-S <gff_homology_file>]\n\t\t[-P <parameter_file>]\n\t\t[-E exonweight]\n\t\t[-V evidence_exonweight]\n\t\t[-Bv] [-h]\n\t\t<locus_seq_in_fasta_format>\nRELEASE\n\tgeneid v 1.4\n";
+char* USAGE="NAME\n\tgeneid - a program to annotate genomic sequences\nSYNOPSIS\n\tgeneid\t[-bdaefitnxszru]\n\t\t[-TDAZU]\n\t\t[-p gene_prefix]\n\t\t[-G] [-3] [-X] [-M] [-m]\n\t\t[-WCF] [-o]\n\t\t[-j lower_bound_coord]\n\t\t[-k upper_bound_coord]\n\t\t[-N numer_nt_mapped]\n\t\t[-O <gff_exons_file>]\n\t\t[-R <gff_annotation-file>]\n\t\t[-S <gff_homology_file>]\n\t\t[-P <parameter_file>]\n\t\t[-E exonweight]\n\t\t[-V evidence_exonweight]\n\t\t[-Bv] [-h]\n\t\t<locus_seq_in_fasta_format>\nRELEASE\n\t" GENEID_RELEASE "\n";
 
 void printHelp()
 {
@@ -104,7 +104,7 @@ void printHelp()
   printf("\t-h: Show this help\n");
 
   printf ("AUTHORS\n");
-  printf("\t%s has been developed by Enrique Blanco, Tyler Alioto and Roderic Guigo.\n\tParameter files have been created by Genis Parra and Tyler Alioto. Any bug or suggestion\n\tcan be reported to geneid@crg.es\n",VERSION);
+  printf("\t%s has been developed by Enrique Blanco, Tyler Alioto and Roderic Guigo.\n\tParameter files have been created by Genis Parra and Tyler Alioto. Any bug or suggestion\n\tcan be reported to geneid@crg.es\n",GENEID_RELEASE);
 
   printf("\n\n\n");
 }


### PR DESCRIPTION
## Fix stale version display + normalize GFF source tags

The v1.5 version bump missed two spots, so the binary (git tag `v1.5.1`) misreported itself:

- The `USAGE`/help banner had a **hardcoded** `RELEASE\n\tgeneid v 1.4` string in `readargv.c`, so `-h` and every error message printed "geneid v 1.4".
- The `EXONS` GFF source tag in `geneid.h` was still `geneid_v1.4`, so predicted **exon** lines carried a stale source column (while gene/site lines already said `geneid_v1.5`).

### Changes
- Add `GENEID_RELEASE "geneid v1.5.1"` as the single human-facing release string. The `USAGE` banner now derives its RELEASE line from it via compile-time string-literal concatenation (so it can't drift from the macro again), and the AUTHORS credits line uses it instead of the `VERSION` source tag.
- Normalize `EXONS` from `geneid_v1.4` → `geneid_v1.5` so all three GFF source tags (`VERSION`/`SITES`/`EXONS`) match the minor version.

`VERSION`/`SITES`/`EXONS` intentionally remain at the **minor** version (`geneid_v1.5`) as GFF source tags; the patch level lives only in the human-facing `GENEID_RELEASE`.

### Note
Normalizing `EXONS` **changes program output**: the source column (col 2) of predicted exon lines goes from `geneid_v1.4` to `geneid_v1.5`. Flagging in case any downstream consumer matches on that string.

### Verification
- `make` clean.
- `-h` / error banner and AUTHORS credits now show `geneid v1.5.1`; no remaining `v 1.4` in output.
- A prediction run emits all GFF source tags as `geneid_v1.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
