### PR TITLE
Phase 4 (part 1): Python SN/SP evaluation + eWF/oWF optimization

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -126,6 +126,24 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_optimize(args: argparse.Namespace) -> int:
+    from .optimize import optimize
+
+    base = open(args.param).read()
+    opt_text, results = optimize(
+        base, args.eval_fastas, args.eval_gff,
+        geneid_bin=args.geneid, workers=args.workers,
+    )
+    best = results[0]
+    with open(args.output, "w") as fh:
+        fh.write(opt_text)
+    print(f"grid points evaluated: {len(results)}")
+    print(f"best eWF={best.ewf:g} oWF={best.owf:g} -> "
+          f"SNSP={best.accuracy.snsp:.4f} SNSPg={best.accuracy.snspg:.4f}")
+    print(f"wrote optimized parameter file: {args.output}")
+    return 0
+
+
 def _cmd_train(args: argparse.Namespace) -> int:
     from .train import train
 
@@ -218,6 +236,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--seed", type=int, default=0, help="RNG seed for background sampling (reproducibility)"
     )
     p_train.set_defaults(func=_cmd_train)
+
+    p_opt = sub.add_parser(
+        "optimize", help="grid-search exon/site weights against a held-out set (maximise SNSP)"
+    )
+    p_opt.add_argument("--param", required=True, help="base trained .param file")
+    p_opt.add_argument("--eval-fastas", required=True, help="held-out locus FASTA (gp format)")
+    p_opt.add_argument("--eval-gff", required=True, help="held-out annotation GFF (gp convention)")
+    p_opt.add_argument("--output", required=True, help="output optimized .param path")
+    p_opt.add_argument("--geneid", default="geneid", help="path to the geneid binary")
+    p_opt.add_argument("--workers", type=int, default=4, help="parallel geneid runs")
+    p_opt.set_defaults(func=_cmd_optimize)
 
     p_eval = sub.add_parser(
         "evaluate", help="score a prediction GFF against an annotation GFF (SN/SP)"

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -26,7 +26,6 @@ from .prepare.classify import classify_report
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
 _STUBS = {
-    "evaluate": "score a .param against held-out gene models, U2/U12-aware (phase 5)",
     "jackknife": "leave-group-out cross-validation of a training set (phase 7)",
 }
 
@@ -112,6 +111,18 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
             f"{args.results}.validated.prot.fa",
         )
         print(f"wrote:             {args.results}.validated.{{gff3,cds.fa,prot.fa}}")
+    return 0
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    from .evaluate import evaluate_files
+
+    a = evaluate_files(args.predictions, args.annotations)
+    print("level        SN     SP     combined")
+    print(f"nucleotide  {a.sn:6.3f} {a.sp:6.3f}   CC={a.cc:.3f}")
+    print(f"exon        {a.sne:6.3f} {a.spe:6.3f}   SNSP={a.snsp:.3f}")
+    print(f"gene        {a.sng:6.3f} {a.spg:6.3f}   SNSPg={a.snspg:.3f}")
+    print(f"raME={a.ra_me:.3f} raWE={a.ra_we:.3f}")
     return 0
 
 
@@ -207,6 +218,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--seed", type=int, default=0, help="RNG seed for background sampling (reproducibility)"
     )
     p_train.set_defaults(func=_cmd_train)
+
+    p_eval = sub.add_parser(
+        "evaluate", help="score a prediction GFF against an annotation GFF (SN/SP)"
+    )
+    p_eval.add_argument("predictions", help="geneid prediction GFF (typed CDS exons)")
+    p_eval.add_argument("annotations", help="annotation GFF in gp convention (per-locus info line)")
+    p_eval.set_defaults(func=_cmd_evaluate)
 
     p_conv = sub.add_parser("convert", help="convert GFF2 or GTF annotation to canonical GFF3")
     p_conv.add_argument("--from", dest="from_", required=True, choices=["gff2", "gtf"])

--- a/training/src/geneid_train/evaluate.py
+++ b/training/src/geneid_train/evaluate.py
@@ -173,8 +173,9 @@ def finalize(t: Totals) -> Accuracy:
     fp = t.cds_pred - t.tp
     fn = t.cds_real - t.tp
     tn = rn - fp
+    # CC needs a real sequence length (rn, pn > 0); guard degenerate/missing lengths
     denom = t.cds_real * rn * t.cds_pred * pn
-    cc = ((t.tp * tn) - (fn * fp)) / math.sqrt(denom) if denom > 0 else 0.0
+    cc = ((t.tp * tn) - (fn * fp)) / math.sqrt(denom) if rn > 0 and pn > 0 and denom > 0 else 0.0
     sne = _safe_div(t.tpe, t.exr)
     spe = _safe_div(t.tpe, t.exp)
     sng = _safe_div(t.tpg, t.ger)

--- a/training/src/geneid_train/evaluate.py
+++ b/training/src/geneid_train/evaluate.py
@@ -1,0 +1,236 @@
+"""Prediction accuracy scorer (replaces the compiled ``evaluation`` tool).
+
+Compares a geneid prediction GFF against an annotation GFF and reports
+sensitivity/specificity at the nucleotide, exon and gene levels, matching the
+definitions of Enrique Blanco's ``evaluation`` C tool (the metric the parameter
+optimiser maximises is the exon-level ``SNSP = (SNe + SPe)/2``).
+
+Both inputs are read per locus in the geneid "gp" convention: the *annotation*
+file's first line of each locus is an info line whose 5th field is the sequence
+length (and is not itself counted as an exon — this mirrors the C tool's
+``ExtractInfo``); every other line is a typed CDS exon (First/Internal/Terminal/
+Single) grouped into genes by column 9. Stats are accumulated across loci and the
+totals reported (the ``-t`` total line the optimiser reads).
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Exon:
+    start: int
+    end: int
+    strand: str
+    group: str
+
+
+@dataclass
+class Locus:
+    name: str
+    length: int
+    exons: list[Exon]
+
+
+def _overlap_nt(a: list[Exon], b: list[Exon]) -> int:
+    """Total nucleotides covered by both exon sets (same strand). Exon sets are
+    internally non-overlapping CDS, so this equals the C tool's computeTP."""
+    tp = 0
+    for p in a:
+        for r in b:
+            lo = max(p.start, r.start)
+            hi = min(p.end, r.end)
+            if hi >= lo:
+                tp += hi - lo + 1
+    return tp
+
+
+def _by_strand(exons: list[Exon]) -> dict[str, list[Exon]]:
+    out: dict[str, list[Exon]] = defaultdict(list)
+    for e in exons:
+        out[e.strand].append(e)
+    return out
+
+
+def _exact_matches(pred: list[Exon], real: list[Exon]) -> int:
+    """Count predicted exons whose (start, end) exactly match a real exon on the
+    same strand (multiset intersection)."""
+    real_keys: dict[tuple[int, int, str], int] = defaultdict(int)
+    for r in real:
+        real_keys[(r.start, r.end, r.strand)] += 1
+    tpe = 0
+    for p in pred:
+        k = (p.start, p.end, p.strand)
+        if real_keys.get(k, 0) > 0:
+            real_keys[k] -= 1
+            tpe += 1
+    return tpe
+
+
+def _no_overlap_count(query: list[Exon], other: list[Exon]) -> int:
+    """Number of query exons with no overlapping exon in ``other`` (same strand)."""
+    by_strand = _by_strand(other)
+    n = 0
+    for q in query:
+        hits = by_strand.get(q.strand, [])
+        if not any(min(q.end, o.end) >= max(q.start, o.start) for o in hits):
+            n += 1
+    return n
+
+
+def _genes(exons: list[Exon]) -> dict[tuple[str, str], list[Exon]]:
+    """Group exons into genes by (group id, strand), each sorted by start."""
+    genes: dict[tuple[str, str], list[Exon]] = defaultdict(list)
+    for e in exons:
+        genes[(e.group, e.strand)].append(e)
+    for g in genes.values():
+        g.sort(key=lambda e: e.start)
+    return genes
+
+
+def _gene_matches(pred: list[Exon], real: list[Exon]) -> int:
+    """Count predicted genes whose full exon structure (same count, identical
+    boundaries) matches a real gene on the same strand."""
+    real_structs: dict[tuple, int] = defaultdict(int)
+    for (_, strand), exons in _genes(real).items():
+        key = (strand, tuple((e.start, e.end) for e in exons))
+        real_structs[key] += 1
+    tpg = 0
+    for (_, strand), exons in _genes(pred).items():
+        key = (strand, tuple((e.start, e.end) for e in exons))
+        if real_structs.get(key, 0) > 0:
+            real_structs[key] -= 1
+            tpg += 1
+    return tpg
+
+
+@dataclass
+class Totals:
+    tp: int = 0
+    cds_real: int = 0
+    cds_pred: int = 0
+    length: int = 0
+    tpe: int = 0
+    exr: int = 0
+    exp: int = 0
+    me: int = 0
+    we: int = 0
+    tpg: int = 0
+    ger: int = 0
+    gep: int = 0
+
+
+@dataclass
+class Accuracy:
+    """Total-level accuracy across all loci."""
+
+    sn: float
+    sp: float
+    cc: float
+    sne: float
+    spe: float
+    snsp: float
+    sng: float
+    spg: float
+    snspg: float
+    ra_me: float
+    ra_we: float
+    totals: Totals = field(repr=False, default_factory=Totals)
+
+
+def _safe_div(a: float, b: float) -> float:
+    return a / b if b else 0.0
+
+
+def accumulate(pred_exons: list[Exon], real_exons: list[Exon], length: int, t: Totals) -> None:
+    """Add one locus's counts into the running totals."""
+    pred_s, real_s = _by_strand(pred_exons), _by_strand(real_exons)
+    for strand in ("+", "-"):
+        t.tp += _overlap_nt(pred_s.get(strand, []), real_s.get(strand, []))
+        t.tpe += _exact_matches(pred_s.get(strand, []), real_s.get(strand, []))
+    t.cds_real += sum(e.end - e.start + 1 for e in real_exons)
+    t.cds_pred += sum(e.end - e.start + 1 for e in pred_exons)
+    t.length += length
+    t.exr += len(real_exons)
+    t.exp += len(pred_exons)
+    t.me += _no_overlap_count(real_exons, pred_exons)
+    t.we += _no_overlap_count(pred_exons, real_exons)
+    t.tpg += _gene_matches(pred_exons, real_exons)
+    t.ger += len(_genes(real_exons))
+    t.gep += len(_genes(pred_exons))
+
+
+def finalize(t: Totals) -> Accuracy:
+    """Compute total-level SN/SP/CC and exon/gene metrics from accumulated counts."""
+    sn = _safe_div(t.tp, t.cds_real)
+    sp = _safe_div(t.tp, t.cds_pred)
+    # correlation coefficient (needs the non-coding complement via sequence length)
+    rn = t.length - t.cds_real
+    pn = t.length - t.cds_pred
+    fp = t.cds_pred - t.tp
+    fn = t.cds_real - t.tp
+    tn = rn - fp
+    denom = t.cds_real * rn * t.cds_pred * pn
+    cc = ((t.tp * tn) - (fn * fp)) / math.sqrt(denom) if denom > 0 else 0.0
+    sne = _safe_div(t.tpe, t.exr)
+    spe = _safe_div(t.tpe, t.exp)
+    sng = _safe_div(t.tpg, t.ger)
+    spg = _safe_div(t.tpg, t.gep)
+    return Accuracy(
+        sn=sn, sp=sp, cc=cc,
+        sne=sne, spe=spe, snsp=(sne + spe) / 2,
+        sng=sng, spg=spg, snspg=(sng + spg) / 2,
+        ra_me=_safe_div(t.me, t.exr), ra_we=_safe_div(t.we, t.exp),
+        totals=t,
+    )
+
+
+_TYPED_EXONS = {"First", "Internal", "Terminal", "Single"}
+
+
+def read_annotation_gff(path) -> list[Locus]:
+    """Parse the annotation (real) GFF in gp convention: the first line of each
+    locus is the info line (field 5 = sequence length, not an exon); the rest are
+    typed CDS exons grouped by column 9."""
+    loci: list[Locus] = []
+    current: Locus | None = None
+    for raw in open(path):
+        line = raw.rstrip("\n")
+        if not line or line.startswith("#"):
+            continue
+        f = line.split("\t")
+        locus = f[0]
+        if current is None or current.name != locus:
+            # first line of a new locus = info line (length in field 5)
+            current = Locus(name=locus, length=int(f[4]), exons=[])
+            loci.append(current)
+            continue
+        if f[2] in _TYPED_EXONS:
+            current.exons.append(Exon(int(f[3]), int(f[4]), f[6], f[8]))
+    return loci
+
+
+def read_prediction_gff(path) -> dict[str, list[Exon]]:
+    """Parse the prediction GFF into ``{locus: [typed CDS exons]}`` (no info line)."""
+    out: dict[str, list[Exon]] = defaultdict(list)
+    for raw in open(path):
+        line = raw.rstrip("\n")
+        if not line or line.startswith("#"):
+            continue
+        f = line.split("\t")
+        if len(f) >= 9 and f[2] in _TYPED_EXONS:
+            out[f[0]].append(Exon(int(f[3]), int(f[4]), f[6], f[8]))
+    return out
+
+
+def evaluate_files(prediction_gff, annotation_gff) -> Accuracy:
+    """Score a prediction GFF against an annotation GFF (total-level accuracy)."""
+    real_loci = read_annotation_gff(annotation_gff)
+    pred = read_prediction_gff(prediction_gff)
+    t = Totals()
+    for locus in real_loci:
+        accumulate(pred.get(locus.name, []), locus.exons, locus.length, t)
+    return finalize(t)

--- a/training/src/geneid_train/optimize.py
+++ b/training/src/geneid_train/optimize.py
@@ -1,0 +1,132 @@
+"""Parameter optimisation: grid-search the exon/site weights (replaces the
+legacy OptimizeParameter loop).
+
+For each ``(eWF, oWF)`` grid point the exon-weight / exon-factor / site-factor
+fields of the parameter file are set, geneid is run on a held-out evaluation set,
+and the prediction is scored with :mod:`geneid_train.evaluate`. The point with
+the best exon-level ``SNSP`` (tie-broken by gene ``SNSPg``, nucleotide ``CC``,
+then fewest missing/wrong exons — the legacy ``sorteval`` order) wins, and its
+weights are written into the optimised parameter file.
+
+Only the default eWF×oWF grid is implemented (matching the reference run); the
+branch/U12 acceptor-context + min-branch axes are left for the U12 work.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+from .core.param import Param
+from .evaluate import Accuracy, evaluate_files
+
+# default grid bounds from the legacy driver (init, final, step)
+DEFAULT_EWF = (-4.5, -2.5, 0.5)
+DEFAULT_OWF = (0.25, 0.50, 0.05)
+
+_TYPED_EXONS = ("First", "Internal", "Terminal", "Single")
+
+
+def _frange(init: float, final: float, step: float) -> list[float]:
+    vals, v = [], init
+    while v <= final + 1e-9:
+        vals.append(round(v, 6))
+        v += step
+    return vals
+
+
+def _set_all(param: Param, keyword: str, value: float, n: int = 4) -> None:
+    """Set the first ``n`` fields of every occurrence of a vector section (one per
+    isochore) to ``value``, preserving trailing fields (e.g. the single-exon
+    column)."""
+    count = sum(1 for k in param.keywords() if k == keyword)
+    for i in range(count):
+        old = param.vector(keyword, index=i)
+        k = min(n, len(old))
+        param.set_scalar(keyword, " ".join([f"{value:g}"] * k + old[k:]), index=i)
+
+
+def apply_weights(param: Param, ewf: float, owf: float) -> None:
+    """Set Exon_weights=[ewf]*4, Exon_factor=[owf]*4, Site_factor=[1-owf]*4 across
+    all isochores."""
+    _set_all(param, "Exon_weights", ewf)
+    _set_all(param, "Exon_factor", owf)
+    _set_all(param, "Site_factor", 1 - owf)
+
+
+def run_geneid(geneid_bin: str, param_path: str, fasta: str) -> str:
+    """Run ``geneid -GP param fasta`` and return the typed-CDS-exon prediction
+    lines (First/Internal/Terminal/Single), dropping comments and generic exons."""
+    out = subprocess.run(
+        [geneid_bin, "-GP", param_path, fasta],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    kept = []
+    for line in out.splitlines():
+        f = line.split("\t")
+        if len(f) >= 9 and f[2] in _TYPED_EXONS:
+            kept.append(line)
+    return "\n".join(kept) + "\n"
+
+
+@dataclass
+class GridResult:
+    ewf: float
+    owf: float
+    accuracy: Accuracy
+
+    def sort_key(self) -> tuple:
+        a = self.accuracy
+        # SNSP desc, SNSPg desc, CC desc, raME asc, raWE asc  (legacy sorteval)
+        return (-a.snsp, -a.snspg, -a.cc, a.ra_me, a.ra_we)
+
+
+def _score_point(
+    base_text: str, ewf: float, owf: float, geneid_bin: str, fasta: str, gff: str, workdir: Path
+) -> GridResult:
+    param = Param.from_text(base_text)
+    apply_weights(param, ewf, owf)
+    ptmp = workdir / f"param_{ewf}_{owf}.tmp"
+    param.write(ptmp)
+    pred = workdir / f"pred_{ewf}_{owf}.gff"
+    pred.write_text(run_geneid(geneid_bin, str(ptmp), fasta))
+    acc = evaluate_files(str(pred), gff)
+    return GridResult(ewf, owf, acc)
+
+
+def optimize(
+    base_param_text: str,
+    eval_fasta: str,
+    eval_gff: str,
+    *,
+    geneid_bin: str = "geneid",
+    ewf_grid: tuple[float, float, float] = DEFAULT_EWF,
+    owf_grid: tuple[float, float, float] = DEFAULT_OWF,
+    workers: int = 4,
+) -> tuple[str, list[GridResult]]:
+    """Grid-search eWF×oWF; return the optimised param text and all results
+    (best first). geneid runs in parallel across grid points."""
+    bin_path = shutil.which(geneid_bin) or geneid_bin
+    ewfs = _frange(*ewf_grid)
+    owfs = _frange(*owf_grid)
+    results: list[GridResult] = []
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futs = [
+                pool.submit(
+                    _score_point, base_param_text, e, o, bin_path, eval_fasta, eval_gff, workdir
+                )
+                for e in ewfs
+                for o in owfs
+            ]
+            results = [f.result() for f in futs]
+    results.sort(key=lambda r: r.sort_key())
+    best = results[0]
+    param = Param.from_text(base_param_text)
+    apply_weights(param, best.ewf, best.owf)
+    return param.to_text(), results

--- a/training/tests/test_evaluate.py
+++ b/training/tests/test_evaluate.py
@@ -1,0 +1,104 @@
+
+from geneid_train.evaluate import (
+    Exon,
+    _exact_matches,
+    _gene_matches,
+    _no_overlap_count,
+    _overlap_nt,
+    evaluate_files,
+    read_annotation_gff,
+)
+
+# The synthetic pred/real pair below was cross-checked against Enrique Blanco's
+# compiled `evaluation` tool: its #Total line (what the geneid optimiser parses)
+# reads SN=0.92 SP=1.00 CC=0.95 SNe=0.80 SPe=0.80 SNSP=0.80 SNg=SPg=SNSPg=0.50.
+
+REAL = (
+    "LocusA\tanno\tSequence\t1\t5000\t.\t+\t.\tLocusA\n"
+    "LocusA\tanno\tFirst\t401\t500\t.\t+\t.\tgeneA\n"
+    "LocusA\tanno\tInternal\t1000\t1100\t.\t+\t.\tgeneA\n"
+    "LocusA\tanno\tTerminal\t2000\t2100\t.\t+\t.\tgeneA\n"
+    "#$\n"
+    "LocusB\tanno\tSequence\t1\t3000\t.\t+\t.\tLocusB\n"
+    "LocusB\tanno\tFirst\t401\t600\t.\t+\t.\tgeneB\n"
+    "LocusB\tanno\tTerminal\t1500\t1600\t.\t+\t.\tgeneB\n"
+)
+PRED = (
+    "LocusA\tgeneid\tFirst\t401\t500\t5\t+\t0\tgeneA\n"
+    "LocusA\tgeneid\tInternal\t1000\t1100\t3\t+\t1\tgeneA\n"
+    "LocusA\tgeneid\tTerminal\t2000\t2050\t2\t+\t2\tgeneA\n"
+    "#$\n"
+    "LocusB\tgeneid\tFirst\t401\t600\t4\t+\t0\tgeneB\n"
+    "LocusB\tgeneid\tTerminal\t1500\t1600\t3\t+\t1\tgeneB\n"
+)
+
+
+def _write_pair(tmp_path):
+    real = tmp_path / "real.gff"
+    pred = tmp_path / "pred.gff"
+    real.write_text(REAL)
+    pred.write_text(PRED)
+    return pred, real
+
+
+def test_evaluate_files_matches_reference_evaluation_tool(tmp_path):
+    pred, real = _write_pair(tmp_path)
+    a = evaluate_files(pred, real)
+    # accumulated counts (each verified against the C tool's per-locus output)
+    t = a.totals
+    assert (t.tp, t.cds_real, t.cds_pred) == (553, 603, 553)
+    assert (t.tpe, t.exr, t.exp) == (4, 5, 5)
+    assert (t.tpg, t.ger, t.gep) == (1, 2, 2)
+    # total-level metrics == the tool's #Total line
+    assert round(a.sn, 2) == 0.92
+    assert round(a.sp, 2) == 1.00
+    assert round(a.cc, 2) == 0.95
+    assert a.sne == 0.8 and a.spe == 0.8 and a.snsp == 0.8
+    assert a.sng == 0.5 and a.spg == 0.5 and a.snspg == 0.5
+    assert a.ra_me == 0.0 and a.ra_we == 0.0
+
+
+def test_annotation_first_line_is_info_not_exon(tmp_path):
+    real = tmp_path / "real.gff"
+    real.write_text(REAL)
+    loci = read_annotation_gff(real)
+    assert [locus.name for locus in loci] == ["LocusA", "LocusB"]
+    assert loci[0].length == 5000  # field 5 of the consumed info line
+    # the Sequence info line is not counted as an exon (3 exons, not 4)
+    assert len(loci[0].exons) == 3
+    assert loci[1].length == 3000 and len(loci[1].exons) == 2
+
+
+def test_overlap_nt_partial_and_full():
+    a = [Exon(100, 200, "+", "g")]
+    b = [Exon(150, 250, "+", "g")]
+    assert _overlap_nt(a, b) == 51  # 150..200 inclusive
+    assert _overlap_nt(a, a) == 101  # full self-overlap
+
+
+def test_exact_matches_requires_both_boundaries():
+    pred = [Exon(10, 20, "+", "g"), Exon(30, 41, "+", "g")]
+    real = [Exon(10, 20, "+", "g"), Exon(30, 40, "+", "g")]
+    assert _exact_matches(pred, real) == 1  # only the first is an exact match
+
+
+def test_no_overlap_count_is_missing_or_wrong():
+    real = [Exon(10, 20, "+", "g"), Exon(100, 110, "+", "g")]
+    pred = [Exon(12, 18, "+", "g")]  # overlaps first, misses second
+    assert _no_overlap_count(real, pred) == 1  # ME: second real exon unmatched
+    assert _no_overlap_count(pred, real) == 0  # WE: the prediction overlaps
+
+
+def test_gene_matches_needs_identical_structure():
+    real = [Exon(10, 20, "+", "gA"), Exon(50, 60, "+", "gA")]
+    exact = [Exon(10, 20, "+", "x"), Exon(50, 60, "+", "x")]
+    off = [Exon(10, 20, "+", "y"), Exon(50, 61, "+", "y")]
+    assert _gene_matches(exact, real) == 1
+    assert _gene_matches(off, real) == 0
+
+
+def test_exact_match_is_strand_sensitive():
+    # identical coordinates on opposite strands are not the same exon
+    pred = [Exon(10, 20, "+", "g")]
+    real = [Exon(10, 20, "-", "g")]
+    assert _exact_matches(pred, real) == 0

--- a/training/tests/test_optimize.py
+++ b/training/tests/test_optimize.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from geneid_train.core.param import Param
+from geneid_train.evaluate import Accuracy
+from geneid_train.optimize import GridResult, _frange, apply_weights, optimize
+
+from .conftest import ref_dir
+
+_MINI_PARAM = (
+    "number_of_isochores\n1\n"
+    "Exon_weights\n-4 -4 -4 -4 0\n"
+    "Exon_factor\n0.4 0.4 0.4 0.4\n"
+    "Site_factor\n0.6 0.6 0.6 0.6 0.6\n"
+)
+
+
+def test_frange_inclusive_of_final():
+    assert _frange(-4.5, -2.5, 0.5) == [-4.5, -4.0, -3.5, -3.0, -2.5]
+    assert _frange(0.25, 0.50, 0.05) == [0.25, 0.30, 0.35, 0.40, 0.45, 0.50]
+
+
+def test_apply_weights_sets_leading_and_preserves_trailing():
+    p = Param.from_text(_MINI_PARAM)
+    apply_weights(p, ewf=-3.5, owf=0.3)
+    assert p.vector("Exon_weights") == ["-3.5", "-3.5", "-3.5", "-3.5", "0"]
+    assert p.vector("Exon_factor") == ["0.3", "0.3", "0.3", "0.3"]
+    # site factor = 1 - owf, trailing 0.6 preserved
+    assert p.vector("Site_factor") == ["0.7", "0.7", "0.7", "0.7", "0.6"]
+
+
+def _acc(snsp, snspg=0.0, cc=0.0, ra_me=0.0, ra_we=0.0):
+    return Accuracy(
+        sn=0, sp=0, cc=cc, sne=snsp, spe=snsp, snsp=snsp,
+        sng=snspg, spg=snspg, snspg=snspg, ra_me=ra_me, ra_we=ra_we,
+    )
+
+
+def test_grid_result_sort_prefers_higher_snsp_then_tiebreaks():
+    a = GridResult(-4.5, 0.3, _acc(0.80))
+    b = GridResult(-4.0, 0.3, _acc(0.70))
+    c = GridResult(-3.5, 0.3, _acc(0.80, snspg=0.5))  # ties a on SNSP, wins on SNSPg
+    results = sorted([a, b, c], key=lambda r: r.sort_key())
+    assert results[0] is c
+    assert results[1] is a
+    assert results[2] is b
+
+
+# ---- end-to-end with a real geneid binary -----------------------------------
+
+REF = ref_dir()
+GENEID = os.environ.get("GENEID_BIN") or (
+    "/Users/talioto/repositories/geneid_fresh/bin/geneid"
+)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    REF is None or not Path(GENEID).exists(),
+    reason="needs GENEID_TRAIN_REFDIR and a geneid binary (GENEID_BIN)",
+)
+def test_optimize_runs_grid_and_selects_best():
+    sp = "Xerocrassa_montserratensis"
+    base = (REF / f"{sp}.geneid.param").read_text()
+    fasta = str(REF / f"{sp}.eval.gp.fa")
+    gff = str(REF / f"{sp}.eval.gp.gff")
+    # a tiny 2x2 grid keeps the test quick
+    opt_text, results = optimize(
+        base, fasta, gff, geneid_bin=GENEID,
+        ewf_grid=(-4.5, -4.0, 0.5), owf_grid=(0.30, 0.35, 0.05), workers=2,
+    )
+    assert len(results) == 4
+    # results are sorted best-first by SNSP
+    snsps = [r.accuracy.snsp for r in results]
+    assert snsps == sorted(snsps, reverse=True)
+    # the optimised param carries the winning weights
+    best = results[0]
+    p = Param.from_text(opt_text)
+    assert p.vector("Exon_weights")[0] == f"{best.ewf:g}"
+    assert p.vector("Exon_factor")[0] == f"{best.owf:g}"


### PR DESCRIPTION
## Phase 4 (part 1) — evaluation + optimization

Follows Phase 3 (#31, the full site/coding estimation + `geneid-train train`). This adds the pieces that score and tune a trained parameter file, each validated against the original C tooling.

### What's here
- **`evaluate.py`** — a pure-Python SN/SP scorer replacing Enrique Blanco's compiled `evaluation` tool. Reports nucleotide (SN/SP/CC), exon (SNe/SPe/**SNSP**, raME/raWE) and gene (SNg/SPg/SNSPg) accuracy, reading the geneid "gp" convention (annotation's first line per locus is a length info-line; `#$` separators; typed CDS exons grouped by column 9). CLI: `geneid-train evaluate <pred.gff> <annotation.gff>`.
- **`optimize.py`** — grid-search over the exon-weight (`eWF`) and exon-factor (`oWF`) fields: each point sets `Exon_weights=[eWF]*4`, `Exon_factor=[oWF]*4`, `Site_factor=[1-oWF]*4`, runs geneid on a held-out set, and scores it. The point with the best exon **SNSP** wins (tie-broken by gene SNSPg → nucleotide CC → raME → raWE, the legacy `sorteval` order). geneid runs in parallel across grid points. CLI: `geneid-train optimize --param base.param --eval-fastas fa --eval-gff gff --output opt.param`.

### Validation (opt-in integration tests)
- `evaluate.py` reproduces a freshly compiled `evaluation` binary **exactly** on a two-locus pair: every per-locus count (TP/CDS/TPe/TPg/Ex/Ge) matches, and the count-based `#Total` line the optimiser parses is identical — SN=0.92, SP=1.00, CC=0.95, SNe=SPe=**SNSP=0.80**, SNg=SPg=SNSPg=0.50.
- `optimize.py` runs the full 30-point grid over the xgXerMont eval set against geneid v1.5.1 in ~21s, ranks correctly by SNSP, and writes the winning weights into the optimised param.

**109 tests pass, ruff clean.**

### Not in this PR
Jackknife (leave-group-out CV) lands next. Also deferred: the AccCtx/min-branch grid axes and the optional GC/U12/branch aux profiles (train-and-toggle-if-SNSP-improves).

### Follow-up noted
The optimiser currently sets the four exon-type weights (First/Internal/Terminal/Single) to a single shared value; tuning them independently (and revisiting the search algorithm) is planned once the trainer/optimizer/jackknife package is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
