### PR TITLE
Phase 4 (part 2): jackknife cross-validation + train Markov-order fix

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -25,9 +25,7 @@ from .prepare.classify import classify_report
 
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
-_STUBS = {
-    "jackknife": "leave-group-out cross-validation of a training set (phase 7)",
-}
+_STUBS: dict[str, str] = {}
 
 
 def _cmd_param_info(args: argparse.Namespace) -> int:
@@ -111,6 +109,33 @@ def _cmd_prepare(args: argparse.Namespace) -> int:
             f"{args.results}.validated.prot.fa",
         )
         print(f"wrote:             {args.results}.validated.{{gff3,cds.fa,prot.fa}}")
+    return 0
+
+
+def _cmd_jackknife(args: argparse.Namespace) -> int:
+    from .evaluate import read_annotation_gff
+    from .jackknife import jackknife
+
+    genome = read_fasta(args.fastas)
+    records = read_gff3(args.gff)
+    models = collapse_isoforms(build_models(records), records)
+    models = filter_non_overlapping(
+        filter_min_protein(filter_complete(models, genome), genome, args.min_aa)
+    )
+    if not models:
+        sys.stderr.write("no models survived filtering\n")
+        return 1
+    locus_fasta = read_fasta(args.eval_fastas)
+    annotations = read_annotation_gff(args.eval_gff)
+    weights = (args.ewf, args.owf) if args.ewf is not None and args.owf is not None else None
+    acc = jackknife(
+        models, genome, args.species, locus_fasta, annotations,
+        geneid_bin=args.geneid, folds=args.folds, weights=weights,
+    )
+    print(f"{args.folds}-fold cross-validation ({len(models)} models):")
+    print(f"nucleotide  SN={acc.sn:.3f} SP={acc.sp:.3f} CC={acc.cc:.3f}")
+    print(f"exon        SNe={acc.sne:.3f} SPe={acc.spe:.3f} SNSP={acc.snsp:.3f}")
+    print(f"gene        SNg={acc.sng:.3f} SPg={acc.spg:.3f} SNSPg={acc.snspg:.3f}")
     return 0
 
 
@@ -247,6 +272,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_opt.add_argument("--geneid", default="geneid", help="path to the geneid binary")
     p_opt.add_argument("--workers", type=int, default=4, help="parallel geneid runs")
     p_opt.set_defaults(func=_cmd_optimize)
+
+    p_jk = sub.add_parser(
+        "jackknife", help="leave-group-out cross-validation of a training set"
+    )
+    p_jk.add_argument("--gff", required=True, help="training GFF3 of CDS features")
+    p_jk.add_argument("--fastas", required=True, help="genomic multi-FASTA (for training)")
+    p_jk.add_argument("--species", required=True, help="species name")
+    p_jk.add_argument("--eval-fastas", required=True, help="per-locus prediction FASTA (gp format)")
+    p_jk.add_argument("--eval-gff", required=True, help="per-locus annotation GFF (gp convention)")
+    p_jk.add_argument("--geneid", default="geneid", help="path to the geneid binary")
+    p_jk.add_argument("--folds", type=int, default=10, help="number of cross-validation folds")
+    p_jk.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
+    p_jk.add_argument("--ewf", type=float, help="optimized exon weight to apply per fold")
+    p_jk.add_argument("--owf", type=float, help="optimized exon factor to apply per fold")
+    p_jk.set_defaults(func=_cmd_jackknife)
 
     p_eval = sub.add_parser(
         "evaluate", help="score a prediction GFF against an annotation GFF (SN/SP)"

--- a/training/src/geneid_train/jackknife.py
+++ b/training/src/geneid_train/jackknife.py
@@ -1,0 +1,109 @@
+"""Leave-group-out cross-validation (replaces the legacy runJacknife).
+
+Estimates a parameter file's real accuracy without a separate held-out set: the
+training loci are split into ~10 groups; for each group a fresh parameter file is
+trained on all the *other* loci (carrying the optimised exon/site weights) and
+scored on the held-out group with geneid + :mod:`geneid_train.evaluate`. Counts
+from every fold accumulate into one cross-validated SN/SP estimate.
+
+Retraining every fold is the whole point (it exposes over-fitting), so a fixed
+background model is reused across folds to keep them comparable and fast.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from .core.param import Param
+from .evaluate import Accuracy, Locus, Totals, accumulate, finalize, read_prediction_gff
+from .optimize import apply_weights, run_geneid
+from .prepare.base import GeneModel
+from .stats.background import from_genome
+from .stats.sites import Matrix
+from .train import train
+
+
+def make_folds(names: Sequence[str], k: int = 10) -> list[set[str]]:
+    """Split sorted locus names into ~``k`` contiguous groups of size
+    ``len//k + 1`` (matching the legacy group sizing)."""
+    ordered = sorted(names)
+    n = len(ordered)
+    size = n // k + 1
+    return [set(ordered[i : i + size]) for i in range(0, n, size)]
+
+
+def _write_fasta(records: Mapping[str, str], names: set[str], path: Path) -> int:
+    written = 0
+    with open(path, "w") as fh:
+        for name in sorted(names):
+            seq = records.get(name)
+            if seq is None:
+                continue
+            fh.write(f">{name}\n")
+            for i in range(0, len(seq), 60):
+                fh.write(seq[i : i + 60] + "\n")
+            written += 1
+    return written
+
+
+def jackknife(
+    models: Sequence[GeneModel],
+    genome: Mapping[str, str],
+    species: str,
+    locus_fasta: Mapping[str, str],
+    annotations: Sequence[Locus],
+    *,
+    geneid_bin: str = "geneid",
+    folds: int = 10,
+    weights: tuple[float, float] | None = None,
+    background: tuple[Matrix, Matrix] | None = None,
+    seed: int = 0,
+) -> Accuracy:
+    """Run leave-group-out CV and return the aggregated accuracy.
+
+    ``locus_fasta`` maps each locus name to its (flanked) prediction sequence;
+    ``annotations`` are the per-locus real exon sets (from
+    :func:`evaluate.read_annotation_gff`). ``weights`` = ``(eWF, oWF)`` applies the
+    optimised weights to each fold's param before scoring.
+    """
+    ann_by_name = {locus.name: locus for locus in annotations}
+    # one background for every fold, so folds differ only by their training genes
+    if background is None:
+        background = from_genome(genome.values(), seed=seed)
+
+    fold_groups = make_folds([m.gene_id for m in models], folds)
+    totals = Totals()
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+        for i, held in enumerate(fold_groups):
+            train_models = [m for m in models if m.gene_id not in held]
+            if not train_models:
+                continue
+            param = Param.from_text(
+                train(train_models, genome, species, background=background)
+            )
+            if weights is not None:
+                apply_weights(param, *weights)
+            ppath = workdir / f"fold{i}.param"
+            param.write(ppath)
+
+            fapath = workdir / f"fold{i}.fa"
+            if not _write_fasta(locus_fasta, held, fapath):
+                continue
+            try:
+                pred_text = run_geneid(geneid_bin, str(ppath), str(fapath))
+            except subprocess.CalledProcessError:
+                continue
+            predpath = workdir / f"fold{i}.pred.gff"
+            predpath.write_text(pred_text)
+            pred = read_prediction_gff(predpath)
+
+            for name in held:
+                locus = ann_by_name.get(name)
+                if locus is None:
+                    continue
+                accumulate(pred.get(name, []), locus.exons, locus.length, totals)
+    return finalize(totals)

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -127,8 +127,14 @@ def train(
 
     cds_seqs = [m.cds(genome) for m in models]
     intron_seqs = [s for m in models for s in m.intron_seqs(genome)]
-    init_logs, trans_logs, cbases, nbases = derive_coding_potential(cds_seqs, intron_seqs)
+    # pick the Markov order from the data size FIRST, then build matrices at that
+    # order so Markov_order and the matrix oligo widths always agree
+    cbases = sum(len(s) for s in cds_seqs)
+    nbases = sum(len(s) for s in intron_seqs)
     _, transition_order = choose_orders(cbases, nbases)
+    init_logs, trans_logs, _, _ = derive_coding_potential(
+        cds_seqs, intron_seqs, transition_order
+    )
 
     lo, hi = intron_range([len(s) for s in intron_seqs])
 

--- a/training/tests/test_jackknife.py
+++ b/training/tests/test_jackknife.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from geneid_train.jackknife import _write_fasta, make_folds
+
+from .conftest import ref_dir
+
+
+def test_make_folds_partitions_without_overlap():
+    names = [f"g{i:02d}" for i in range(23)]
+    folds = make_folds(names, k=10)
+    # size = 23//10 + 1 = 3  -> ceil(23/3) = 8 folds
+    assert all(len(f) <= 3 for f in folds)
+    union: set[str] = set()
+    for f in folds:
+        assert not (union & f)  # disjoint
+        union |= f
+    assert union == set(names)  # complete coverage
+
+
+def test_make_folds_small_set():
+    folds = make_folds(["b", "a", "c"], k=10)  # size = 0+1 = 1 -> 3 folds
+    assert [sorted(f) for f in folds] == [["a"], ["b"], ["c"]]
+
+
+def test_write_fasta_selects_and_wraps(tmp_path):
+    records = {"x": "ACGT" * 20, "y": "TTTT", "z": "GG"}
+    path = tmp_path / "out.fa"
+    n = _write_fasta(records, {"x", "z"}, path)
+    assert n == 2
+    text = path.read_text()
+    assert ">x\n" in text and ">z\n" in text and ">y\n" not in text
+    # x (80 bp) wraps at 60
+    assert "ACGT" * 15 + "\n" in text
+
+
+# ---- end-to-end cross-validation with a real geneid binary ------------------
+
+REF = ref_dir()
+GENEID = os.environ.get("GENEID_BIN") or "/Users/talioto/repositories/geneid_fresh/bin/geneid"
+GENOME = (
+    REF.parents[2] / "xgXerMont_curated.no_mt.scrubbed.fa.gz" if REF else None
+)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    REF is None or not (GENOME and GENOME.exists()) or not Path(GENEID).exists(),
+    reason="needs GENEID_TRAIN_REFDIR, the genome, and a geneid binary",
+)
+def test_jackknife_runs_and_aggregates():
+    from geneid_train.core.fasta import read_fasta, read_fasta_subset
+    from geneid_train.core.gff import read_gff3
+    from geneid_train.evaluate import read_annotation_gff
+    from geneid_train.jackknife import jackknife
+    from geneid_train.prepare.base import (
+        build_models,
+        collapse_isoforms,
+        filter_complete,
+        filter_non_overlapping,
+    )
+
+    sp = "Xerocrassa_montserratensis"
+    gff3 = REF.parent / "get_candidates" / "good_candidates.1trans.gff3"
+    recs = read_gff3(gff3)
+    models = collapse_isoforms(build_models(recs), recs)
+    train_loci = {
+        ln.strip()[1:]
+        for ln in open(REF / f"{sp}.train.gp.fa")
+        if ln.startswith(">")
+    }
+    want = {f"SUPER_{i}" for i in range(1, 9)}
+    models = [m for m in models if m.gene_id in train_loci and m.seqid in want]
+    genome = read_fasta_subset(str(GENOME), {m.seqid for m in models})
+    models = filter_non_overlapping(filter_complete(models, genome))
+
+    locus_fasta = read_fasta(REF / f"{sp}.train.gp.fa")
+    annots = read_annotation_gff(REF / f"{sp}.train.gp.gff")
+
+    acc = jackknife(
+        models, genome, sp, locus_fasta, annots,
+        geneid_bin=GENEID, folds=2, weights=(-4.5, 0.35), seed=1,
+    )
+    # each fold retrained and predicted -> non-empty aggregated counts
+    assert acc.totals.tp > 0
+    assert acc.totals.exr > 0 and acc.totals.exp > 0
+    assert 0.0 <= acc.snsp <= 1.0

--- a/training/tests/test_train.py
+++ b/training/tests/test_train.py
@@ -107,9 +107,18 @@ def test_train_end_to_end_produces_valid_param():
     assert "@" not in text  # every sentinel filled
 
     p = Param.from_text(text)
-    assert p.scalar("Markov_order") == "5"
     for kw in ("Start_profile", "Acceptor_profile", "Donor_profile"):
         assert p.profile(kw).rows
+
+    # Markov_order must agree with the matrix oligo widths (regression: a small
+    # training set picks order 4, and the matrices must be built at that order,
+    # else geneid rejects the file)
+    order = int(p.scalar("Markov_order"))
+    lines = text.splitlines()
+    init_i = lines.index("Markov_Initial_probability_matrix")
+    trans_i = lines.index("Markov_Transition_probability_matrix")
+    assert len(lines[init_i + 1].split()[0]) == order  # initial oligo = order-mer
+    assert len(lines[trans_i + 1].split()[0]) == order + 1  # transition = (order+1)-mer
     assert p.has("Markov_Initial_probability_matrix")
     assert p.has("Markov_Transition_probability_matrix")
     gm = "".join(p._find("General_Gene_Model").raw)


### PR DESCRIPTION
## Phase 4 (part 2) — jackknife cross-validation

Completes the trainer/optimizer/**jackknife** package on top of #33 (evaluate + optimize).

### What's here
- **`jackknife.py`** — leave-group-out cross-validation (replaces the legacy `runJacknife`). The training loci are split into ~10 groups; each fold retrains a parameter file on the *other* groups (carrying the optimized `eWF`/`oWF`), predicts the held-out group with geneid, and scores it — accumulating one cross-validated SN/SP estimate. A single background model is reused across folds so folds differ only by their training genes. CLI: `geneid-train jackknife --gff --fastas --species --eval-fastas --eval-gff [--folds] [--ewf --owf]`.

### Bug fix (surfaced by jackknife)
`train()` built the coding-potential Markov matrices at the default order 5 but wrote `Markov_order` from `choose_orders`, which returns **4** for sub-400 kb training sets. So `Markov_order` (4) disagreed with the matrix oligo widths (5-/6-mers) and geneid rejected the file with *"Wrong format/number … Transition Markov value"*. The full xgXerMont set picks order 5, so Phase 3 never hit it; a smaller jackknife fold did. Now the order is chosen first and passed to `derive_coding_potential`, and a regression check asserts `Markov_order` matches the initial/transition oligo lengths.

### Validation
- 2-fold CV over 319 real xgXerMont gene models retrains each fold, runs geneid v1.5.1, and aggregates non-empty counts (opt-in integration test).
- Unit tests cover fold partitioning + FASTA subsetting.

**113 tests pass, ruff clean.**

### Follow-up (noted for after this lands)
The optimiser sets the four exon-type weights (First/Internal/Terminal/Single) to a single shared value; tuning them independently and revisiting the search algorithm is planned now that the trainer/optimizer/jackknife package is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
