### PR TITLE
Per-exon-type weight optimization via coordinate descent

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -152,7 +152,7 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
 
 
 def _cmd_optimize(args: argparse.Namespace) -> int:
-    from .optimize import optimize
+    from .optimize import coordinate_descent, optimize, uniform_point
 
     base = open(args.param).read()
     opt_text, results = optimize(
@@ -160,11 +160,23 @@ def _cmd_optimize(args: argparse.Namespace) -> int:
         geneid_bin=args.geneid, workers=args.workers,
     )
     best = results[0]
+    print(f"uniform grid: {len(results)} points, best eWF={best.ewf:g} oWF={best.owf:g} "
+          f"-> SNSP={best.accuracy.snsp:.4f}")
+
+    if args.per_type:
+        # refine the four exon types independently, seeded from the uniform best
+        opt_text, cd, history = coordinate_descent(
+            base, args.eval_fastas, args.eval_gff, geneid_bin=args.geneid,
+            init=uniform_point(best.ewf, best.owf), workers=args.workers,
+        )
+        types = "First/Internal/Terminal/Single"
+        print(f"per-type refine ({len(history)} improving steps) -> "
+              f"SNSP={cd.accuracy.snsp:.4f}")
+        print(f"  eWF [{types}] = {cd.point.ewf}")
+        print(f"  oWF [{types}] = {cd.point.owf}")
+
     with open(args.output, "w") as fh:
         fh.write(opt_text)
-    print(f"grid points evaluated: {len(results)}")
-    print(f"best eWF={best.ewf:g} oWF={best.owf:g} -> "
-          f"SNSP={best.accuracy.snsp:.4f} SNSPg={best.accuracy.snspg:.4f}")
     print(f"wrote optimized parameter file: {args.output}")
     return 0
 
@@ -271,6 +283,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_opt.add_argument("--output", required=True, help="output optimized .param path")
     p_opt.add_argument("--geneid", default="geneid", help="path to the geneid binary")
     p_opt.add_argument("--workers", type=int, default=4, help="parallel geneid runs")
+    p_opt.add_argument(
+        "--per-type", action="store_true",
+        help="after the uniform grid, refine First/Internal/Terminal/Single weights "
+             "independently by coordinate descent",
+    )
     p_opt.set_defaults(func=_cmd_optimize)
 
     p_jk = sub.add_parser(

--- a/training/src/geneid_train/optimize.py
+++ b/training/src/geneid_train/optimize.py
@@ -8,21 +8,34 @@ the best exon-level ``SNSP`` (tie-broken by gene ``SNSPg``, nucleotide ``CC``,
 then fewest missing/wrong exons — the legacy ``sorteval`` order) wins, and its
 weights are written into the optimised parameter file.
 
-Only the default eWF×oWF grid is implemented (matching the reference run); the
-branch/U12 acceptor-context + min-branch axes are left for the U12 work.
+Two search strategies are available:
+
+- :func:`optimize` — the legacy uniform grid over a single ``(eWF, oWF)`` applied
+  to all exon types (fast, good for a coarse starting point).
+- :func:`coordinate_descent` — refines the four exon types (First/Internal/
+  Terminal/Single) *independently*: the Exon_weights / Exon_factor / Site_factor
+  columns exist to be tuned per type, so this walks the 8-dimensional space one
+  coordinate at a time. Seed it with :func:`uniform_point` from a coarse grid.
+
+The branch/U12 acceptor-context + min-branch axes are left for the U12 work.
 """
 
 from __future__ import annotations
 
+import itertools
 import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from .core.param import Param
 from .evaluate import Accuracy, evaluate_files
+
+# the four exon types tuned independently (columns 0-3 of Exon_weights /
+# Exon_factor / Site_factor; column 4, where present, is UTR and is left alone)
+EXON_TYPES = ("First", "Internal", "Terminal", "Single")
 
 # default grid bounds from the legacy driver (init, final, step)
 DEFAULT_EWF = (-4.5, -2.5, 0.5)
@@ -73,6 +86,12 @@ def run_geneid(geneid_bin: str, param_path: str, fasta: str) -> str:
     return "\n".join(kept) + "\n"
 
 
+def accuracy_key(a: Accuracy) -> tuple:
+    """Ranking key: exon SNSP desc, then gene SNSPg desc, nucleotide CC desc,
+    fewest missing then wrong exons (the legacy ``sorteval`` order)."""
+    return (-a.snsp, -a.snspg, -a.cc, a.ra_me, a.ra_we)
+
+
 @dataclass
 class GridResult:
     ewf: float
@@ -80,9 +99,7 @@ class GridResult:
     accuracy: Accuracy
 
     def sort_key(self) -> tuple:
-        a = self.accuracy
-        # SNSP desc, SNSPg desc, CC desc, raME asc, raWE asc  (legacy sorteval)
-        return (-a.snsp, -a.snspg, -a.cc, a.ra_me, a.ra_we)
+        return accuracy_key(self.accuracy)
 
 
 def _score_point(
@@ -130,3 +147,128 @@ def optimize(
     param = Param.from_text(base_param_text)
     apply_weights(param, best.ewf, best.owf)
     return param.to_text(), results
+
+
+# --- per-exon-type coordinate-descent optimisation ---------------------------
+
+
+@dataclass(frozen=True)
+class WeightPoint:
+    """Per-exon-type exon weights (``ewf``) and factors (``owf``), ordered
+    First, Internal, Terminal, Single. ``Exon_factor`` takes ``owf`` and
+    ``Site_factor`` takes ``1 - owf`` per type, mirroring the uniform search."""
+
+    ewf: tuple[float, float, float, float]
+    owf: tuple[float, float, float, float]
+
+    def with_value(self, axis: str, idx: int, value: float) -> WeightPoint:
+        vals = list(getattr(self, axis))
+        vals[idx] = value
+        return replace(self, **{axis: tuple(vals)})
+
+
+def uniform_point(ewf: float, owf: float) -> WeightPoint:
+    """A WeightPoint with every exon type set to the same ``ewf``/``owf`` — the
+    starting point equivalent to the uniform grid's result."""
+    return WeightPoint((ewf,) * 4, (owf,) * 4)
+
+
+def _set_columns(param: Param, keyword: str, values: tuple[float, ...]) -> None:
+    """Set columns 0..len(values)-1 of every occurrence of a vector section,
+    preserving trailing columns (e.g. the UTR column)."""
+    count = sum(1 for k in param.keywords() if k == keyword)
+    for i in range(count):
+        old = param.vector(keyword, index=i)
+        new = [f"{v:g}" for v in values] + old[len(values):]
+        param.set_scalar(keyword, " ".join(new), index=i)
+
+
+def apply_weight_point(param: Param, point: WeightPoint) -> None:
+    """Write a per-type WeightPoint into Exon_weights / Exon_factor / Site_factor."""
+    _set_columns(param, "Exon_weights", point.ewf)
+    _set_columns(param, "Exon_factor", point.owf)
+    _set_columns(param, "Site_factor", tuple(round(1 - o, 6) for o in point.owf))
+
+
+@dataclass
+class CDResult:
+    point: WeightPoint
+    accuracy: Accuracy
+
+
+def _score_weight_point(
+    base_text: str, point: WeightPoint, geneid_bin: str,
+    fasta: str, gff: str, workdir: Path, tag: str,
+) -> Accuracy:
+    param = Param.from_text(base_text)
+    apply_weight_point(param, point)
+    ptmp = workdir / f"p_{tag}.param"
+    param.write(ptmp)
+    pred = workdir / f"pred_{tag}.gff"
+    pred.write_text(run_geneid(geneid_bin, str(ptmp), fasta))
+    return evaluate_files(str(pred), gff)
+
+
+def coordinate_descent(
+    base_param_text: str,
+    eval_fasta: str,
+    eval_gff: str,
+    *,
+    geneid_bin: str = "geneid",
+    init: WeightPoint | None = None,
+    ewf_values: list[float] | None = None,
+    owf_values: list[float] | None = None,
+    workers: int = 4,
+    max_rounds: int = 3,
+) -> tuple[str, CDResult, list[CDResult]]:
+    """Refine per-exon-type weights by coordinate descent, maximising held-out
+    exon SNSP. Each of the 8 coordinates (4 eWF + 4 oWF) is line-searched in turn
+    (its candidate values run in parallel) holding the others fixed; rounds repeat
+    until no coordinate improves or ``max_rounds`` is reached.
+
+    Returns ``(optimised_param_text, best CDResult, history of improvements)``.
+    Seed with :func:`uniform_point` from a coarse :func:`optimize` for a good start.
+    """
+    bin_path = shutil.which(geneid_bin) or geneid_bin
+    ewf_values = ewf_values if ewf_values is not None else _frange(*DEFAULT_EWF)
+    owf_values = owf_values if owf_values is not None else _frange(*DEFAULT_OWF)
+    point = init if init is not None else uniform_point(-4.0, 0.30)
+
+    counter = itertools.count()
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+
+        def score(p: WeightPoint) -> Accuracy:
+            return _score_weight_point(
+                base_param_text, p, bin_path, eval_fasta, eval_gff, workdir,
+                str(next(counter)),
+            )
+
+        best_acc = score(point)
+        history = [CDResult(point, best_acc)]
+        for _ in range(max_rounds):
+            improved = False
+            for axis, values in (("ewf", ewf_values), ("owf", owf_values)):
+                for idx in range(4):
+                    trials = [
+                        point.with_value(axis, idx, v)
+                        for v in values
+                        if v != getattr(point, axis)[idx]
+                    ]
+                    if not trials:
+                        continue
+                    with ThreadPoolExecutor(max_workers=workers) as pool:
+                        accs = list(pool.map(score, trials))
+                    candidates = [(point, best_acc)] + list(zip(trials, accs))
+                    candidates.sort(key=lambda c: accuracy_key(c[1]))
+                    best_point, best_of = candidates[0]
+                    if best_point != point:
+                        point, best_acc = best_point, best_of
+                        improved = True
+                        history.append(CDResult(point, best_acc))
+            if not improved:
+                break
+
+    param = Param.from_text(base_param_text)
+    apply_weight_point(param, point)
+    return param.to_text(), CDResult(point, best_acc), history

--- a/training/tests/test_optimize.py
+++ b/training/tests/test_optimize.py
@@ -5,7 +5,16 @@ import pytest
 
 from geneid_train.core.param import Param
 from geneid_train.evaluate import Accuracy
-from geneid_train.optimize import GridResult, _frange, apply_weights, optimize
+from geneid_train.optimize import (
+    GridResult,
+    WeightPoint,
+    _frange,
+    accuracy_key,
+    apply_weight_point,
+    apply_weights,
+    optimize,
+    uniform_point,
+)
 
 from .conftest import ref_dir
 
@@ -48,6 +57,34 @@ def test_grid_result_sort_prefers_higher_snsp_then_tiebreaks():
     assert results[2] is b
 
 
+def test_accuracy_key_orders_by_snsp_then_snspg():
+    assert accuracy_key(_acc(0.80)) < accuracy_key(_acc(0.70))
+    assert accuracy_key(_acc(0.80, snspg=0.5)) < accuracy_key(_acc(0.80, snspg=0.4))
+
+
+def test_uniform_point_sets_all_types_equal():
+    p = uniform_point(-3.5, 0.3)
+    assert p.ewf == (-3.5, -3.5, -3.5, -3.5)
+    assert p.owf == (0.3, 0.3, 0.3, 0.3)
+
+
+def test_weight_point_with_value_is_immutable_single_change():
+    p = uniform_point(-4.0, 0.3)
+    q = p.with_value("ewf", 2, -2.0)  # Terminal only
+    assert q.ewf == (-4.0, -4.0, -2.0, -4.0)
+    assert p.ewf == (-4.0, -4.0, -4.0, -4.0)  # original untouched
+    assert q.owf == p.owf
+
+
+def test_apply_weight_point_per_type_columns_preserve_utr():
+    p = Param.from_text(_MINI_PARAM)
+    apply_weight_point(p, WeightPoint((-1, -2, -3, -4), (0.1, 0.2, 0.3, 0.4)))
+    assert p.vector("Exon_weights") == ["-1", "-2", "-3", "-4", "0"]  # UTR 0 kept
+    assert p.vector("Exon_factor") == ["0.1", "0.2", "0.3", "0.4"]
+    # Site_factor = 1 - owf per type, trailing UTR 0.6 preserved
+    assert p.vector("Site_factor") == ["0.9", "0.8", "0.7", "0.6", "0.6"]
+
+
 # ---- end-to-end with a real geneid binary -----------------------------------
 
 REF = ref_dir()
@@ -80,3 +117,28 @@ def test_optimize_runs_grid_and_selects_best():
     p = Param.from_text(opt_text)
     assert p.vector("Exon_weights")[0] == f"{best.ewf:g}"
     assert p.vector("Exon_factor")[0] == f"{best.owf:g}"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    REF is None or not Path(GENEID).exists(),
+    reason="needs GENEID_TRAIN_REFDIR and a geneid binary (GENEID_BIN)",
+)
+def test_coordinate_descent_beats_or_matches_uniform_seed():
+    from geneid_train.optimize import coordinate_descent
+
+    sp = "Xerocrassa_montserratensis"
+    base = (REF / f"{sp}.geneid.param").read_text()
+    fasta = str(REF / f"{sp}.eval.gp.fa")
+    gff = str(REF / f"{sp}.eval.gp.gff")
+    seed = uniform_point(-4.5, 0.35)
+    opt_text, best, history = coordinate_descent(
+        base, fasta, gff, geneid_bin=GENEID, init=seed,
+        ewf_values=[-4.5], owf_values=[0.30, 0.35], workers=2, max_rounds=1,
+    )
+    # descent only ever accepts improvements over the seed, so best >= seed
+    assert best.accuracy.snsp >= history[0].accuracy.snsp
+    assert len(best.point.ewf) == 4 and len(best.point.owf) == 4
+    # optimised param carries the per-type owf (First may differ from the rest)
+    p = Param.from_text(opt_text)
+    assert p.vector("Exon_factor") == [f"{o:g}" for o in best.point.owf]


### PR DESCRIPTION
## Per-exon-type weight optimization (coordinate descent)

The four exon types — First, Internal, Terminal, Single — have their own columns in `Exon_weights` / `Exon_factor` / `Site_factor` (column 4 is UTR). They exist to be tuned independently, but the uniform grid (#33) set all four to a single shared `eWF`/`oWF`. This adds a per-type search.

### What's here
- **`WeightPoint`** — per-type `(ewf, owf)` 4-tuples; `apply_weight_point` writes columns 0–3 of the three sections (`Exon_factor = owf`, `Site_factor = 1 − owf`), preserving the trailing UTR column.
- **`coordinate_descent()`** — walks the 8-D space (4 eWF + 4 oWF) one coordinate at a time: each coordinate's candidate values run in parallel, holding the others fixed; rounds repeat until no coordinate improves held-out exon **SNSP** (`accuracy_key` = the legacy `sorteval` order). Seed it from a coarse `optimize()` via `uniform_point()`.
- **CLI**: `geneid-train optimize --per-type` runs the uniform grid, then refines the four types independently and reports the per-type weights.

### Result
Against geneid v1.5.1 on the xgXerMont eval set, coordinate descent seeded from the uniform best (**SNSP 0.6842**) improves to **0.6889** by tuning the First-exon factor (0.30) apart from the others (0.35) — the per-type gain the uniform grid can't reach.

**118 tests pass, ruff clean** (unit coverage for `WeightPoint`/`apply_weight_point`/`accuracy_key`; an opt-in integration test drives real geneid).

### Design notes / future
Coordinate descent is a pragmatic first redesign — it's parallel within each line search and cheap to reason about. Natural follow-ups: adaptive step refinement around the incumbent, or a global method (Nelder–Mead / Bayesian) over the 8-D space; and eventually the branch/U12 AccCtx + min-branch axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
