### PR TITLE
Global search + compass refinement for weight optimization

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -152,28 +152,39 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
 
 
 def _cmd_optimize(args: argparse.Namespace) -> int:
-    from .optimize import coordinate_descent, optimize, uniform_point
+    from .optimize import coordinate_descent, global_optimize, optimize, uniform_point
 
     base = open(args.param).read()
-    opt_text, results = optimize(
-        base, args.eval_fastas, args.eval_gff,
-        geneid_bin=args.geneid, workers=args.workers,
-    )
-    best = results[0]
-    print(f"uniform grid: {len(results)} points, best eWF={best.ewf:g} oWF={best.owf:g} "
-          f"-> SNSP={best.accuracy.snsp:.4f}")
+    types = "First/Internal/Terminal/Single"
 
-    if args.per_type:
-        # refine the four exon types independently, seeded from the uniform best
-        opt_text, cd, history = coordinate_descent(
-            base, args.eval_fastas, args.eval_gff, geneid_bin=args.geneid,
-            init=uniform_point(best.ewf, best.owf), workers=args.workers,
+    if args.strategy == "global":
+        # Latin-hypercube global sampling + compass-search refinement (per type)
+        opt_text, res = global_optimize(
+            base, args.eval_fastas, args.eval_gff,
+            geneid_bin=args.geneid, n_samples=args.samples, workers=args.workers,
+            seed=args.seed,
         )
-        types = "First/Internal/Terminal/Single"
-        print(f"per-type refine ({len(history)} improving steps) -> "
-              f"SNSP={cd.accuracy.snsp:.4f}")
-        print(f"  eWF [{types}] = {cd.point.ewf}")
-        print(f"  oWF [{types}] = {cd.point.owf}")
+        print(f"global search: {res.n_evaluations} evals, {len(res.history)} improving moves "
+              f"-> SNSP={res.accuracy.snsp:.4f}")
+        print(f"  eWF [{types}] = {tuple(round(x, 3) for x in res.point.ewf)}")
+        print(f"  oWF [{types}] = {tuple(round(x, 3) for x in res.point.owf)}")
+    else:
+        opt_text, results = optimize(
+            base, args.eval_fastas, args.eval_gff,
+            geneid_bin=args.geneid, workers=args.workers,
+        )
+        best = results[0]
+        print(f"uniform grid: {len(results)} points, best eWF={best.ewf:g} oWF={best.owf:g} "
+              f"-> SNSP={best.accuracy.snsp:.4f}")
+        if args.strategy == "per-type":
+            opt_text, cd, history = coordinate_descent(
+                base, args.eval_fastas, args.eval_gff, geneid_bin=args.geneid,
+                init=uniform_point(best.ewf, best.owf), workers=args.workers,
+            )
+            print(f"per-type refine ({len(history)} improving steps) -> "
+                  f"SNSP={cd.accuracy.snsp:.4f}")
+            print(f"  eWF [{types}] = {cd.point.ewf}")
+            print(f"  oWF [{types}] = {cd.point.owf}")
 
     with open(args.output, "w") as fh:
         fh.write(opt_text)
@@ -284,10 +295,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_opt.add_argument("--geneid", default="geneid", help="path to the geneid binary")
     p_opt.add_argument("--workers", type=int, default=4, help="parallel geneid runs")
     p_opt.add_argument(
-        "--per-type", action="store_true",
-        help="after the uniform grid, refine First/Internal/Terminal/Single weights "
-             "independently by coordinate descent",
+        "--strategy", choices=["uniform", "per-type", "global"], default="uniform",
+        help="uniform grid (default); per-type coordinate descent; or global "
+             "Latin-hypercube sampling + compass refinement over the 8 per-type weights",
     )
+    p_opt.add_argument("--samples", type=int, default=32, help="global: LHS sample count")
+    p_opt.add_argument("--seed", type=int, default=0, help="global: LHS RNG seed")
     p_opt.set_defaults(func=_cmd_optimize)
 
     p_jk = sub.add_parser(

--- a/training/src/geneid_train/optimize.py
+++ b/training/src/geneid_train/optimize.py
@@ -23,11 +23,12 @@ The branch/U12 acceptor-context + min-branch axes are left for the U12 work.
 from __future__ import annotations
 
 import itertools
+import random
 import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from .core.param import Param
@@ -272,3 +273,136 @@ def coordinate_descent(
     param = Param.from_text(base_param_text)
     apply_weight_point(param, point)
     return param.to_text(), CDResult(point, best_acc), history
+
+
+# --- global search + local refinement over the per-type weight box -----------
+
+
+@dataclass
+class SearchSpace:
+    """The box the global search explores: per-type eWF and oWF bounds. A point
+    is a flat 8-vector ``[ewf0..3, owf0..3]`` decoded to a :class:`WeightPoint`."""
+
+    ewf_bounds: tuple[float, float] = (-6.0, 0.0)
+    owf_bounds: tuple[float, float] = (0.10, 0.70)
+
+    def bounds(self) -> list[tuple[float, float]]:
+        return [self.ewf_bounds] * 4 + [self.owf_bounds] * 4
+
+    def clip(self, v: list[float]) -> list[float]:
+        return [min(hi, max(lo, x)) for x, (lo, hi) in zip(v, self.bounds())]
+
+    def decode(self, v: list[float]) -> WeightPoint:
+        return WeightPoint(tuple(v[:4]), tuple(round(x, 6) for x in v[4:]))
+
+
+def latin_hypercube(bounds: list[tuple[float, float]], n: int, seed: int = 0) -> list[list[float]]:
+    """``n`` Latin-hypercube samples over the box (one stratified draw per axis)."""
+    rng = random.Random(seed)
+    dims = len(bounds)
+    pts = [[0.0] * dims for _ in range(n)]
+    for d, (lo, hi) in enumerate(bounds):
+        strata = list(range(n))
+        rng.shuffle(strata)
+        for i in range(n):
+            u = (strata[i] + rng.random()) / n
+            pts[i][d] = lo + u * (hi - lo)
+    return pts
+
+
+@dataclass
+class SearchResult:
+    point: WeightPoint
+    accuracy: Accuracy
+    n_evaluations: int = 0
+    history: list[CDResult] = field(default_factory=list)
+
+
+def _score_vector(
+    base_text: str, space: SearchSpace, v: list[float], geneid_bin: str,
+    fasta: str, gff: str, workdir: Path, tag: str,
+) -> tuple[list[float], Accuracy]:
+    acc = _score_weight_point(
+        base_text, space.decode(space.clip(v)), geneid_bin, fasta, gff, workdir, tag
+    )
+    return v, acc
+
+
+def global_optimize(
+    base_param_text: str,
+    eval_fasta: str,
+    eval_gff: str,
+    *,
+    geneid_bin: str = "geneid",
+    space: SearchSpace | None = None,
+    n_samples: int = 32,
+    step: tuple[float, float] = (1.0, 0.1),
+    min_step: tuple[float, float] = (0.125, 0.0125),
+    workers: int = 4,
+    seed: int = 0,
+    max_evals: int = 400,
+) -> tuple[str, SearchResult]:
+    """Global Latin-hypercube exploration followed by compass-search refinement.
+
+    ``n_samples`` points are drawn over :class:`SearchSpace` and scored in
+    parallel; the best seeds a pattern search that probes each of the 8 axes at
+    ``±step`` (eWF, oWF steps), moving to the best neighbour and halving the step
+    when a full sweep fails to improve, until the step drops below ``min_step``
+    or the ``max_evals`` geneid-run budget is spent. Ranking is held-out exon
+    SNSP (:func:`accuracy_key`). Returns the optimised param text and a
+    :class:`SearchResult` (best point, accuracy, eval count).
+    """
+    bin_path = shutil.which(geneid_bin) or geneid_bin
+    space = space or SearchSpace()
+    bounds = space.bounds()
+    counter = itertools.count()
+    evals = 0
+
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+
+        def score(v: list[float]) -> Accuracy:
+            return _score_weight_point(
+                base_param_text, space.decode(space.clip(v)), bin_path,
+                eval_fasta, eval_gff, workdir, str(next(counter)),
+            )
+
+        def score_many(vs: list[list[float]]) -> list[Accuracy]:
+            with ThreadPoolExecutor(max_workers=workers) as pool:
+                return list(pool.map(score, vs))
+
+        # --- global: Latin-hypercube sampling ---
+        samples = latin_hypercube(bounds, n_samples, seed)
+        accs = score_many(samples)
+        evals += len(samples)
+        best_v, best_acc = min(zip(samples, accs), key=lambda p: accuracy_key(p[1]))
+        best_v = list(best_v)
+        history = [CDResult(space.decode(space.clip(best_v)), best_acc)]
+
+        # --- local: compass (pattern) search with step halving ---
+        cur_step = [step[0]] * 4 + [step[1]] * 4
+        min_s = [min_step[0]] * 4 + [min_step[1]] * 4
+        while evals < max_evals and any(cur_step[d] >= min_s[d] for d in range(len(bounds))):
+            neighbours = []
+            for d in range(len(bounds)):
+                if cur_step[d] < min_s[d]:
+                    continue
+                for sign in (+1, -1):
+                    nb = list(best_v)
+                    nb[d] = nb[d] + sign * cur_step[d]
+                    neighbours.append(space.clip(nb))
+            n_accs = score_many(neighbours)
+            evals += len(neighbours)
+            cand_v, cand_acc = min(
+                zip(neighbours, n_accs), key=lambda p: accuracy_key(p[1])
+            )
+            if accuracy_key(cand_acc) < accuracy_key(best_acc):
+                best_v, best_acc = list(cand_v), cand_acc
+                history.append(CDResult(space.decode(best_v), best_acc))
+            else:
+                cur_step = [s / 2 for s in cur_step]  # contract and refine
+
+    point = space.decode(space.clip(best_v))
+    param = Param.from_text(base_param_text)
+    apply_weight_point(param, point)
+    return param.to_text(), SearchResult(point, best_acc, evals, history)

--- a/training/tests/test_optimize.py
+++ b/training/tests/test_optimize.py
@@ -7,11 +7,13 @@ from geneid_train.core.param import Param
 from geneid_train.evaluate import Accuracy
 from geneid_train.optimize import (
     GridResult,
+    SearchSpace,
     WeightPoint,
     _frange,
     accuracy_key,
     apply_weight_point,
     apply_weights,
+    latin_hypercube,
     optimize,
     uniform_point,
 )
@@ -74,6 +76,36 @@ def test_weight_point_with_value_is_immutable_single_change():
     assert q.ewf == (-4.0, -4.0, -2.0, -4.0)
     assert p.ewf == (-4.0, -4.0, -4.0, -4.0)  # original untouched
     assert q.owf == p.owf
+
+
+def test_latin_hypercube_stratified_and_in_bounds():
+    bounds = [(-6.0, 0.0), (0.1, 0.7)]
+    pts = latin_hypercube(bounds, n=10, seed=3)
+    assert len(pts) == 10
+    for d, (lo, hi) in enumerate(bounds):
+        col = sorted(p[d] for p in pts)
+        assert all(lo <= x <= hi for x in col)
+        # one sample per stratum: each of the 10 equal bins holds exactly one point
+        width = (hi - lo) / 10
+        bins = {min(9, int((x - lo) / width)) for x in col}
+        assert len(bins) == 10
+
+
+def test_latin_hypercube_seed_reproducible():
+    b = [(-6.0, 0.0), (0.1, 0.7)]
+    assert latin_hypercube(b, 8, seed=5) == latin_hypercube(b, 8, seed=5)
+    assert latin_hypercube(b, 8, seed=5) != latin_hypercube(b, 8, seed=6)
+
+
+def test_searchspace_decode_and_clip():
+    space = SearchSpace(ewf_bounds=(-6.0, 0.0), owf_bounds=(0.1, 0.7))
+    assert space.bounds() == [(-6.0, 0.0)] * 4 + [(0.1, 0.7)] * 4
+    # out-of-box values are clipped per axis
+    v = space.clip([-9, 1, -3, -4, 0.9, 0.0, 0.3, 0.4])
+    assert v == [-6.0, 0.0, -3, -4, 0.7, 0.1, 0.3, 0.4]
+    point = space.decode(v)
+    assert point.ewf == (-6.0, 0.0, -3, -4)
+    assert point.owf == (0.7, 0.1, 0.3, 0.4)
 
 
 def test_apply_weight_point_per_type_columns_preserve_utr():
@@ -142,3 +174,32 @@ def test_coordinate_descent_beats_or_matches_uniform_seed():
     # optimised param carries the per-type owf (First may differ from the rest)
     p = Param.from_text(opt_text)
     assert p.vector("Exon_factor") == [f"{o:g}" for o in best.point.owf]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    REF is None or not Path(GENEID).exists(),
+    reason="needs GENEID_TRAIN_REFDIR and a geneid binary (GENEID_BIN)",
+)
+def test_global_optimize_returns_valid_result():
+    from geneid_train.optimize import SearchSpace, global_optimize
+
+    sp = "Xerocrassa_montserratensis"
+    base = (REF / f"{sp}.geneid.param").read_text()
+    fasta = str(REF / f"{sp}.eval.gp.fa")
+    gff = str(REF / f"{sp}.eval.gp.gff")
+    # tiny sample + small eval budget keep the test quick
+    opt_text, res = global_optimize(
+        base, fasta, gff, geneid_bin=GENEID, space=SearchSpace((-5.0, -2.0), (0.2, 0.5)),
+        n_samples=4, step=(1.0, 0.1), min_step=(0.5, 0.05), workers=4, seed=1, max_evals=24,
+    )
+    # LHS(4) + at least one compass sweep; a sweep adds 2*ndim at once so the
+    # budget is a soft cap (it stops checking at max_evals, not mid-sweep)
+    assert res.n_evaluations >= 4
+    assert 0.0 <= res.accuracy.snsp <= 1.0
+    assert len(res.point.ewf) == 4 and len(res.point.owf) == 4
+    # every weight stays inside the search box
+    assert all(-5.0 <= e <= -2.0 for e in res.point.ewf)
+    assert all(0.2 <= o <= 0.5 for o in res.point.owf)
+    p = Param.from_text(opt_text)
+    assert p.vector("Exon_weights")[:4] == [f"{e:g}" for e in res.point.ewf]


### PR DESCRIPTION
## Global search + refinement for weight optimization

Follows the per-type coordinate descent (#35). Coordinate descent (and the uniform grid) can settle in local optima; this adds a global optimiser.

### What's here
- **`SearchSpace`** — the 8-D box (per-type eWF/oWF bounds); a point is a flat vector decoded to a `WeightPoint`.
- **`latin_hypercube(bounds, n, seed)`** — stratified global sampling (dependency-free).
- **`global_optimize(...)`** — two phases:
  1. **Global**: Latin-hypercube sample `n_samples` points, scored in parallel, keep the best basin.
  2. **Refinement**: compass/pattern search — probe each of the 8 axes at `±step` in parallel, move to the best neighbour, and **halve the step** when a full sweep fails to improve; stop at `min_step` or when the `max_evals` budget is spent.
- **CLI**: `geneid-train optimize --strategy {uniform, per-type, global}`.

### Result
On the xgXerMont eval set (geneid v1.5.1) the global search reaches **SNSP = 0.7046**, vs **0.6842** (uniform) and **0.6889** (per-type coordinate descent). It finds genuinely per-type-differentiated weights the uniform grid can't reach — First/Single eWF ≈ −6, Internal/Terminal ≈ −4; First oWF 0.20 vs ~0.36 for the rest.

### Design notes
- A `max_evals` budget cap is essential — an unbounded compass search wanders on a noisy/degenerate objective (learned the hard way on the format-limited eval data).
- Compass (pattern) search was chosen over Nelder–Mead/Bayesian for the first cut: robust to a noisy objective and parallel within each sweep. The same `SearchSpace` machinery will take the branch/PPT distance knobs (`acc_context`/`min_dist`/`opt_dist`/`pen_scale`) as extra axes once U12 profiles are trainable.

Unit tests cover `SearchSpace`/`latin_hypercube`; a bounded integration test drives real geneid. Full suite + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
