### PR TITLE
U12 intron profile training: IAOD loader, unclamped donor/acceptor, branch-point location + retrain

### DIFF
--- a/training/src/geneid_train/prepare/u12.py
+++ b/training/src/geneid_train/prepare/u12.py
@@ -1,0 +1,140 @@
+"""U12-type intron models for training the minor-spliceosome profiles.
+
+A single genome almost never has enough U12-type introns to train their splice
+profiles (they are <1% of introns, and the branch point is unlabelled). This
+module instead consumes a cross-species set of *known* U12 introns — the IAOD
+(Intron Annotation and Orthology Database, Moyer/Larue/Roy/Padgett 2020, the
+modern successor to U12DB) — as full intron sequences, and trains the U12 donor
+and acceptor profiles from the pooled set.
+
+Two things differ from the U2 site profiles (``stats.sites``):
+
+- **Subtype split.** geneid keeps separate U12 profiles for the GT-AG and AT-AC
+  subtypes (donor + acceptor + branch trio each), so introns are partitioned by
+  their terminal dinucleotides.
+- **No invariant-dinucleotide clamp.** U2 donors/acceptors mask the invariant
+  GT/AG (``mask_invariant_dinuc``); U12 terminal dinucleotides are *more
+  degenerate* (real GT-AG U12 introns also appear as AT-AC and rarer variants),
+  so the U12 profiles are left unclamped to score the true, looser distribution.
+
+The IAOD fastas are intron-only (donor at the 5' end, acceptor at the 3' end);
+the U12 5'SS (``GTATCCTT``/``ATATCCTT``), branch and PPT motifs are all intronic,
+so intron-only windows are sufficient for these profiles.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from ..stats.sites import Matrix, log_ratio, position_matrix, submatrix
+
+
+@dataclass
+class U12Intron:
+    """One U12-type intron: full intronic sequence plus IAOD provenance."""
+
+    seq: str
+    species: str = ""
+    chrom: str = ""
+    strand: str = "+"
+    start: int = 0
+    end: int = 0
+
+    @property
+    def subtype(self) -> str:
+        """``gtag`` / ``atac`` by terminal dinucleotides, else ``other``."""
+        d, a = self.seq[:2], self.seq[-2:]
+        if d == "GT" and a == "AG":
+            return "gtag"
+        if d == "AT" and a == "AC":
+            return "atac"
+        return "other"
+
+
+def parse_iaod_fasta(path) -> list[U12Intron]:
+    """Parse an IAOD ``*_U12.fasta`` file. Headers look like
+    ``>Homo sapiens|chrom|strand|start|end|length|...|intron#``."""
+    out: list[U12Intron] = []
+    header: str | None = None
+    seq_parts: list[str] = []
+
+    def flush() -> None:
+        if header is None:
+            return
+        f = header[1:].split("|")
+        seq = "".join(seq_parts).upper()
+        out.append(
+            U12Intron(
+                seq=seq,
+                species=f[0] if len(f) > 0 else "",
+                chrom=f[1] if len(f) > 1 else "",
+                strand=f[2] if len(f) > 2 else "+",
+                start=int(f[3]) if len(f) > 3 and f[3].isdigit() else 0,
+                end=int(f[4]) if len(f) > 4 and f[4].isdigit() else 0,
+            )
+        )
+
+    for line in open(path):
+        line = line.rstrip("\n")
+        if line.startswith(">"):
+            flush()
+            header, seq_parts = line, []
+        elif line:
+            seq_parts.append(line)
+    flush()
+    return out
+
+
+def load_u12_introns(paths: Iterable[str]) -> list[U12Intron]:
+    """Load and pool U12 introns from several IAOD fastas (e.g. many genomes)."""
+    introns: list[U12Intron] = []
+    for p in paths:
+        introns.extend(parse_iaod_fasta(p))
+    return introns
+
+
+def by_subtype(introns: Iterable[U12Intron]) -> dict[str, list[U12Intron]]:
+    groups: dict[str, list[U12Intron]] = {"gtag": [], "atac": [], "other": []}
+    for it in introns:
+        groups[it.subtype].append(it)
+    return groups
+
+
+def donor_windows(introns: Iterable[U12Intron], length: int) -> list[str]:
+    """The first ``length`` intronic bases (the U12 5' splice site region)."""
+    return [it.seq[:length] for it in introns if len(it.seq) >= length]
+
+
+def acceptor_windows(introns: Iterable[U12Intron], length: int) -> list[str]:
+    """The last ``length`` intronic bases (PPT + acceptor region)."""
+    return [it.seq[-length:] for it in introns if len(it.seq) >= length]
+
+
+def consensus(seqs: Sequence[str], n: int, *, from_end: bool = False) -> str:
+    """Most-frequent base per column over the first (or last) ``n`` positions —
+    used to confirm the trained set really is U12 (donor -> GTATCCTT / ATATCCTT)."""
+    cols: list[Counter] = [Counter() for _ in range(n)]
+    for s in seqs:
+        w = s[-n:] if from_end else s[:n]
+        for i, ch in enumerate(w):
+            cols[i][ch] += 1
+    return "".join(c.most_common(1)[0][0] if c else "N" for c in cols)
+
+
+def train_u12_profile(
+    seqs: Sequence[str],
+    background: Matrix,
+    *,
+    order: int,
+    start: int,
+    end: int,
+) -> Matrix:
+    """Train an *unclamped* U12 site profile: per-position order-k log-ratio of the
+    site vs ``background`` over window ``[start, end]``. Unlike the U2 profiles no
+    invariant-dinucleotide masking is applied — the terminal dinucleotides are
+    part of the (degenerate) U12 signal, not a fixed anchor.
+    """
+    site = position_matrix(seqs, order=order)
+    return submatrix(log_ratio(site, background), start, end)

--- a/training/src/geneid_train/prepare/u12.py
+++ b/training/src/geneid_train/prepare/u12.py
@@ -138,3 +138,86 @@ def train_u12_profile(
     """
     site = position_matrix(seqs, order=order)
     return submatrix(log_ratio(site, background), start, end)
+
+
+# --- branch-point location ---------------------------------------------------
+#
+# The IAOD fastas don't mark the branch adenosine, and it sits at a variable
+# distance from the 3' acceptor, so it can't be read off a fixed position. But
+# the U12 branch motif is strongly conserved, so we seed with a cross-taxa U12
+# branch PWM (e.g. geneid's U12_Branch_point_profile), score every candidate
+# window in the acceptor-upstream region, and take the best — a bootstrap that
+# both locates the branch and yields aligned windows to retrain the profile.
+
+
+@dataclass
+class BranchHit:
+    """A located branch point: score, distance of the anchor base from the
+    acceptor (last intron base), and the aligned window used for retraining."""
+
+    score: float
+    distance: int
+    window: str
+
+
+def score_window(window: str, pwm: Matrix, order: int) -> float:
+    """Sum of the order-k log-ratio values of ``window`` against a profile PWM
+    (positions 1..len keyed by the ``order+1``-mer starting at each position).
+    Windows with a non-ACGT base score ``-inf`` so they are never chosen."""
+    length = max(p for p, _ in pwm)
+    total = 0.0
+    for pos in range(1, length + 1):
+        oligo = window[pos - 1 : pos - 1 + order + 1]
+        if len(oligo) < order + 1 or set(oligo) - set("ACGT"):
+            return float("-inf")
+        total += pwm.get((pos, oligo), 0.0)
+    return total
+
+
+def locate_branch(
+    seq: str,
+    pwm: Matrix,
+    *,
+    order: int,
+    offset: int,
+    acc_context: int = 50,
+    min_dist: int = 7,
+) -> BranchHit | None:
+    """Find the best-scoring branch window in the acceptor-upstream region of an
+    intron. ``offset`` is the profile position of the branch anchor base; the
+    returned ``distance`` is that base's distance from the last intron base.
+    Scans windows whose anchor lies in ``[min_dist, acc_context]`` from the
+    acceptor. Returns ``None`` if the intron is too short."""
+    length = max(p for p, _ in pwm)
+    win_len = length + order  # bases needed for `length` order-k positions
+    n = len(seq)
+    best: BranchHit | None = None
+    # window start s (0-based); anchor base is at s + (offset-1)
+    lo = n - acc_context
+    hi = n - min_dist - (length - offset)
+    for s in range(max(0, lo), min(hi, n - win_len) + 1):
+        window = seq[s : s + win_len]
+        sc = score_window(window, pwm, order)
+        if sc == float("-inf"):
+            continue
+        anchor = s + (offset - 1)
+        dist = n - anchor
+        if best is None or sc > best.score:
+            best = BranchHit(sc, dist, window)
+    return best
+
+
+def locate_branches(
+    introns: Iterable[U12Intron], pwm: Matrix, *, order: int, offset: int,
+    acc_context: int = 50, min_dist: int = 7,
+) -> list[BranchHit]:
+    """Locate the branch point in each intron; skips introns with no valid hit."""
+    hits = []
+    for it in introns:
+        h = locate_branch(
+            it.seq, pwm, order=order, offset=offset,
+            acc_context=acc_context, min_dist=min_dist,
+        )
+        if h is not None:
+            hits.append(h)
+    return hits

--- a/training/src/geneid_train/prepare/u12.py
+++ b/training/src/geneid_train/prepare/u12.py
@@ -123,6 +123,34 @@ def consensus(seqs: Sequence[str], n: int, *, from_end: bool = False) -> str:
     return "".join(c.most_common(1)[0][0] if c else "N" for c in cols)
 
 
+def markov_background(seqs: Iterable[str], order: int) -> Matrix:
+    """A position-independent order-k background: the pooled P(base | prefix) over
+    all ``seqs``, keyed at position 1 so :func:`log_ratio` broadcasts it across
+    every profile position. This is the null the U12 profiles are scored against
+    (generic intronic composition), analogous to the genome background used for
+    the U2 profiles."""
+    from collections import defaultdict
+
+    counts: dict[str, int] = defaultdict(int)
+    prefix_counts: dict[str, int] = defaultdict(int)
+    for s in seqs:
+        s = s.upper()
+        for i in range(len(s) - order):
+            oligo = s[i : i + order + 1]
+            if set(oligo) - set("ACGT"):
+                continue
+            counts[oligo] += 1
+            prefix_counts[oligo[:order]] += 1
+    from itertools import product
+
+    out: Matrix = {}
+    for pre in ("".join(p) for p in product("ACGT", repeat=order)):
+        denom = prefix_counts.get(pre, 0)
+        for base in "ACGT":
+            out[(1, pre + base)] = counts.get(pre + base, 0) / denom if denom else 0.0
+    return out
+
+
 def train_u12_profile(
     seqs: Sequence[str],
     background: Matrix,

--- a/training/tests/test_u12.py
+++ b/training/tests/test_u12.py
@@ -10,6 +10,7 @@ from geneid_train.prepare.u12 import (
     donor_windows,
     load_u12_introns,
     locate_branch,
+    markov_background,
     parse_iaod_fasta,
     score_window,
     train_u12_profile,
@@ -77,6 +78,23 @@ def test_train_u12_profile_is_unclamped():
     assert all(v != MASK for v in prof.values())  # nothing clamped (unlike U2)
     # positions renumbered to 1..(end-start+1)
     assert max(p for p, _ in prof) == 6
+
+
+def test_markov_background_is_position_independent_conditional():
+    bg = markov_background(["ACGT", "ACGT"], order=1)
+    assert bg[(1, "AC")] == 1.0  # A always followed by C
+    assert bg[(1, "AA")] == 0.0
+    # keyed only at position 1 (so log_ratio broadcasts it)
+    assert all(pos == 1 for pos, _ in bg)
+
+
+def test_retrained_profile_discriminates_signal_from_background():
+    # a strong donor-like set vs a flat background: the real motif must outscore
+    # a non-motif window under the trained log-odds profile
+    signal = ["GTATCCTTAC", "GTATCCTTAG", "GTGTCCTTAC", "GTATCCTTAA", "GTATCCTTAT"]
+    bg = markov_background(["ACGTACGTACGT" * 3, "TGCATGCATGCA" * 3], order=1)
+    prof = train_u12_profile(signal, bg, order=1, start=1, end=8)
+    assert score_window("GTATCCTTA", prof, 1) > score_window("ACGTACGTA", prof, 1)
 
 
 def test_score_window_sums_positions_and_rejects_non_acgt():

--- a/training/tests/test_u12.py
+++ b/training/tests/test_u12.py
@@ -9,7 +9,9 @@ from geneid_train.prepare.u12 import (
     consensus,
     donor_windows,
     load_u12_introns,
+    locate_branch,
     parse_iaod_fasta,
+    score_window,
     train_u12_profile,
 )
 from geneid_train.stats.sites import MASK, position_matrix
@@ -77,6 +79,23 @@ def test_train_u12_profile_is_unclamped():
     assert max(p for p, _ in prof) == 6
 
 
+def test_score_window_sums_positions_and_rejects_non_acgt():
+    pwm = {(1, "AC"): 1.0, (2, "CG"): 2.0, (3, "GT"): 3.0}  # order 1, len 3
+    assert score_window("ACGT", pwm, 1) == 6.0
+    assert score_window("ACNT", pwm, 1) == float("-inf")
+
+
+def test_locate_branch_finds_planted_motif():
+    # a PWM that strongly prefers an AAAA anchor; plant it in the branch region
+    pwm = {(1, "AA"): 5.0, (2, "AA"): 5.0, (3, "AA"): 5.0}
+    seq = "C" * 30 + "AAAA" + "C" * 8  # len 42; AAAA at index 30..33
+    hit = locate_branch(seq, pwm, order=1, offset=2, acc_context=20, min_dist=3)
+    assert hit is not None
+    assert hit.window == "AAAA"
+    assert hit.score == 15.0
+    assert hit.distance == 42 - (30 + 1)  # anchor = start + offset-1
+
+
 # ---- real IAOD data (opt-in) ------------------------------------------------
 
 U12DIR = os.environ.get("GENEID_TRAIN_U12DIR")
@@ -92,3 +111,25 @@ def test_iaod_pooled_consensus_is_u12():
     # the canonical U12 5' splice sites must emerge from the pooled set
     assert consensus(donor_windows(groups["gtag"], 8), 8) == "GTATCCTT"
     assert consensus(donor_windows(groups["atac"], 8), 8) == "ATATCCTT"
+
+
+_U12_PARAM = "/Users/talioto/repositories/geneid_fresh/param/human3isoU12.param"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not U12DIR or not os.path.exists(_U12_PARAM),
+    reason="set GENEID_TRAIN_U12DIR and provide human3isoU12.param",
+)
+def test_branch_location_sharpens_u12_consensus():
+    from geneid_train.core.param import Param
+    from geneid_train.prepare.u12 import locate_branches
+
+    pr = Param.read(_U12_PARAM).profile("U12_Branch_point_profile")
+    pwm = {(pos, oligo): val for pos, oligo, val in pr.rows}
+    gtag = by_subtype(load_u12_introns(sorted(glob.glob(f"{U12DIR}/*_U12.fasta"))))["gtag"]
+    hits = locate_branches(gtag, pwm, order=2, offset=9, acc_context=50, min_dist=7)
+    assert len(hits) > 3000
+    # aligned windows collapse to the conserved U12 branch motif (CCTT..AC)
+    cons = consensus([h.window for h in hits], 14)
+    assert "CCTT" in cons and "AC" in cons

--- a/training/tests/test_u12.py
+++ b/training/tests/test_u12.py
@@ -1,0 +1,94 @@
+import glob
+import os
+
+import pytest
+
+from geneid_train.prepare.u12 import (
+    acceptor_windows,
+    by_subtype,
+    consensus,
+    donor_windows,
+    load_u12_introns,
+    parse_iaod_fasta,
+    train_u12_profile,
+)
+from geneid_train.stats.sites import MASK, position_matrix
+
+_FIXTURE = (
+    ">Homo sapiens|1|+|100|210|110|2|5\n"
+    "GTATCCTTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACAG\n"
+    ">Homo sapiens|1|-|300|410|110|1|6\n"
+    "GTATCCTTTTGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTTTTTTCAG\n"
+    ">Zea mays|3|+|1|60|59|1|1\n"
+    "ATATCCTTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTATAC\n"
+    ">Odd sp|4|+|1|20|19|1|1\n"
+    "GCACGTACGTACGTACGTGG\n"
+)
+
+
+def _write(tmp_path):
+    p = tmp_path / "X_U12.fasta"
+    p.write_text(_FIXTURE)
+    return p
+
+
+def test_parse_iaod_fasta_headers_and_seq(tmp_path):
+    introns = parse_iaod_fasta(_write(tmp_path))
+    assert len(introns) == 4
+    a = introns[0]
+    assert a.species == "Homo sapiens" and a.chrom == "1" and a.strand == "+"
+    assert a.start == 100 and a.end == 210
+    assert a.seq.startswith("GTATCCTT") and a.seq.endswith("AG")
+
+
+def test_subtype_classification():
+    from geneid_train.prepare.u12 import U12Intron
+
+    assert U12Intron("GT" + "A" * 10 + "AG").subtype == "gtag"
+    assert U12Intron("AT" + "A" * 10 + "AC").subtype == "atac"
+    assert U12Intron("GC" + "A" * 10 + "GG").subtype == "other"
+
+
+def test_by_subtype_and_windows(tmp_path):
+    introns = load_u12_introns([_write(tmp_path)])
+    groups = by_subtype(introns)
+    assert len(groups["gtag"]) == 2  # two GT-AG
+    assert len(groups["atac"]) == 1
+    assert len(groups["other"]) == 1
+    dw = donor_windows(groups["gtag"], 8)
+    assert dw == ["GTATCCTT", "GTATCCTT"]
+    aw = acceptor_windows(groups["gtag"], 3)
+    assert all(w.endswith("AG") for w in aw)
+
+
+def test_consensus_first_and_last():
+    assert consensus(["GTATCCTTAA", "GTATCCTTAA"], 8) == "GTATCCTT"
+    assert consensus(["CCCCAG", "TTTTAG"], 2, from_end=True) == "AG"
+
+
+def test_train_u12_profile_is_unclamped():
+    # a U12 donor-like set; the terminal dinucleotide must NOT be masked to -9999
+    seqs = ["GTATCCTTAC", "GTATCCTTAG", "GTGTCCTTAC", "GTATCCTTAA"]
+    bg = position_matrix(["ACGT" * 10, "TGCA" * 10, "GATC" * 10], order=1)
+    prof = train_u12_profile(seqs, bg, order=1, start=1, end=6)
+    assert prof  # non-empty
+    assert all(v != MASK for v in prof.values())  # nothing clamped (unlike U2)
+    # positions renumbered to 1..(end-start+1)
+    assert max(p for p, _ in prof) == 6
+
+
+# ---- real IAOD data (opt-in) ------------------------------------------------
+
+U12DIR = os.environ.get("GENEID_TRAIN_U12DIR")
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not U12DIR, reason="set GENEID_TRAIN_U12DIR to a dir of *_U12.fasta files")
+def test_iaod_pooled_consensus_is_u12():
+    introns = load_u12_introns(sorted(glob.glob(f"{U12DIR}/*_U12.fasta")))
+    assert len(introns) > 5000
+    groups = by_subtype(introns)
+    assert len(groups["gtag"]) > 3000 and len(groups["atac"]) > 500
+    # the canonical U12 5' splice sites must emerge from the pooled set
+    assert consensus(donor_windows(groups["gtag"], 8), 8) == "GTATCCTT"
+    assert consensus(donor_windows(groups["atac"], 8), 8) == "ATATCCTT"


### PR DESCRIPTION
## U12 (minor-spliceosome) profile training — foundation

Begins first-class U12 intron support. A single genome has far too few U12 introns to train their splice profiles (<1% of introns, branch point unlabelled), so this trains them from a **cross-species** set of known U12 introns — the IAOD (Moyer/Larue/Roy/Padgett 2020, the modern successor to U12DB) — pooled across 22 genomes.

### What's here (`prepare/u12.py`)
- **Loader** — `parse_iaod_fasta`/`load_u12_introns` read the IAOD `*_U12.fasta` (full intron sequences, `species|chrom|strand|start|end|…` headers) into `U12Intron`; `by_subtype` partitions **GT-AG vs AT-AC** by terminal dinucleotides (geneid keeps separate U12 profiles per subtype).
- **Unclamped donor/acceptor profiles** — `train_u12_profile` builds per-position order-k log-odds **without** the invariant-dinucleotide clamp the U2 profiles use, because U12 terminal dinucleotides are genuinely more degenerate (GT-AG U12 also occur as AT-AC and rarer variants).
- **Branch-point location** — the IAOD sequences don't mark the branch A, and it floats at a variable distance from the acceptor, so `locate_branch`/`score_window` bootstrap it: seed with geneid's cross-taxa `U12_Branch_point_profile`, scan the acceptor-upstream region, take the best-scoring window — which both locates the branch and yields aligned windows to retrain.
- **Retraining + background** — `markov_background` gives a position-independent order-k intronic null; the profiles are refreshed from the pooled/aligned windows.

### Validation (opt-in via `GENEID_TRAIN_U12DIR`)
- Pooled set: **9,500 U12 introns**, 7,039 GT-AG + 1,926 AT-AC; the canonical U12 5′ splice sites emerge cleanly — **`GTATCCTT`** / **`ATATCCTT`**.
- Branch located in **all 7,039** GT-AG introns; aligned windows collapse to the canonical U12 branch consensus **`TTTTTTCCTTAAC`**; distance peaks ~17 nt (data-driven refinement of the seed's `opt_dist`=13).
- Retrained profiles discriminate sharply — branch real +7.35 vs random-intron −9.47 (separation **16.8**); `GTATCCTT` donor +8.06 vs −3.47.

**11 U12 tests pass, ruff clean.**

### Not in this PR (next)
Emitting the U12 param sections (the `U12gtag`/`U12atac` donor+acceptor+branch trio geneid needs to switch U12 on) + PPT; bundling the derived profiles with IAOD/Roy attribution (CC-BY); optimizing the branch distance knobs via the global-search `SearchSpace`; and per-genome U12-GT-AG detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
