### PR TITLE
geneid-train: automated U2 branch-point discovery + report-only Branch_point_score_weight

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -354,6 +354,10 @@ A. DEFINITIONS
 #define sExon_weights "Exon_weights"
 #define sU12_EXON_WEIGHT "U12_Exon_weight"
 
+/* Optional weight on the U2 branch-point score's contribution to the acceptor
+   score (0 = report-only; default 1) */
+#define sBRANCH_SCORE_WEIGHT "Branch_point_score_weight"
+
 /* Header evidence factor and weight */
 #define sEVIDENCEF "Evidence_Factor"
 #define sEVIDENCEW "Evidence_Exon_Weight"

--- a/src/BuildAcceptors.c
+++ b/src/BuildAcceptors.c
@@ -35,6 +35,7 @@ extern int UTR;
 /* Additional profiles */
 extern int BP;
 extern int PPT;
+extern float BRANCH_SCORE_WEIGHT;
 float ComputeU2BranchProfile(char* s,
 			     long positionAcc,
 			     long limitRight,
@@ -220,7 +221,7 @@ long  BuildAcceptors(char* s,
 	    /* For the time being, we will not use the BP or PPT scores */
 	    /* if (scoreBP > 0){score = score + scoreBP;} */ /* + scorePPT */
 	    scoreAcc = score;
-	    score = score + scoreBP;
+	    score = score + BRANCH_SCORE_WEIGHT * scoreBP;
 	    score = p->afactor + (p->bfactor * score); 
 	    if(UTR){
 	      score = score + PeakEdgeScore(is + p->order,Strand,external,l1,l2,6);
@@ -280,7 +281,7 @@ long  BuildAcceptors(char* s,
 		  
 	    /* if (scoreBP > 0){score = score + scoreBP;} */ /* + scorePPT */
 	    scoreAcc = score;
-	    score = score + scoreBP;
+	    score = score + BRANCH_SCORE_WEIGHT * scoreBP;
 	    score = p->afactor + (p->bfactor * score); 
 	    if(UTR){
 	      score = score + PeakEdgeScore(left + is + p->offset,Strand,external,l1,l2,6);
@@ -334,7 +335,7 @@ long  BuildAcceptors(char* s,
 		  
 	    /* if (scoreBP > 0){score = score + scoreBP;} */ /* + scorePPT */
 	    scoreAcc = score;
-	    score = score + scoreBP;
+	    score = score + BRANCH_SCORE_WEIGHT * scoreBP;
 	    score = p->afactor + (p->bfactor * score); 
 	    if(UTR){
 	      score = score + PeakEdgeScore(left + is + p->offset,Strand,external,l1,l2,6);
@@ -391,7 +392,7 @@ long  BuildAcceptors(char* s,
 		  
 	    /* if (scoreBP > 0){score = score + scoreBP;} */ /* + scorePPT */
 	    scoreAcc = score;
-	    score = score + scoreBP;
+	    score = score + BRANCH_SCORE_WEIGHT * scoreBP;
 	    score = p->afactor + (p->bfactor * score); 
 	    if(UTR){
 	      score = score + PeakEdgeScore(left + is + p->offset,Strand,external,l1,l2,6);

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -110,6 +110,12 @@ float EvidenceFactor = 1;
 float U12_SPLICE_SCORE_THRESH = -1000;
 float U12_EXON_SCORE_THRESH = -1000;
 
+/* Weight applied to the U2 branch-point score when it is added to the acceptor
+   score (see BuildAcceptors.c). Default 1 preserves the historical behaviour; a
+   param file may set it to 0 so the branch is scored and reported (bp_score /
+   bp_pos in the GFF) without contributing to the splice-site score. */
+float BRANCH_SCORE_WEIGHT = 1;
+
 /* Detection of recursive splice sites */
 float RSSMARKOVSCORE = 0;
 float RSSDON = RDT;

--- a/src/readparam.c
+++ b/src/readparam.c
@@ -42,6 +42,7 @@ extern int SGE;
 extern int PAS;
 extern int BKGD_SUBTRACT_FLANK_LENGTH;
 extern short SPLICECLASSES;
+extern float BRANCH_SCORE_WEIGHT;
 extern float U12_SPLICE_SCORE_THRESH;
 extern float U12_EXON_SCORE_THRESH;
 extern float U12EW;
@@ -775,6 +776,18 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 
 		  sprintf(mess,"U12_EXON_SCORE_THRESH: \t%9.2f",
 				  U12_EXON_SCORE_THRESH);
+		  printMess(mess);
+	}
+	 /* Optional: BRANCH_SCORE_WEIGHT, scales how much the U2 branch-point score
+	    contributes to the acceptor score. 0 = branch scored and reported
+	    (bp_score/bp_pos) but not counted toward the splice-site score. */
+	if(!strcasecmp(header,sBRANCH_SCORE_WEIGHT)){
+		  readLine(RootFile,line);
+		  if ((sscanf(line,"%f\n", &(BRANCH_SCORE_WEIGHT)))!=1)
+			printError("Wrong format: Branch_point_score_weight value (number/type)");
+
+		  sprintf(mess,"BRANCH_SCORE_WEIGHT: \t%9.2f",
+				  BRANCH_SCORE_WEIGHT);
 		  printMess(mess);
 	}
 	 /* Optional: U12_EXON_WEIGHT, an additional exon weight that applies to exons flanking U12 introns */

--- a/training/DESIGN.md
+++ b/training/DESIGN.md
@@ -300,3 +300,63 @@ the round-tripped file.
   serve as regression references.
 - `make install` (editable + dev deps) / `make test` / `make lint` / `make fmt`
   (ruff). No network required to run the unit suite.
+
+## 8. U2 branch-point discovery (PLANNED — not yet implemented)
+
+**Status.** Design only. The U12 branch/donor/acceptor trio already ships (bundled,
+IAOD-derived; `param/u12.py`) and the U12-vs-U2 donor screen is in `classify.py`.
+This section is the plan for the *U2* branch-point (+ PPT) profiles, which are
+trained **per genome** from that genome's own introns.
+
+**Motivation.** The U2 `Branch_point_profile` (+ `Poly_Pyrimidine_Tract_profile`)
+was historically discovered by hand with MEME — find the motif, search it, train a
+PWM. The goal is to automate that as a self-supervised step that runs by default
+and is **included only when it improves held-out accuracy** (§2 "Optional
+splice-class profiles" toggle). Strongly-conserved-branch genomes (fungi) are the
+clearest win; but since our genome portfolio is mostly non-fungal, the design
+targets the **generic, degenerate-branch case** first (see engine choice below).
+
+**What NOT to do.** Do *not* port BPP (Zhang et al. 2017, `github.com/zhqingit/BPP`)
+as a tool. BPP is tuned to the *hard, degenerate human* branch problem and is
+human-specific in ways that would actively mislead elsewhere: fixed offset windows
+(BPS 21–34, background 187–200, PPT 3–16 nt upstream of the 3′SS) that **do not fit
+short fungal introns**; a motif seeded from human U2 snRNP and trained on ~223k
+human introns; and a PPT model (half the BPP score) explicitly co-evolved with
+human U2AF65. Take only the *idea* — an EM mixture to discover a branch motif
+without labels — and train everything on the target genome.
+
+**Pipeline (`stats/branch.py`, new).**
+
+1. **Adaptive search window.** Per U2 intron, scan the acceptor-upstream region
+   defined *relative to intron length* with AG-exclusion (from the 3′SS back to the
+   first upstream AG beyond a small gap), capped by the intron's own length so short
+   introns still fit. No hardcoded human offsets.
+2. **EM mixture, self-trained.** Two components — a branch-motif PWM (~7 nt,
+   branch-A anchored) vs an intronic background — fit by EM over the candidate
+   windows. **Seed** the motif from the *universal* U2-snRNA-complementary consensus
+   (branch-A pairing → `yUNAy`/TACTAAC-like), **not** human weights; **train** only
+   on the target genome so the result is species-appropriate. EM converges sharply
+   for conserved (fungal) branches and still yields a usable model when degenerate.
+   Chosen over a consensus/Hamming-to-U2-complement shortcut (Kupfer 2004) because
+   the generic degenerate case covers most of our genomes; the conserved case is the
+   easy sub-case EM also handles.
+3. **Branch location + distances from data.** EM assigns each intron's branch-A;
+   the branch header's `acc_context` / `min_dist` / `opt_dist` are set from
+   *percentiles of the discovered branch-A→3′SS distances* (short for fungi, longer
+   elsewhere) — not searched. This supersedes tuning branch *distance* in the
+   optimiser; `optimize --tune-branch` is demoted to optional `pen_scale`-only
+   refinement (`pen_scale` is not directly observable).
+4. **PPT — deferred.** Because the PPT is species-specific and weak/inessential in
+   fungi, model it later as a separate, independently-gated stage
+   (`Poly_Pyrimidine_Tract_profile`); v1 is branch-PWM only.
+5. **Emit + gate.** Reuse `param.u12`'s acceptor-side insertion for
+   `Branch_point_profile`; assemble with vs without it and keep it only if held-out
+   exon SNSP improves (`evaluate.py` / `jackknife.py`). Discovery runs by default;
+   inclusion is earned and self-correcting across genome types.
+
+**Validation.** Primary working test = **xgXerMont** (already wired end-to-end; a
+metazoan with a degenerate U2 branch — exercises the generic EM path): check that
+EM recovers a sensible branch consensus and the toggle behaves. This is a *weak*
+positive control (a snail's branches aren't independently characterised); a genome
+with **known/characterised U2 branch points** (e.g. a small fungal genome with the
+sharp TACTAAC motif) is wanted for a stronger sanity check — TBD which.

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -233,7 +233,10 @@ def _cmd_train(args: argparse.Namespace) -> int:
         sys.stderr.write("no models survived filtering\n")
         return 1
     try:
-        param_text = train(models, genome, args.species, seed=args.seed, u12=args.u12)
+        param_text = train(
+            models, genome, args.species, seed=args.seed, u12=args.u12,
+            u2_branch=args.u2_branch, branch_weight=args.branch_weight,
+        )
     except NotImplementedError as exc:
         sys.stderr.write(f"geneid-train train: {exc}\n")
         return 2
@@ -320,6 +323,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--u12",
         action="store_true",
         help="include bundled U12 (minor-spliceosome) profiles so geneid -U predicts U12 introns",
+    )
+    p_train.add_argument(
+        "--u2-branch",
+        action="store_true",
+        help="discover a U2 Branch_point_profile from the genome's introns (EM) and include it",
+    )
+    p_train.add_argument(
+        "--branch-weight", type=float, default=0.0,
+        help="Branch_point_score_weight: contribution of the branch score to the acceptor "
+             "score (default 0 = scored and reported via bp_score/bp_pos but not counted)",
     )
     p_train.set_defaults(func=_cmd_train)
 

--- a/training/src/geneid_train/stats/branch.py
+++ b/training/src/geneid_train/stats/branch.py
@@ -1,0 +1,269 @@
+"""U2 branch-point discovery by a self-supervised EM motif finder.
+
+The U2 branch point was historically found by hand with MEME. This module
+automates that: it fits a two-component mixture (a branch-motif PWM vs an
+intronic background) to the acceptor-upstream region of a genome's *own* introns
+by EM, so the result is species-appropriate — sharp for conserved (fungal)
+branches, still usable when degenerate (mammalian). Nothing is human-tuned: the
+motif is *seeded* only from the universal U2-snRNA-complementary consensus (the
+invariant branch adenosine) and everything else is learned from the target genome.
+
+This is deliberately *not* a port of BPP (Zhang et al. 2017), whose fixed human
+offset windows and human-trained weights would misfire on short fungal introns and
+non-human composition. We keep only the idea — unsupervised EM motif discovery.
+
+The model is OOPS (one occurrence per sequence): each intron has exactly one branch
+in its 3' region. The EM also yields, per intron, the most likely branch position,
+whose distance distribution to the 3' splice site sets geneid's branch-distance
+knobs (``opt_dist``/``min_dist``/``acc_context``) directly from data rather than by
+search. Emission of the geneid ``Branch_point_profile`` + the accuracy-gated toggle
+live elsewhere; this module is the discovery + distance estimation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from ..prepare.base import GeneModel
+
+_ACGT = ("A", "C", "G", "T")
+_ACGT_SET = frozenset(_ACGT)
+
+# Motif geometry. Width 7 with the branch adenosine at index 5 matches the yeast
+# UACUAAC / mammalian yUnAy consensus (branch A is the 6th base). AG at the 3' end
+# of the intron is excluded from the search window (2 nt).
+BRANCH_WIDTH = 7
+BRANCH_A = 5
+_AG = 2  # terminal AG excluded from the branch search window
+# search the acceptor-upstream region; capped so short introns still fit (adaptive)
+MAX_WINDOW = 45
+
+
+@dataclass
+class BranchModel:
+    """A discovered branch model: the per-position motif PWM (``pwm[m][base]``),
+    the intronic background composition, and the motif geometry."""
+
+    pwm: list[dict[str, float]]
+    background: dict[str, float]
+    width: int
+    anchor: int
+    require_anchor: str | None = "A"
+
+
+def branch_windows(
+    models: Iterable[GeneModel],
+    genome: Mapping[str, str],
+    *,
+    max_window: int = MAX_WINDOW,
+    width: int = BRANCH_WIDTH,
+) -> list[str]:
+    """The acceptor-upstream search window of every intron: up to ``max_window``
+    intronic bases ending just before the terminal AG (adaptive — short introns
+    contribute whatever they have). Windows shorter than ``width`` or containing a
+    non-ACGT base are dropped."""
+    out: list[str] = []
+    for m in models:
+        if m.seqid not in genome:
+            continue
+        for iseq in m.intron_seqs(genome):
+            n = len(iseq)
+            if n < width + _AG:
+                continue
+            w = iseq[max(0, n - _AG - max_window) : n - _AG]
+            if len(w) >= width and set(w) <= _ACGT_SET:
+                out.append(w)
+    return out
+
+
+def _background(windows: Sequence[str]) -> dict[str, float]:
+    counts = dict.fromkeys(_ACGT, 0.0)
+    for w in windows:
+        for b in w:
+            counts[b] += 1
+    total = sum(counts.values()) or 1.0
+    return {b: counts[b] / total for b in _ACGT}
+
+
+def _seed_pwm(width: int, anchor: int, background: dict[str, float]) -> list[dict[str, float]]:
+    """Seed every position at the background composition except the anchor, which
+    is set strongly to the invariant branch adenosine (the only universal,
+    non-species-specific prior). EM learns the flanking preferences from the data."""
+    pwm = [dict(background) for _ in range(width)]
+    pwm[anchor] = {"A": 0.94, "C": 0.02, "G": 0.02, "T": 0.02}
+    return pwm
+
+
+def _normalize(counts: dict[str, float]) -> dict[str, float]:
+    total = sum(counts.values()) or 1.0
+    return {b: counts[b] / total for b in _ACGT}
+
+
+def _position_odds(window: str, start: int, pwm: list[dict[str, float]],
+                   background: dict[str, float], width: int) -> float:
+    """Likelihood ratio of the motif starting at ``start`` vs all-background."""
+    odds = 1.0
+    for m in range(width):
+        b = window[start + m]
+        odds *= pwm[m][b] / background[b]
+    return odds
+
+
+def _anchored_starts(window: str, width: int, anchor: int, require: str | None) -> list[int]:
+    """Candidate motif starts. The branch adenosine is the invariant 2'-OH
+    nucleophile, so by default only positions with that base at the anchor slot are
+    considered — without this constraint EM drifts to whatever k-mer is most
+    over-represented (in T/pyrimidine-rich intron 3' ends, a spurious T/G motif)."""
+    starts = range(0, len(window) - width + 1)
+    if require is None:
+        return list(starts)
+    return [j for j in starts if window[j + anchor] == require]
+
+
+_IDX = {"A": 0, "C": 1, "G": 2, "T": 3}
+
+
+def fit_branch_em(
+    windows: Sequence[str],
+    *,
+    width: int = BRANCH_WIDTH,
+    anchor: int = BRANCH_A,
+    require_anchor: str | None = "A",
+    max_iter: int = 40,
+    pseudo: float = 0.1,
+    tol: float = 1e-4,
+    max_fit: int = 5000,
+    seed: int = 0,
+) -> BranchModel:
+    """Fit the branch motif by EM (OOPS). Each iteration: E-step computes, per
+    window, the posterior that the branch sits at each *anchor-consistent* start
+    (odds vs background, normalised over those starts); M-step re-estimates the PWM
+    from the posterior-weighted base counts. The background is fixed at the observed
+    composition. Converges when the PWM stops moving (max abs change < ``tol``).
+
+    ``require_anchor='A'`` (default) restricts candidates to A-anchored positions —
+    the biological invariant that keeps EM on the real branch rather than the most
+    frequent k-mer. Set ``None`` to discover an unconstrained motif. At most
+    ``max_fit`` windows (sampled) are used to fit the PWM; that is ample for a
+    7-column model and bounds the runtime.
+
+    Encodes windows to int arrays and precomputes the anchor-consistent starts once
+    (they don't change across iterations) so the hot loop is plain arithmetic."""
+    usable = [w for w in windows if len(w) >= width and set(w) <= _ACGT_SET]
+    if not usable:
+        raise ValueError("no usable branch windows")
+    background = _background(usable)
+
+    fit = usable
+    if len(usable) > max_fit:
+        import random
+
+        fit = random.Random(seed).sample(usable, max_fit)
+
+    # encode once: each window -> (int-coded bases, list of anchor-consistent starts)
+    a_idx = _IDX.get(require_anchor) if require_anchor is not None else None
+    encoded: list[tuple[list[int], list[int]]] = []
+    for w in fit:
+        codes = [_IDX[b] for b in w]
+        starts = [
+            j for j in range(len(w) - width + 1)
+            if a_idx is None or codes[j + anchor] == a_idx
+        ]
+        if starts:
+            encoded.append((codes, starts))
+
+    bg = [background[b] for b in _ACGT]
+    pwm = [[p[b] for b in _ACGT] for p in _seed_pwm(width, anchor, background)]
+
+    for _ in range(max_iter):
+        ratio = [[pwm[m][b] / bg[b] for b in range(4)] for m in range(width)]
+        counts = [[pseudo] * 4 for _ in range(width)]
+        for codes, starts in encoded:
+            odds = []
+            for j in starts:
+                o = 1.0
+                for m in range(width):
+                    o *= ratio[m][codes[j + m]]
+                odds.append(o)
+            z = sum(odds)
+            if z <= 0:
+                continue
+            for j, o in zip(starts, odds):
+                gamma = o / z
+                for m in range(width):
+                    counts[m][codes[j + m]] += gamma
+        new_pwm = []
+        for col in counts:
+            s = sum(col) or 1.0
+            new_pwm.append([c / s for c in col])
+        delta = max(abs(new_pwm[m][b] - pwm[m][b]) for m in range(width) for b in range(4))
+        pwm = new_pwm
+        if delta < tol:
+            break
+
+    pwm_dicts = [dict(zip(_ACGT, col)) for col in pwm]
+    return BranchModel(pwm_dicts, background, width, anchor, require_anchor)
+
+
+def locate_branch(window: str, model: BranchModel) -> tuple[int, float] | None:
+    """Best (A-anchored) branch start position in ``window`` and its log-odds
+    score, or ``None`` if no anchor-consistent position exists."""
+    import math
+
+    starts = _anchored_starts(window, model.width, model.anchor, model.require_anchor)
+    best_j, best_odds = None, -1.0
+    for j in starts:
+        o = _position_odds(window, j, model.pwm, model.background, model.width)
+        if best_j is None or o > best_odds:
+            best_j, best_odds = j, o
+    if best_j is None:
+        return None
+    return best_j, math.log(best_odds) if best_odds > 0 else float("-inf")
+
+
+def branch_distances(windows: Sequence[str], model: BranchModel) -> list[int]:
+    """Distance (nt) from the located branch adenosine to the 3' splice site, per
+    window. The window ends ``_AG`` nt before the 3'SS, so for a branch starting at
+    ``j`` the branch-A distance is ``len(window) + _AG - (j + anchor)``."""
+    dists = []
+    for w in windows:
+        if len(w) < model.width or not set(w) <= _ACGT_SET:
+            continue
+        hit = locate_branch(w, model)
+        if hit is None:
+            continue
+        j, _ = hit
+        dists.append(len(w) + _AG - (j + model.anchor))
+    return dists
+
+
+@dataclass
+class BranchDistances:
+    """geneid branch-distance knobs estimated from the data: minimum, optimal
+    (penalty-free) and the acceptor-context scan span."""
+
+    acc_context: int
+    min_dist: int
+    opt_dist: int
+
+
+def distance_knobs(distances: Sequence[int], *, offset: int = BRANCH_A) -> BranchDistances:
+    """Set the branch-distance knobs from the observed branch→3'SS distribution:
+    ``opt_dist`` at the median, ``min_dist`` at the 5th percentile, ``acc_context``
+    spanning the 95th (so the scan reaches essentially every real branch). geneid
+    requires ``acc_context - offset - opt_dist > 0``, so ``acc_context`` is floored
+    accordingly."""
+    d = sorted(distances)
+    n = len(d)
+    if n == 0:
+        raise ValueError("no branch distances")
+
+    def pct(p: float) -> int:
+        return d[min(n - 1, max(0, int(p * n)))]
+
+    opt = pct(0.50)
+    lo = max(1, pct(0.05))
+    hi = max(pct(0.95), opt)
+    acc = max(hi + 5, offset + opt + 1)
+    return BranchDistances(acc_context=acc, min_dist=lo, opt_dist=opt)

--- a/training/src/geneid_train/stats/branch.py
+++ b/training/src/geneid_train/stats/branch.py
@@ -267,3 +267,56 @@ def distance_knobs(distances: Sequence[int], *, offset: int = BRANCH_A) -> Branc
     hi = max(pct(0.95), opt)
     acc = max(hi + 5, offset + opt + 1)
     return BranchDistances(acc_context=acc, min_dist=lo, opt_dist=opt)
+
+
+# --- emit the geneid Branch_point_profile ------------------------------------
+#
+# geneid's U2 branch profile header is `len offset cutoff order a b acc_context
+# min_dist opt_dist pen_scale` (readparam ReadProfile). We emit an order-0 log-odds
+# PWM: offset = the branch-A index (so geneid's PositionBP lands on the branch A),
+# order 0, and the distance knobs come from distance_knobs() — set from the data,
+# not searched. The score contribution is governed separately by the param scalar
+# Branch_point_score_weight (see geneid BuildAcceptors.c); default 0 = the branch
+# is scored and reported (bp_score/bp_pos) without affecting splice-site selection.
+
+BRANCH_CUTOFF = -20.0  # permissive: let the branch always be located/reported
+BRANCH_PEN_SCALE = 6  # quadratic distance-penalty scale (geneid default)
+
+
+def _fmt(v: float) -> str:
+    return str(int(v)) if v == int(v) else f"{v:g}"
+
+
+def branch_profile_lines(
+    model: BranchModel,
+    knobs: BranchDistances,
+    *,
+    cutoff: float = BRANCH_CUTOFF,
+    pen_scale: int = BRANCH_PEN_SCALE,
+) -> list[str]:
+    """geneid ``Branch_point_profile`` data lines: the header then per-position
+    ``pos base log-odds`` rows (order-0 log-ratio of the motif PWM vs background)."""
+    import math
+
+    header = [
+        model.width, model.anchor, cutoff, 0, 0, 1,
+        knobs.acc_context, knobs.min_dist, knobs.opt_dist, pen_scale,
+    ]
+    lines = [" ".join(_fmt(float(x)) for x in header),
+             "# Transition probabilities at every position"]
+    for pos in range(model.width):
+        for base in _ACGT:
+            lo = math.log(model.pwm[pos][base] / model.background[base])
+            lines.append(f"{pos + 1} {base} {_fmt(round(lo, 6))}")
+    return lines
+
+
+def branch_profile_section(model: BranchModel, knobs: BranchDistances, **kw) -> str:
+    """The full ``Branch_point_profile`` section text, ready to splice in before
+    ``Acceptor_profile`` (via :meth:`Param.insert_text_before`)."""
+    return "Branch_point_profile\n" + "\n".join(branch_profile_lines(model, knobs, **kw)) + "\n"
+
+
+def branch_weight_scalar(weight: float) -> str:
+    """The optional ``Branch_point_score_weight`` scalar section (0 = report-only)."""
+    return f"Branch_point_score_weight\n{_fmt(weight)}\n"

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -95,6 +95,8 @@ def train(
     background: tuple[Matrix, Matrix] | None = None,
     seed: int = 0,
     u12: bool = False,
+    u2_branch: bool = False,
+    branch_weight: float = 0.0,
 ) -> str:
     """Train a geneid parameter file from complete, filtered gene ``models``.
 
@@ -106,6 +108,12 @@ def train(
     trio is spliced in, so geneid can predict U12-type introns (run with ``-U``).
     A single genome rarely has enough U12 introns to train these, so they are
     IAOD-derived and shipped with the package (see ``param.u12``).
+
+    When ``u2_branch`` is set, a U2 ``Branch_point_profile`` is discovered from the
+    genome's own introns by EM (``stats.branch``), its distance knobs set from the
+    observed branch positions, and spliced in with ``Branch_point_score_weight``
+    (default 0 = the branch is scored and reported, ``bp_score``/``bp_pos``, without
+    contributing to splice-site selection).
     """
     if not models:
         raise ValueError("no gene models to train on")
@@ -150,7 +158,7 @@ def train(
 
         u12_sections = load_bundled_u12()
 
-    return assemble_param(
+    param_text = assemble_param(
         species=species,
         start_profile=start_lines,
         acceptor_profile=acceptor_lines,
@@ -162,3 +170,35 @@ def train(
         intergenic_range="200:Infinity",
         u12=u12_sections,
     )
+
+    if u2_branch:
+        param_text = _add_u2_branch(param_text, models, genome, branch_weight)
+
+    return param_text
+
+
+def _add_u2_branch(
+    param_text: str, models: Sequence[GeneModel], genome: Mapping[str, str], weight: float
+) -> str:
+    """Discover the U2 branch point (EM), then splice its Branch_point_profile +
+    score-weight scalar into an assembled param."""
+    from .core.param import Param
+    from .stats.branch import (
+        branch_distances,
+        branch_profile_section,
+        branch_weight_scalar,
+        branch_windows,
+        distance_knobs,
+        fit_branch_em,
+    )
+
+    windows = branch_windows(models, genome)
+    if not windows:
+        return param_text
+    model = fit_branch_em(windows)
+    knobs = distance_knobs(branch_distances(windows, model), offset=model.anchor)
+
+    p = Param.from_text(param_text)
+    p.insert_text_before("Acceptor_profile", branch_profile_section(model, knobs))
+    p.insert_text_before("Exon_weights", branch_weight_scalar(weight))
+    return p.to_text()

--- a/training/tests/test_branch.py
+++ b/training/tests/test_branch.py
@@ -1,0 +1,72 @@
+import random
+
+from geneid_train.prepare.base import Exon, GeneModel
+from geneid_train.stats.branch import (
+    BRANCH_A,
+    branch_distances,
+    branch_windows,
+    distance_knobs,
+    fit_branch_em,
+    locate_branch,
+)
+
+
+def _planted(n=400, motif="TACTAAC", dist_from_end=20, seed=0):
+    """n random windows each with `motif` planted at a fixed distance from the 3' end."""
+    rng = random.Random(seed)
+    wins = []
+    for _ in range(n):
+        length = rng.randint(35, 45)
+        bases = [rng.choice("ACGT") for _ in range(length)]
+        start = length - dist_from_end
+        bases[start : start + len(motif)] = list(motif)
+        wins.append("".join(bases))
+    return wins
+
+
+def test_em_recovers_planted_motif():
+    wins = _planted(motif="TACTAAC")
+    model = fit_branch_em(wins, width=7)
+    # the per-position argmax base should spell the planted motif
+    consensus = "".join(max("ACGT", key=lambda b: pos[b]) for pos in model.pwm)
+    assert consensus == "TACTAAC"
+    # the branch adenosine column is (nearly) invariant A
+    assert model.pwm[BRANCH_A]["A"] > 0.9
+
+
+def test_locate_branch_finds_the_plant():
+    wins = _planted(n=50, motif="TACTAAC", dist_from_end=20)
+    model = fit_branch_em(wins, width=7)
+    j, score = locate_branch(wins[0], model)
+    # motif planted at length-20; its start index is where locate should land
+    assert wins[0][j : j + 7] == "TACTAAC"
+    assert score > 0
+
+
+def test_distances_cluster_at_the_plant():
+    # motif at a fixed distance -> branch-A distance clusters at that value + anchor offset
+    wins = _planted(n=200, motif="TACTAAC", dist_from_end=20)
+    model = fit_branch_em(wins, width=7)
+    dists = branch_distances(wins, model)
+    # branch A is BRANCH_A into the motif; motif start is 20 from window end, plus _AG(2)
+    # to the 3'SS -> branch-A distance = (20 - BRANCH_A) + 2
+    expected = (20 - BRANCH_A) + 2
+    mode = max(set(dists), key=dists.count)
+    assert mode == expected
+    knobs = distance_knobs(dists)
+    assert knobs.min_dist <= knobs.opt_dist <= knobs.acc_context
+    assert knobs.opt_dist == expected
+
+
+def test_branch_windows_excludes_ag_and_is_adaptive():
+    # intron: donor GT ... branch region ... acceptor AG
+    intron = "GT" + "C" * 30 + "TACTAAC" + "CCCC" + "AG"
+    exon = "AAAAAA"
+    genome = {"c": exon + intron + exon}
+    a2 = 6 + len(intron) + 1
+    m = GeneModel("g", "c", "+", [Exon(1, 6), Exon(a2, a2 + 5)])
+    wins = branch_windows([m], genome, max_window=45)
+    assert len(wins) == 1
+    # the terminal AG is excluded; the branch motif is inside the window
+    assert not wins[0].endswith("AG")
+    assert "TACTAAC" in wins[0]

--- a/training/tests/test_branch.py
+++ b/training/tests/test_branch.py
@@ -58,6 +58,30 @@ def test_distances_cluster_at_the_plant():
     assert knobs.opt_dist == expected
 
 
+def test_branch_profile_emission_format():
+    from geneid_train.stats.branch import (
+        BranchDistances,
+        branch_profile_lines,
+        branch_profile_section,
+        branch_weight_scalar,
+    )
+
+    wins = _planted(n=100, motif="TACTAAC")
+    model = fit_branch_em(wins, width=7)
+    knobs = BranchDistances(acc_context=46, min_dist=5, opt_dist=27)
+    lines = branch_profile_lines(model, knobs)
+    # header: len offset cutoff order a b acc_context min_dist opt_dist pen_scale
+    assert lines[0].split() == ["7", "5", "-20", "0", "0", "1", "46", "5", "27", "6"]
+    assert lines[1].startswith("#")
+    rows = {(int(p), b): float(v) for p, b, v in (ln.split() for ln in lines[2:])}
+    assert len(rows) == 7 * 4  # every position x base
+    # the invariant branch-A column is strongly positive (log-odds of A >> others)
+    assert rows[(6, "A")] > rows[(6, "C")] and rows[(6, "A")] > rows[(6, "G")]
+    # section + scalar wrappers
+    assert branch_profile_section(model, knobs).startswith("Branch_point_profile\n")
+    assert branch_weight_scalar(0) == "Branch_point_score_weight\n0\n"
+
+
 def test_branch_windows_excludes_ag_and_is_adaptive():
     # intron: donor GT ... branch region ... acceptor AG
     intron = "GT" + "C" * 30 + "TACTAAC" + "CCCC" + "AG"


### PR DESCRIPTION
Automates U2 branch-point (+ future PPT) support that used to be hand-built with MEME, and adds a geneid param option so the branch can be scored and reported without affecting predictions. Base: `dev`.

## What's here

**1. DESIGN §8** — the plan: a self-supervised EM branch finder trained on each genome's own introns, seeded only from the universal invariant branch adenosine (not BPP's human-tuned weights/offsets, which misfire on short/non-human introns).

**2. `stats/branch.py` — EM branch discovery.** Fits a two-component OOPS mixture (branch-motif PWM vs intronic background) to the acceptor-upstream region by EM. The branch A is anchor-constrained (`require_anchor='A'`) — without it EM drifts to the most frequent k-mer (a spurious T/G motif in pyrimidine-rich intron tails). Int-encoded windows + precomputed anchored starts + a fit-sample cap bring a fit on ~10k snail introns from ~17 min to ~3 s. The per-intron branch positions set the geneid distance knobs (`opt/min/acc_context`) directly from data, not by search. On xgXerMont: consensus `TTTTAAT` (a degenerate metazoan branch, as expected), branch distance median 27 nt.

**3. geneid `Branch_point_score_weight` param option (C).** Optional param scalar (default 1, backward-compatible) weighting the branch score's contribution to the acceptor score in `BuildAcceptors.c` (`score += BRANCH_SCORE_WEIGHT * scoreBP`). Set it to 0 and the branch is scored and reported (`bp_score`/`bp_pos`, alongside the existing `acceptor_profile_score` = acceptor without the branch) but does not affect splice-site selection — the informational use case. `ScoreBP` is still stored unweighted so reporting is unaffected. Verified: weight 0 vs 1 changes multi-exon predictions (21 vs 19 genes), single-exon unaffected.

**4. Emit + `train --u2-branch`.** Renders the discovered model as a geneid `Branch_point_profile` (order-0 log-odds; offset = the branch-A index so `bp_pos` lands on the branch A; data-driven distance knobs) plus the weight scalar, spliced in before `Acceptor_profile` / `Exon_weights`. `--branch-weight` (default 0) sets the contribution.

## Validation
End-to-end against the feature geneid: `train --u2-branch` on real snail models yields a param geneid loads with BranchPoint active; at weight 0 the intron GFF shows `acceptor_score == acceptor_profile_score` (zero contribution) with `bp_score`/`bp_pos` reported, `bp_pos` ~-25..-33 matching the data-driven `opt_dist` 27. 131 tests pass, ruff clean.

## Deferred (optional)
- Accuracy-gated toggle / weight optimization (default 0 is already report-only).
- PPT (`Poly_Pyrimidine_Tract_profile`) — separate, weak in fungi.
- Stronger validation on a characterized-branch (fungal) genome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)