### PR TITLE
geneid-train: skew-robust gene-model max intron (p99.9, not mean+3sd)

### DIFF
--- a/training/src/geneid_train/stats/genemodel.py
+++ b/training/src/geneid_train/stats/genemodel.py
@@ -7,16 +7,21 @@ connections, the intergenic range gates gene-to-gene connections.
 
 from __future__ import annotations
 
-import math
 from collections.abc import Sequence
 
 
-def _mean_sd(values: Sequence[float]) -> tuple[float, float]:
-    """Mean and *population* standard deviation (matches geneidCEGMA::average)."""
-    n = len(values)
-    mean = sum(values) / n
-    var = sum((v - mean) ** 2 for v in values) / n
-    return mean, math.sqrt(var)
+def _percentile(values: Sequence[float], q: float) -> float:
+    """The ``q`` quantile (0..1) by linear interpolation between order statistics."""
+    s = sorted(values)
+    n = len(s)
+    if n == 1:
+        return float(s[0])
+    idx = q * (n - 1)
+    lo = int(idx)
+    frac = idx - lo
+    if lo + 1 < n:
+        return s[lo] + frac * (s[lo + 1] - s[lo])
+    return float(s[lo])
 
 
 def intron_range(
@@ -24,19 +29,23 @@ def intron_range(
     *,
     short_cap: int = 40,
     long_cap: int = 100_000,
+    max_quantile: float = 0.999,
 ) -> tuple[float, float]:
     """Return ``(min_intron, max_intron)`` for the gene model.
 
-    ``min = 0.75 * shortest_intron`` capped at ``short_cap`` (40); ``max =
-    mean + 3*sd`` capped at ``long_cap`` (100000) — the legacy WriteStatsFile
-    heuristic.
+    ``min = 0.75 * shortest_intron`` capped at ``short_cap`` (40). ``max`` is the
+    ``max_quantile`` (default p99.9) of the intron lengths, capped at ``long_cap``
+    (100000). Intron lengths are strongly right-skewed, so the legacy
+    ``mean + 3*sd`` heuristic clips a real long tail (e.g. ~1.8% of introns on
+    xgXerMont) — and geneid cannot span an intron longer than this max, so a too-low
+    value fragments long-intron genes into separate models. A high percentile spans
+    essentially all real introns while staying under the safety cap.
     """
     shortest = min(intron_lengths)
     lo = shortest * 0.75
     if lo > short_cap:
         lo = float(short_cap)
-    mean, sd = _mean_sd(list(intron_lengths))
-    hi = mean + 3 * sd
+    hi = _percentile(list(intron_lengths), max_quantile)
     if hi > long_cap:
         hi = float(long_cap)
     return lo, hi

--- a/training/tests/test_genemodel.py
+++ b/training/tests/test_genemodel.py
@@ -24,13 +24,25 @@ def test_format_range():
 REF = ref_dir()
 
 
+def test_intron_range_max_is_p999_skew_robust():
+    # a right-skewed set: bulk small + a long tail. mean+3sd would sit far above
+    # the bulk; p99.9 tracks the actual tail and excludes ~0.1%.
+    lens = [1000] * 999 + [90000]
+    lo, hi = intron_range(lens)
+    over = sum(1 for x in lens if x > hi)
+    assert over <= 1  # at most the top ~0.1% excluded
+    assert hi <= 100_000
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(REF is None, reason="set GENEID_TRAIN_REFDIR to the train_geneid dir")
-def test_intron_range_matches_reference():
+def test_intron_range_reference_spans_long_tail():
     name = "Xerocrassa_montserratensis.train.intron.tbl"
     lens = [len(ln.split("\t")[1].strip()) for ln in open(REF / name)]
     lo, hi = intron_range(lens)
-    # reference gene model uses 24.75:25394.023; lo is exact, hi matches to <1 bp
-    # (the last-decimal difference is float-printing noise on a coarse bound)
     assert lo == 24.75
-    assert abs(hi - 25394.023) < 1.0
+    # the p99.9 max spans the skewed long tail -> well above the legacy mean+3sd
+    # (~25394) that clipped ~1.8% of real introns, and under the 100 kb safety cap
+    assert hi > 25394
+    assert hi <= 100_000
+    assert sum(1 for x in lens if x > hi) <= len(lens) // 1000 + 1


### PR DESCRIPTION
Makes the trained gene-model **max intron length** skew-robust.

## Problem
`intron_range` set the max intron to **mean + 3·sd** (the legacy `WriteStatsFile` heuristic). Intron lengths are strongly right-skewed, so that formula clips a real long tail. On xgXerMont the training introns are median ~2.2 kb but reach ~100 kb, and **~1.8% exceed the mean+3sd cap (~25 kb)**. geneid cannot span an intron longer than the gene-model max, so every gene with a >cap intron is **fragmented into separate models** — a real over-prediction contributor.

## Fix
Use the **p99.9 percentile** of the intron lengths as the max (capped at the 100 kb safety bound), so the range spans essentially all real introns while excluding only the extreme 0.1% tail. The min logic is unchanged.

## Effect (full xgXerMont annotation, masked assembly)
- Gene-model max intron: 25,179 → **85,301** (p99.9).
- **4,686** introns >25 kb are now spannable instead of forcing a split.
- Raw ab-initio gene count: **132,913 → 130,588** (−2,325). A modest but real reduction (the dominant over-prediction drivers remain unmasked TEs and generic ab-initio calls — tracked separately).

Tests updated; 132 pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)