### PR TITLE
geneid-train: emit U12 score thresholds (fix U12 over-calling)

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -235,6 +235,7 @@ def _cmd_train(args: argparse.Namespace) -> int:
     try:
         param_text = train(
             models, genome, args.species, seed=args.seed, u12=args.u12,
+            u12_splice_thresh=args.u12_splice_thresh, u12_exon_thresh=args.u12_exon_thresh,
             u2_branch=args.u2_branch, branch_weight=args.branch_weight,
         )
     except NotImplementedError as exc:
@@ -323,6 +324,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--u12",
         action="store_true",
         help="include bundled U12 (minor-spliceosome) profiles so geneid -U predicts U12 introns",
+    )
+    p_train.add_argument(
+        "--u12-splice-thresh", type=float, default=9.0,
+        help="U12_Splice_Score_Threshold: min combined U12 donor+acceptor score to accept a "
+             "U12 join (default 9, conservative; reference U12 params; lower over-calls U12)",
+    )
+    p_train.add_argument(
+        "--u12-exon-thresh", type=float, default=8.0,
+        help="U12_Exon_Score_Threshold: min combined exon score for a U12 join (default 8)",
     )
     p_train.add_argument(
         "--u2-branch",

--- a/training/src/geneid_train/param/assemble.py
+++ b/training/src/geneid_train/param/assemble.py
@@ -39,13 +39,22 @@ def assemble_param(
     intergenic_range: str,
     template: str | None = None,
     u12: U12Sections | None = None,
+    u12_splice_thresh: float = 9.0,
+    u12_exon_thresh: float = 8.0,
 ) -> str:
     """Build a full geneid param. Profile/Markov args are geneid-format data
     lines (from ``stats.sites.format_profile`` / ``stats.coding.format_markov_matrix``);
     ``intron_range``/``intergenic_range`` are ``min:max`` tokens.
 
     When ``u12`` is given, the minor-spliceosome profile trio is spliced in before
-    the required acceptor/donor profiles so geneid enables U12 splice prediction.
+    the required acceptor/donor profiles so geneid enables U12 splice prediction,
+    and the ``U12_Splice_Score_Threshold`` / ``U12_Exon_Score_Threshold`` gates are
+    emitted. Those thresholds are essential: without them geneid uses its −1000
+    default, which accepts almost any GT-AG intron as U12 (≈6.5% mislabeled on
+    xgXerMont vs a plausible <0.5%). The default (9, human value; drosophila uses
+    10) is deliberately conservative — U12 is hard to train without a large
+    genome-specific set, so we favour precision and let homology/RNA-seq recover
+    false negatives later. A SUPER_1 sweep: threshold 8→0.41%, 9≈0.1-0.2%, 10→0.03%.
     """
     p = Param.from_text(template if template is not None else load_template())
 
@@ -63,6 +72,13 @@ def assemble_param(
         # required Acceptor_profile / Donor_profile — see ReadProfileSpliceSites)
         p.insert_text_before("Acceptor_profile", u12.acceptor_side)
         p.insert_text_before("Donor_profile", u12.donor_side)
+        # the U12 acceptance-score gates (read in the optional-scalar block before
+        # Exon_weights) — without them geneid mass-mislabels U2 GT-AG as U12
+        p.insert_text_before(
+            "Exon_weights",
+            f"U12_Splice_Score_Threshold\n{u12_splice_thresh:g}\n"
+            f"U12_Exon_Score_Threshold\n{u12_exon_thresh:g}\n",
+        )
 
     text = p.to_text()
     text = text.replace("@INTRON_RANGE@", intron_range)

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -95,6 +95,8 @@ def train(
     background: tuple[Matrix, Matrix] | None = None,
     seed: int = 0,
     u12: bool = False,
+    u12_splice_thresh: float = 9.0,
+    u12_exon_thresh: float = 8.0,
     u2_branch: bool = False,
     branch_weight: float = 0.0,
 ) -> str:
@@ -169,6 +171,8 @@ def train(
         intron_range=format_range(lo, hi),
         intergenic_range="200:Infinity",
         u12=u12_sections,
+        u12_splice_thresh=u12_splice_thresh,
+        u12_exon_thresh=u12_exon_thresh,
     )
 
     if u2_branch:

--- a/training/tests/test_u12_param.py
+++ b/training/tests/test_u12_param.py
@@ -72,6 +72,35 @@ def test_partition_routes_by_profile_name():
     assert "U12gtag_Donor_profile" in DONOR_SIDE  # routing set drives partition
 
 
+def test_assemble_emits_u12_score_thresholds_before_exon_weights():
+    from geneid_train.param.assemble import assemble_param
+
+    stub = ["1 A 0"]
+    txt = assemble_param(
+        species="X", start_profile=stub, acceptor_profile=stub, donor_profile=stub,
+        markov_order=1, markov_initial=stub, markov_transition=stub,
+        intron_range="40:80000", intergenic_range="200:Infinity",
+        u12=load_bundled_u12(),  # defaults: splice 9, exon 8
+    )
+    lines = txt.splitlines()
+    assert lines[lines.index("U12_Splice_Score_Threshold") + 1] == "9"
+    assert lines[lines.index("U12_Exon_Score_Threshold") + 1] == "8"
+    # geneid reads these gates in the optional-scalar block before Exon_weights
+    assert txt.index("U12_Splice_Score_Threshold") < txt.index("Exon_weights")
+
+
+def test_no_u12_thresholds_when_u12_absent():
+    from geneid_train.param.assemble import assemble_param
+
+    stub = ["1 A 0"]
+    txt = assemble_param(
+        species="X", start_profile=stub, acceptor_profile=stub, donor_profile=stub,
+        markov_order=1, markov_initial=stub, markov_transition=stub,
+        intron_range="40:80000", intergenic_range="200:Infinity",
+    )
+    assert "U12_Splice_Score_Threshold" not in txt
+
+
 def test_bundled_u12_loads_and_has_full_trio():
     sec = load_bundled_u12()
     acc_names = ("U12_Branch_point_profile", "U12gtag_Acceptor_profile", "U12atac_Acceptor_profile")


### PR DESCRIPTION
Fixes geneid mass-mislabeling U2 GT-AG introns as U12. Base: `dev`.

## Problem
`train --u12` emitted the U12 donor/acceptor/branch profiles but **not** the U12 acceptance-score gates (`U12_Splice_Score_Threshold` / `U12_Exon_Score_Threshold`), so geneid used its `-1000` default (accept almost anything). Result on the full xgXerMont annotation: **6.5% of introns called U12** — ~90× more than a plausible minor-spliceosome rate. The gate is `(U12 donor + U12 acceptor score) > threshold` in genamic.c.

## Fix
`assemble_param` now emits both gates whenever U12 is included, defaulting to **splice 9 / exon 8** — the conservative human splice value (drosophila uses 10). Overridable via `--u12-splice-thresh` / `--u12-exon-thresh`.

U12 is hard to train de novo without a large genome-specific set, so the default favours **precision over recall**; false negatives are better recovered later with homology / RNA-seq evidence.

## Calibration (xgXerMont SUPER_1, 148 Mb)
U12gtag call rate vs `U12_Splice_Score_Threshold`:

| threshold | U12 % |
|---|---|
| −1000 (old default) | 6.50 |
| 4 | 4.84 |
| 6 | 2.15 |
| 8 | 0.41 |
| 9 (new default) | ~0.1–0.2 |
| 10 | 0.03 |
| 12 | 0.00 |

134 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)