### PR TITLE
Use GENEID_RELEASE in the run banner (drop hardcoded 'geneid 1.4 2003')

### DIFF
--- a/src/geneid.c
+++ b/src/geneid.c
@@ -218,7 +218,7 @@ int main (int argc, char *argv[])
   
   /* 0.c. Read setup options */
   readargv(argc,argv,ParamFile,SequenceFile,ExonsFile,HSPFile,GenePrefix);
-  printRes("\n\n\t\t\t** Running geneid 1.4 2003 geneid@crg.es **\n\n");
+  printRes("\n\n\t\t\t** Running " GENEID_RELEASE " geneid@crg.es **\n\n");
 
   /* 0.d. Prediction of DNA sequence length to request memory */
   LengthSequence = analizeFile(SequenceFile);


### PR DESCRIPTION
The startup banner printed a stale hardcoded `** Running geneid 1.4 2003 geneid@crg.es **`. Drive it from the `GENEID_RELEASE` macro (the human-facing release string) via compile-time string-literal concatenation, so it now prints `** Running geneid v1.5.2 geneid@crg.es **` and tracks the version automatically.

`GENEID_RELEASE` (not `VERSION`) is correct here: `VERSION`/`SITES`/`EXONS` are the GFF source-column tags (minor version), while `GENEID_RELEASE` is the human-facing patch-level release string meant for the banner/credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)