### PR TITLE
Remove embedded version strings from source comments (+ CVS $Id relics)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Definitions, data structures types and imported headers              *
 *                                                                        *
-*   This file is part of the geneid 1.2 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2003 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -28,7 +28,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/     
 
-/* $Id: geneid.h,v 1.54 2010/11/25 20:48:06 talioto Exp $ */
 
 /* Required libraries */
 #include <stdlib.h>

--- a/src/BackupGenes.c
+++ b/src/BackupGenes.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   To save best partial genes between 2 contigous fragments             *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BackupGenes.c,v 1.11 2011-01-13 11:06:16 talioto Exp $  */
 
 /* geneid processes a long sequence one LENGTHSi-sized fragment at a time
  * (see manager.c/geneid.c), but genamic's DP state (packGenes: Ga/d/km/je,

--- a/src/BuildAcceptors.c
+++ b/src/BuildAcceptors.c
@@ -5,7 +5,7 @@
 *   Signal prediction by using a Position Weighted Array                 *
 *   using branch point or Poly Pyrimidine Tract profiles, if provided    *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/BuildDonors.c
+++ b/src/BuildDonors.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Signal prediction by using a Position Weighted Array                 *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildDonors.c,v 1.7 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildInitialExons.c
+++ b/src/BuildInitialExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   From start/stop codons and donor sites, to build initial exons       *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildInitialExons.c,v 1.10 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildInternalExons.c
+++ b/src/BuildInternalExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   From acceptor/donor sites and stop codons, to build internal exons   *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildInternalExons.c,v 1.11 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildORFs.c
+++ b/src/BuildORFs.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   From start and stop codons, to build ORFs                            *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildORFs.c,v 1.5 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildSingles.c
+++ b/src/BuildSingles.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   From start and stop codons, to build single gene exons               *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildSingles.c,v 1.6 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildSort.c
+++ b/src/BuildSort.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Sorting exons by donor position according to every class properties  *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildSort.c,v 1.6 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildTerminalExons.c
+++ b/src/BuildTerminalExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   From acceptor sites and stop codons, to build initial exons          *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildTerminalExons.c,v 1.9 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildU12Acceptors.c
+++ b/src/BuildU12Acceptors.c
@@ -5,7 +5,7 @@
 *   Signal prediction by using a Position Weighted Array                 *
 *   using U12 branch point                                               *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/BuildUTRExons.c
+++ b/src/BuildUTRExons.c
@@ -4,7 +4,7 @@
  *                                                                        *
  *   From start/stop codons and donor sites, to build initial exons       *
  *                                                                        *
- *   This file is part of the geneid 1.4 distribution                     *
+ *   This file is part of the geneid distribution                         *
  *                                                                        *
  *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
  *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
  *************************************************************************/
 
-/*  $Id: BuildUTRExons.c,v 1.3 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/BuildZeroLengthExons.c
+++ b/src/BuildZeroLengthExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   From acceptor/donor sites and stop codons, to build internal exons   *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: BuildZeroLengthExons.c,v 1.2 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/ComputeStopInfo.c
+++ b/src/ComputeStopInfo.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Store information to avoid prediction of stops in coding frame       *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/* $Id: ComputeStopInfo.c,v 1.4 2011-01-13 11:06:16 talioto Exp $ */
 
 #include "geneid.h"
 

--- a/src/CookingGenes.c
+++ b/src/CookingGenes.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Processing best gene to print by using the selected format           *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: CookingGenes.c,v 1.31 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/CorrectExon.c
+++ b/src/CorrectExon.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Recompute exon limits according to its type                          *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: CorrectExon.c,v 1.8 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/Dictionary.c
+++ b/src/Dictionary.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Implementation of a look-up table by using hash tables               *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: Dictionary.c,v 1.9 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/DumpHash.c
+++ b/src/DumpHash.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Hash table of exons used during backup of genes                      *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: DumpHash.c,v 1.9 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/FetchSequence.c
+++ b/src/FetchSequence.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Reverse and complement DNA sequences (upper and lower case)          *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: FetchSequence.c,v 1.5 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/GetSitesWithProfile.c
+++ b/src/GetSitesWithProfile.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Signal prediction by using a Position Weighted Array                 *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: GetSitesWithProfile.c,v 1.11 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/GetStopCodons.c
+++ b/src/GetStopCodons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Stop codons prediction by using Position Weighted arrays             *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: GetStopCodons.c,v 1.10 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/GetTranscriptTermini-usingslopes.c
+++ b/src/GetTranscriptTermini-usingslopes.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Stop codons prediction by using Position Weighted arrays             *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: GetTranscriptTermini-usingslopes.c,v 1.3 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/Output.c
+++ b/src/Output.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Management: displaying results                                       *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: Output.c,v 1.20 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 extern int U12GTAG;

--- a/src/PeakEdgeScore.c
+++ b/src/PeakEdgeScore.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Signal prediction by using a Position Weighted Array                 *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/PrintExons.c
+++ b/src/PrintExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Formatted printing of predicted exons                                *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: PrintExons.c,v 1.27 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/PrintSites.c
+++ b/src/PrintSites.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Print predicted signals (motif, score and position)                  *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: PrintSites.c,v 1.15 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/ProcessHSPs.c
+++ b/src/ProcessHSPs.c
@@ -3,7 +3,7 @@
 *   Module: ProcessHSPs                                                  *
 *                                                                        *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/ReadExonsGFF.c
+++ b/src/ReadExonsGFF.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Reading exons (GFF format) from file                                 *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: ReadExonsGFF.c,v 1.14 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 extern float EvidenceEW;

--- a/src/ReadGeneModel.c
+++ b/src/ReadGeneModel.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Reading the rules used to assemble best predicted genes              *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: ReadGeneModel.c,v 1.9 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/ReadHSP.c
+++ b/src/ReadHSP.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Loading High-score Segment Pairs (protein alignment) in GFF format   *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: ReadHSP.c,v 1.6 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/ReadSequence.c
+++ b/src/ReadSequence.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Reading input sequences of DNA in fasta format                       *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: ReadSequence.c,v 1.8 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/RecomputePositions.c
+++ b/src/RecomputePositions.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Predicted signals in RVS: translation into FWD sense positions       *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: RecomputePositions.c,v 1.7 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Asking operating system for memory for geneid data structures        *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: RequestMemory.c,v 1.19 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/ScoreExons.c
+++ b/src/ScoreExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Score(exon) = reliability measure about coding potential regions     *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/SearchEvidenceExons.c
+++ b/src/SearchEvidenceExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Extracting evidence exons between (l1, l2) for the current split     *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: SearchEvidenceExons.c,v 1.10 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/SetRatios.c
+++ b/src/SetRatios.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Stablish maximum allowed number of signals and exons per split       *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/SortExons.c
+++ b/src/SortExons.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Sort by left signal position all of predicted exons                  *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: SortExons.c,v 1.18 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/SortHSPs.c
+++ b/src/SortHSPs.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Sort by position Pos1 the input HSP list                             *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/SortSites.c
+++ b/src/SortSites.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Sort by position all of predicted sites                              *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *

--- a/src/SwitchFrames.c
+++ b/src/SwitchFrames.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Exchange frame and remainder from reverse exons                      *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: SwitchFrames.c,v 1.9 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/SwitchPositions.c
+++ b/src/SwitchPositions.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Exchanging left and right signals in reverse sense exons             *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: SwitchPositions.c,v 1.8 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/Translate.c
+++ b/src/Translate.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Translate genomic sequences into protein products (amino acids)      *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: Translate.c,v 1.15 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/account.c
+++ b/src/account.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Accounting: results and run-time stats                               *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: account.c,v 1.8 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/beggar.c
+++ b/src/beggar.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Estimate the memory needed to run geneid (current configuration)     *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: beggar.c,v 1.7 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/genamic.c
+++ b/src/genamic.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Assembling genes from the input set of exons                         *
 *                                                                        *
-*   This file is part of the geneid 1.4 Distribution                     *
+*   This file is part of the geneid Distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: genamic.c,v 1.20 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   geneid main program                                                  *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -29,7 +29,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/* $Id: geneid.c,v 1.27 2011-01-13 11:06:16 talioto Exp $ */
 
 #include "geneid.h"
 /* #include <mcheck.h> */

--- a/src/manager.c
+++ b/src/manager.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Management of prediction actions: signals, exons and scores          *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/* $Id: manager.c,v 1.15 2011-01-13 11:06:16 talioto Exp $ */
 
 #include "geneid.h"
 

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Read set up options and filenames from user input                    *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: readargv.c,v 1.23 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 

--- a/src/readparam.c
+++ b/src/readparam.c
@@ -4,7 +4,7 @@
 *                                                                        *
 *   Reading statistic parameters and gene construction model             *
 *                                                                        *
-*   This file is part of the geneid 1.4 distribution                     *
+*   This file is part of the geneid distribution                         *
 *                                                                        *
 *     Copyright (C) 2006 - Enrique BLANCO GARCIA                         *
 *                          Roderic GUIGO SERRA                           *
@@ -25,7 +25,6 @@
 *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.             *
 *************************************************************************/
 
-/*  $Id: readparam.c,v 1.17 2011-01-13 11:06:16 talioto Exp $  */
 
 #include "geneid.h"
 


### PR DESCRIPTION
Version numbers were embedded in per-file header comments (`part of the geneid 1.4 distribution` — inconsistently 1.2/1.4 and stale vs the current release), and 41 files carried frozen CVS `$Id: … Exp $` keyword lines from 2011. Embedded versions can only ever drift and are a recurring maintenance burden.

This drops the version from the header comment (`part of the geneid distribution`) and deletes the CVS `$Id` lines across 49 files. The single source of truth for the version is now `GENEID_RELEASE` (geneid.h) + git tags; git already tracks per-file history far better than frozen keyword strings.

Comments-only, no behaviour change, comment-box alignment preserved (4-space compensation), builds clean. Pairs with #42 (banner now uses `GENEID_RELEASE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)