### PR TITLE
geneid: soft intron-length model — Stage 0+1 (trainer emits, geneid reads)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -362,6 +362,13 @@ A. DEFINITIONS
    score (0 = report-only; default 1) */
 #define sBRANCH_SCORE_WEIGHT "Branch_point_score_weight"
 
+/* Optional soft intron-length model: a log-normal (mu,sigma) over ln(intron
+   length), and the weight (lambda) on the smooth length-dependent penalty it
+   drives in genamic. lambda default 0 = off (backward compatible), so the model
+   can be carried in a param yet stay inert until it is turned on. */
+#define sINTRON_LENGTH_MODEL "Intron_length_model"
+#define sINTRON_LENGTH_WEIGHT "Intron_length_score_weight"
+
 /* Header evidence factor and weight */
 #define sEVIDENCEF "Evidence_Factor"
 #define sEVIDENCEW "Evidence_Exon_Weight"

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -115,6 +115,15 @@ float U12_EXON_SCORE_THRESH = -1000;
    bp_pos in the GFF) without contributing to the splice-site score. */
 float BRANCH_SCORE_WEIGHT = 1;
 
+/* Soft intron-length model (log-normal over ln(intron length)) emitted by
+   geneid-train, plus the weight (lambda) on the smooth length-dependent penalty
+   it drives on intron-spanning joins in genamic -- a soft replacement for the
+   hard gene-model max distance. lambda default 0 leaves the penalty OFF, so the
+   mu/sigma below are inert unless a param sets Intron_length_score_weight > 0. */
+float INTRON_LENGTH_MU = 0;
+float INTRON_LENGTH_SIGMA = 0;
+float INTRON_LENGTH_WEIGHT = 0;
+
 /* Detection of recursive splice sites */
 float RSSMARKOVSCORE = 0;
 float RSSDON = RDT;

--- a/src/readparam.c
+++ b/src/readparam.c
@@ -42,6 +42,9 @@ extern int PAS;
 extern int BKGD_SUBTRACT_FLANK_LENGTH;
 extern short SPLICECLASSES;
 extern float BRANCH_SCORE_WEIGHT;
+extern float INTRON_LENGTH_MU;
+extern float INTRON_LENGTH_SIGMA;
+extern float INTRON_LENGTH_WEIGHT;
 extern float U12_SPLICE_SCORE_THRESH;
 extern float U12_EXON_SCORE_THRESH;
 extern float U12EW;
@@ -787,6 +790,29 @@ void ReadIsochore(FILE* RootFile, gparam* gp)
 
 		  sprintf(mess,"BRANCH_SCORE_WEIGHT: \t%9.2f",
 				  BRANCH_SCORE_WEIGHT);
+		  printMess(mess);
+	}
+	 /* Optional: Intron_length_model, the log-normal (mu sigma) over ln(intron
+	    length) that drives the soft length penalty in genamic (see
+	    INTRON_LENGTH_WEIGHT). Two floats on one line. */
+	if(!strcasecmp(header,sINTRON_LENGTH_MODEL)){
+		  readLine(RootFile,line);
+		  if ((sscanf(line,"%f %f\n", &(INTRON_LENGTH_MU), &(INTRON_LENGTH_SIGMA)))!=2)
+			printError("Wrong format: Intron_length_model (mu sigma)");
+
+		  sprintf(mess,"INTRON_LENGTH_MODEL: \tmu=%9.2f sigma=%9.2f",
+				  INTRON_LENGTH_MU, INTRON_LENGTH_SIGMA);
+		  printMess(mess);
+	}
+	 /* Optional: Intron_length_score_weight (lambda), how strongly the soft
+	    intron-length penalty counts in genamic. 0 = off (default). */
+	if(!strcasecmp(header,sINTRON_LENGTH_WEIGHT)){
+		  readLine(RootFile,line);
+		  if ((sscanf(line,"%f\n", &(INTRON_LENGTH_WEIGHT)))!=1)
+			printError("Wrong format: Intron_length_score_weight value (number/type)");
+
+		  sprintf(mess,"INTRON_LENGTH_WEIGHT: \t%9.2f",
+				  INTRON_LENGTH_WEIGHT);
 		  printMess(mess);
 	}
 	 /* Optional: U12_EXON_WEIGHT, an additional exon weight that applies to exons flanking U12 introns */

--- a/training/src/geneid_train/param/assemble.py
+++ b/training/src/geneid_train/param/assemble.py
@@ -41,6 +41,7 @@ def assemble_param(
     u12: U12Sections | None = None,
     u12_splice_thresh: float = 9.0,
     u12_exon_thresh: float = 8.0,
+    intron_length_model: tuple[float, float] | None = None,
 ) -> str:
     """Build a full geneid param. Profile/Markov args are geneid-format data
     lines (from ``stats.sites.format_profile`` / ``stats.coding.format_markov_matrix``);
@@ -78,6 +79,18 @@ def assemble_param(
             "Exon_weights",
             f"U12_Splice_Score_Threshold\n{u12_splice_thresh:g}\n"
             f"U12_Exon_Score_Threshold\n{u12_exon_thresh:g}\n",
+        )
+
+    if intron_length_model is not None:
+        # Soft intron-length penalty: the log-normal (mu, sigma) over ln(length)
+        # plus its weight (lambda). The weight is emitted at 0 = off, so the model
+        # is carried but inert until the optimizer (or a user) turns it on; geneid
+        # reads both in the optional-scalar block before Exon_weights.
+        mu, sigma = intron_length_model
+        p.insert_text_before(
+            "Exon_weights",
+            f"Intron_length_model\n{mu:.6g} {sigma:.6g}\n"
+            f"Intron_length_score_weight\n0\n",
         )
 
     text = p.to_text()

--- a/training/src/geneid_train/stats/genemodel.py
+++ b/training/src/geneid_train/stats/genemodel.py
@@ -7,6 +7,7 @@ connections, the intergenic range gates gene-to-gene connections.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 
 
@@ -49,6 +50,31 @@ def intron_range(
     if hi > long_cap:
         hi = float(long_cap)
     return lo, hi
+
+
+def intron_length_model(intron_lengths: Sequence[int]) -> tuple[float, float]:
+    """Fit a log-normal to intron lengths; return ``(mu, sigma)`` in log space.
+
+    These are the maximum-likelihood log-normal parameters — ``mu`` = mean and
+    ``sigma`` = population standard deviation of ``ln(length)``. They are emitted
+    into the param's ``Intron_length_model`` section, where geneid uses them for a
+    smooth, length-dependent intron score penalty: a *soft* replacement for the
+    hard gene-model ``max`` gate (see ``intron_range``). Introns near the typical
+    length sit near the distribution mode and are essentially unpenalised; the
+    penalty grows only in the long tail. Intron lengths are strongly right-skewed,
+    so a log-normal fits far better than a normal on the raw lengths.
+
+    The paired penalty *weight* (``Intron_length_score_weight``) defaults to 0 in
+    geneid, so emitting this model is backward-compatible until the weight is
+    turned on (by the optimizer or by hand).
+    """
+    logs = [math.log(n) for n in intron_lengths if n > 0]
+    n = len(logs)
+    if n == 0:
+        return 0.0, 0.0
+    mu = sum(logs) / n
+    var = sum((x - mu) ** 2 for x in logs) / n
+    return mu, math.sqrt(var)
 
 
 def format_range(lo: float, hi: float | str) -> str:

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -16,7 +16,7 @@ from .prepare.base import GeneModel
 from .prepare.sites import collect_sites
 from .stats.background import from_genome
 from .stats.coding import choose_orders, derive_coding_potential, format_markov_matrix
-from .stats.genemodel import format_range, intron_range
+from .stats.genemodel import format_range, intron_length_model, intron_range
 from .stats.sites import (
     Matrix,
     format_profile,
@@ -152,7 +152,9 @@ def train(
         cds_seqs, intron_seqs, transition_order
     )
 
-    lo, hi = intron_range([len(s) for s in intron_seqs])
+    intron_lens = [len(s) for s in intron_seqs]
+    lo, hi = intron_range(intron_lens)
+    il_model = intron_length_model(intron_lens)
 
     u12_sections = None
     if u12:
@@ -170,6 +172,7 @@ def train(
         markov_transition=format_markov_matrix(trans_logs),
         intron_range=format_range(lo, hi),
         intergenic_range="200:Infinity",
+        intron_length_model=il_model,
         u12=u12_sections,
         u12_splice_thresh=u12_splice_thresh,
         u12_exon_thresh=u12_exon_thresh,

--- a/training/tests/test_assemble.py
+++ b/training/tests/test_assemble.py
@@ -78,6 +78,42 @@ def test_assemble_param_injects_all_sections():
     assert "C D 200:Infinity" in out
 
 
+def test_assemble_param_injects_intron_length_model():
+    out = assemble_param(
+        species="Testus_specius",
+        start_profile=["8 3 -7 0", "1 A 0.5"],
+        acceptor_profile=["30 28 -7 1 0 1", "1 AA 0.1"],
+        donor_profile=["8 1 -7 1 0 1", "1 AA 0.2"],
+        markov_order=5,
+        markov_initial=["AAAAA 0 0 -0.5"],
+        markov_transition=["AAAAAA 0 0 -0.8"],
+        intron_range="24.75:25394.023",
+        intergenic_range="200:Infinity",
+        template=_tiny_template() + "Exon_weights\n1 1 1 1\n",
+        intron_length_model=(7.5, 1.25),
+    )
+    # model + its (off-by-default) weight land as an optional block before Exon_weights
+    assert "Intron_length_model\n7.5 1.25\n" in out
+    assert "Intron_length_score_weight\n0\n" in out
+    assert out.index("Intron_length_model") < out.index("Exon_weights")
+
+
+def test_assemble_param_omits_intron_length_model_when_absent():
+    out = assemble_param(
+        species="Testus_specius",
+        start_profile=["8 3 -7 0"],
+        acceptor_profile=["30 28 -7 1 0 1"],
+        donor_profile=["8 1 -7 1 0 1"],
+        markov_order=5,
+        markov_initial=["AAAAA 0 0 -0.5"],
+        markov_transition=["AAAAAA 0 0 -0.8"],
+        intron_range="24.75:25394.023",
+        intergenic_range="200:Infinity",
+        template=_tiny_template(),
+    )
+    assert "Intron_length_model" not in out
+
+
 def test_bundled_template_has_all_sentinels():
     t = load_template()
     for s in (

--- a/training/tests/test_genemodel.py
+++ b/training/tests/test_genemodel.py
@@ -1,6 +1,12 @@
+import math
+
 import pytest
 
-from geneid_train.stats.genemodel import format_range, intron_range
+from geneid_train.stats.genemodel import (
+    format_range,
+    intron_length_model,
+    intron_range,
+)
 
 from .conftest import ref_dir
 
@@ -19,6 +25,31 @@ def test_intron_range_short_below_cap():
 def test_format_range():
     assert format_range(40.0, "Infinity") == "40:Infinity"
     assert format_range(24.75, 25394.023) == "24.75:25394.023"
+
+
+def test_intron_length_model_recovers_lognormal_params():
+    # Draw ln(length) from a fixed grid so mu/sigma are exactly the mean/pop-sd of
+    # those logs; the fit must recover them.
+    log_vals = [4.0, 5.0, 6.0, 7.0, 8.0]
+    lengths = [round(math.exp(v)) for v in log_vals]
+    mu, sigma = intron_length_model(lengths)
+    logs = [math.log(n) for n in lengths]
+    exp_mu = sum(logs) / len(logs)
+    exp_sigma = math.sqrt(sum((x - exp_mu) ** 2 for x in logs) / len(logs))
+    assert mu == pytest.approx(exp_mu)
+    assert sigma == pytest.approx(exp_sigma)
+
+
+def test_intron_length_model_constant_lengths_zero_sigma():
+    mu, sigma = intron_length_model([2000, 2000, 2000])
+    assert mu == pytest.approx(math.log(2000))
+    assert sigma == pytest.approx(0.0)
+
+
+def test_intron_length_model_ignores_nonpositive_and_empty():
+    assert intron_length_model([]) == (0.0, 0.0)
+    # non-positive lengths (shouldn't occur) are filtered, not crash on log(0)
+    assert intron_length_model([0, -5]) == (0.0, 0.0)
 
 
 REF = ref_dir()


### PR DESCRIPTION
## Soft intron-length model — Stage 0 + Stage 1

First two stages of backlog feature #1: replace the *hard* gene-model intron `max` gate with a smooth, length-dependent penalty. **This PR is plumbing only — no scoring change yet** (that is Stage 2, a convex-gap penalty in genamic).

**Stage 0 — trainer emits the distribution.** `stats/genemodel.py` fits a log-normal (`mu, sigma` over `ln(intron length)`, MLE); `assemble.py`/`train.py` emit an optional `Intron_length_model` section plus `Intron_length_score_weight` (= 0, off) into the `.param`, next to the existing `intron_range`.

**Stage 1 — geneid reads it.** `readparam.c` reads both optional sections (the `Branch_point_score_weight` pattern); new globals `INTRON_LENGTH_MU/SIGMA/WEIGHT`, **weight default 0 = OFF**, so behaviour is unchanged until it is turned on.

### Verification
- Trainer: 124 unit tests pass, ruff clean.
- geneid: clean build (zero warnings); regression suite **5/5 byte-identical**.
- A param carrying the new sections parses correctly (`-v`) and still produces **byte-identical** output at weight 0; a malformed model line aborts with a clear error.

### Notes
- Independent of the training-setup PR (branch `chore/training-setup`); either can merge first. Because the trainer's new-param output is only readable by a geneid that has Stage 1, the two are meant to ship in the same release.
- Next: Stage 2 (convex-gap length penalty in genamic), then Stage 3 (RNA-seq junction-evidence override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
