### PR TITLE
training: foolproof setup (Python 3.10+, one-command venv) + refresh docs

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -1,21 +1,53 @@
-.PHONY: install test test-all lint fmt clean
+# geneid-train dev tooling. Requires Python >= 3.10 (see pyproject.toml).
+#
+# Quick start (from this directory):
+#     make venv                    # if `python3` is already >= 3.10
+#     make venv PYTHON=python3.12  # else point at a 3.10+ interpreter
+#     make test
+#
+# `make venv` builds an isolated ./.venv; the other targets auto-use it, so
+# there is nothing to activate. macOS ships 3.9 as `python3` -- if so, install a
+# newer Python (e.g. `brew install python@3.12`) and pass PYTHON=python3.12.
 
+PYTHON ?= python3
+VENV   := .venv
+
+# Prefer the project venv if it exists, else fall back to the active interpreter.
+PY := $(shell [ -x $(VENV)/bin/python ] && echo $(VENV)/bin/python || echo $(PYTHON))
+
+.PHONY: venv install test test-all lint fmt clean
+
+# One-command setup: isolated venv + editable install with dev tools (pytest, ruff).
+# No activation needed afterwards -- `make test`/`lint`/... pick up ./.venv.
+venv:
+	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' || { \
+	  echo "ERROR: '$(PYTHON)' is $$($(PYTHON) -V 2>&1); geneid-train needs Python >= 3.10."; \
+	  echo "       Install a newer Python (e.g. 'brew install python@3.12') and re-run:"; \
+	  echo "           make venv PYTHON=python3.12"; \
+	  exit 1; }
+	$(PYTHON) -m venv $(VENV)
+	$(VENV)/bin/python -m pip install --upgrade pip
+	$(VENV)/bin/python -m pip install -e ".[dev]"
+	@echo "Ready. Run 'make test', or './.venv/bin/geneid-train --help'."
+
+# Editable install + dev deps into the CURRENT environment (use inside your own venv).
 install:
-	python3 -m pip install -e ".[dev]"
+	$(PY) -m pip install --upgrade pip
+	$(PY) -m pip install -e ".[dev]"
 
 # fast unit suite (skips the opt-in integration round-trip over real params)
 test:
-	python3 -m pytest -q -m "not integration"
+	$(PY) -m pytest -q -m "not integration"
 
 # everything, including byte-identical round-trip over every param/*.param in the repo
 test-all:
-	python3 -m pytest -q
+	$(PY) -m pytest -q
 
 lint:
-	python3 -m ruff check .
+	$(PY) -m ruff check .
 
 fmt:
-	python3 -m ruff format .
+	$(PY) -m ruff format .
 
 clean:
 	rm -rf build dist src/*.egg-info .pytest_cache

--- a/training/README.md
+++ b/training/README.md
@@ -5,19 +5,56 @@ with first-class U2/U12 intron support. Replaces the legacy Perl/AWK/C training
 scripts. See [DESIGN.md](DESIGN.md) for the full plan and the frozen `.param`
 format spec.
 
-Status: **Phase 1** — package scaffold, CLI surface, and the `.param`
-read/write core (byte-identical round-trip).
+Status: **working end-to-end.** From a GFF3 annotation + genome it trains a
+complete geneid `.param` — splice/start site profiles, the coding Markov model,
+the gene model, and optional U12 and U2 branch-point profiles — and also
+`optimize`s the exon weights, `evaluate`s predictions (SN/SP), and runs
+`jackknife` cross-validation. See [DESIGN.md](DESIGN.md) for details.
 
-## Dev cycle
+## Setup
+
+`geneid-train` is **pure Python with no third-party runtime dependencies** — just
+the standard library. There is nothing to compile and no wheels to build, so
+setup is only "get a recent Python and install."
+
+**Requirement: Python ≥ 3.10.** Check with `python3 --version`. On macOS the
+system `python3` is usually 3.9 — install a newer one (`brew install python@3.12`,
+or use pyenv) and point the commands below at it with `PYTHON=python3.12`.
+
+### One-command setup (recommended)
+
+From this `training/` directory:
 
 ```bash
-cd training
-make install     # editable install + dev deps (pytest, ruff) into your env
+make venv                    # if python3 is already >= 3.10
+make venv PYTHON=python3.12  # otherwise, point at a 3.10+ interpreter
+```
+
+That creates an isolated `./.venv`, upgrades pip, and installs `geneid-train`
+(editable) plus the dev tools. **Nothing to activate** — the other targets
+auto-detect `./.venv`:
+
+```bash
 make test        # fast unit suite
-make test-all    # also round-trips every real param/*.param in the repo
+make test-all    # also round-trips every real param/*.param in the repo (slower, opt-in)
 make lint        # ruff check
 make fmt         # ruff format
 ```
+
+Run the CLI directly with `./.venv/bin/geneid-train --help`, or `source
+.venv/bin/activate` first and just call `geneid-train`.
+
+### Installing into your own environment
+
+Already have a virtualenv/conda env on Python ≥ 3.10? Skip `make venv` and install
+into the active environment instead:
+
+```bash
+make install     # pip install --upgrade pip && pip install -e ".[dev]"
+```
+
+If you try to install under Python < 3.10, pip stops with a clear
+`requires a different Python` error rather than failing mysteriously later.
 
 ## Try it
 
@@ -34,6 +71,25 @@ geneid-train convert --from gff2 annotation.gff2 annotation.gff3
 geneid-train prepare --gff annotation.gff3 --fastas genome.fa --min-aa 100 --results out
 ```
 
-`convert` accepts `--from gff2` or `--from gtf`. The remaining subcommands
-(`train`, `evaluate`, `jackknife`) are stubs at this phase and report which phase
-implements them.
+`convert` accepts `--from gff2` or `--from gtf` (GFF3 is the only ingested format).
+
+Train a parameter file, then tune and evaluate it:
+
+```bash
+# GFF3 annotation + genome -> a complete geneid .param
+geneid-train train --gff annotation.gff3 --fastas genome.fa \
+    --species Genus_species --output Genus_species.param [--u12] [--u2-branch]
+
+# grid/search the exon weights against a held-out set
+geneid-train optimize --param Genus_species.param \
+    --eval-fastas eval.fa --eval-gff eval.gff3 --output Genus_species.optimized.param
+
+# SN/SP of predictions vs annotation, and leave-group-out cross-validation
+geneid-train evaluate predictions.gff annotation.gff
+geneid-train jackknife --gff annotation.gff3 --fastas genome.fa \
+    --species Genus_species --eval-fastas eval.fa --eval-gff eval.gff3
+```
+
+`optimize`, `evaluate`, and `jackknife` need a compiled `geneid` binary on your
+`PATH` (or pass `--geneid /path/to/geneid`); build it from the repo root with
+`make`.

--- a/training/pyproject.toml
+++ b/training/pyproject.toml
@@ -7,7 +7,7 @@ name = "geneid-train"
 version = "0.0.1"
 description = "Pure-Python training pipeline for the geneid gene predictor (U2/U12-aware)"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "GPL-3.0-or-later" }
 authors = [{ name = "Tyler Alioto" }]
 dependencies = []

--- a/training/src/geneid_train/optimize.py
+++ b/training/src/geneid_train/optimize.py
@@ -312,7 +312,7 @@ def coordinate_descent(
                         continue
                     with ThreadPoolExecutor(max_workers=workers) as pool:
                         accs = list(pool.map(score, trials))
-                    candidates = [(point, best_acc)] + list(zip(trials, accs))
+                    candidates = [(point, best_acc)] + list(zip(trials, accs, strict=True))
                     candidates.sort(key=lambda c: accuracy_key(c[1]))
                     best_point, best_of = candidates[0]
                     if best_point != point:
@@ -360,7 +360,7 @@ class SearchSpace:
         return base + list(self.branch_bounds) * len(self.branch_profiles)
 
     def clip(self, v: list[float]) -> list[float]:
-        return [min(hi, max(lo, x)) for x, (lo, hi) in zip(v, self.bounds())]
+        return [min(hi, max(lo, x)) for x, (lo, hi) in zip(v, self.bounds(), strict=True)]
 
     def decode(self, v: list[float]) -> WeightPoint:
         return WeightPoint(tuple(v[:4]), tuple(round(x, 6) for x in v[4:8]))
@@ -450,7 +450,7 @@ def global_optimize(
         samples = latin_hypercube(bounds, n_samples, seed)
         accs = score_many(samples)
         evals += len(samples)
-        best_v, best_acc = min(zip(samples, accs), key=lambda p: accuracy_key(p[1]))
+        best_v, best_acc = min(zip(samples, accs, strict=True), key=lambda p: accuracy_key(p[1]))
         best_v = list(best_v)
         history = [CDResult(space.decode(space.clip(best_v)), best_acc)]
 
@@ -470,7 +470,7 @@ def global_optimize(
             n_accs = score_many(neighbours)
             evals += len(neighbours)
             cand_v, cand_acc = min(
-                zip(neighbours, n_accs), key=lambda p: accuracy_key(p[1])
+                zip(neighbours, n_accs, strict=True), key=lambda p: accuracy_key(p[1])
             )
             if accuracy_key(cand_acc) < accuracy_key(best_acc):
                 best_v, best_acc = list(cand_v), cand_acc

--- a/training/src/geneid_train/prepare/base.py
+++ b/training/src/geneid_train/prepare/base.py
@@ -61,7 +61,7 @@ class GeneModel:
     def introns(self) -> list[tuple[int, int]]:
         """Genomic (start, end) of each intron, ascending. Empty if single-exon."""
         out = []
-        for prev, nxt in zip(self.exons, self.exons[1:]):
+        for prev, nxt in zip(self.exons, self.exons[1:], strict=False):
             out.append((prev.end + 1, nxt.start - 1))
         return out
 

--- a/training/src/geneid_train/stats/branch.py
+++ b/training/src/geneid_train/stats/branch.py
@@ -189,7 +189,7 @@ def fit_branch_em(
             z = sum(odds)
             if z <= 0:
                 continue
-            for j, o in zip(starts, odds):
+            for j, o in zip(starts, odds, strict=True):
                 gamma = o / z
                 for m in range(width):
                     counts[m][codes[j + m]] += gamma
@@ -202,7 +202,7 @@ def fit_branch_em(
         if delta < tol:
             break
 
-    pwm_dicts = [dict(zip(_ACGT, col)) for col in pwm]
+    pwm_dicts = [dict(zip(_ACGT, col, strict=True)) for col in pwm]
     return BranchModel(pwm_dicts, background, width, anchor, require_anchor)
 
 

--- a/training/tests/test_param.py
+++ b/training/tests/test_param.py
@@ -49,7 +49,7 @@ def test_set_scalar_is_surgical(mini_param_path: Path):
     before = text.splitlines()
     after = out.splitlines()
     assert len(before) == len(after)
-    diff = [(a, b) for a, b in zip(before, after) if a != b]
+    diff = [(a, b) for a, b in zip(before, after, strict=True) if a != b]
     assert diff == [("0", "-5")]
     # and the change parses back
     assert Param.from_text(out).scalar("NO_SCORE") == "-5"


### PR DESCRIPTION
## Foolproof training setup + doc refresh

Make `training/` "just work" for new users and fix the root cause behind a confusing failure.

**Root cause.** `pyproject.toml` declared `requires-python = ">=3.9"`, but the code uses PEP 604 `X | Y` unions at runtime — so a 3.9 user (e.g. macOS's default `python3`) installed fine, then crashed with a cryptic `TypeError: unsupported operand |`. Bumped to **`>=3.10`**, so pip now refuses 3.9 with a clear *requires a different Python* message.

**One-command setup.** `make venv [PYTHON=python3.12]` builds an isolated `./.venv` (upgrades pip, editable install with dev deps), with a preflight guard that refuses Python < 3.10 with an actionable hint. `test`/`lint`/`fmt` auto-detect `./.venv`, so there is nothing to activate.

**Docs.** New README **Setup** section (pure-stdlib, no third-party runtime deps, one-command venv); refreshed the stale "Phase 1 / stubs" status to the real end-to-end trainer plus `optimize`/`evaluate`/`jackknife` usage.

**Lint.** Targeting 3.10 activates ruff `B905` (`zip()` needs explicit `strict=`): fixed 8 sites — `prepare/base.py`'s sliding-pairwise zip is `strict=False`; the other 7 (`optimize.py`, `stats/branch.py`, `tests/test_param.py`) are equal-length so `strict=True`.

### Verification
Fresh `make venv PYTHON=python3.12` -> `make test` **124 pass**, `make lint` clean; `make venv PYTHON=python3` (3.9) refuses cleanly without touching an existing venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
