### PR TITLE
gitignore: keep samples/ lean (ignore local genome/annotation data drops)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 
 *.o
-param/.DS_Store
-scripts/.DS_Store
+.DS_Store
 
 # Local build artifacts. The whole bin/ dir is build output: geneid is built
 # by `make`, not tracked (it was committed by accident long ago, was macOS-
@@ -14,3 +13,17 @@ scripts/.DS_Store
 # scratch run outputs (the committed suite lives in test/regression/)
 /test/*.gff3
 /test/*.log
+
+# Large local data drops used only to BUILD test fixtures (whole genomes +
+# their annotations). Never track these -- only small derived slices belong in
+# the repo, to keep samples/ lean. Covers e.g. GRCh38.primary_assembly.genome.fa.gz,
+# gencode.v*.*.gff3.gz, and the xgXerMont training genome.
+/samples/*.primary_assembly.*
+/samples/gencode.*
+/samples/xgXerMont*
+/samples/*.genome.fa
+/samples/*.genome.fa.gz
+
+# Legacy training source material + example genomes (24 GB, local reference
+# only, harvested from into the Python `training/` package). Never track.
+/geneid_training/


### PR DESCRIPTION
## Keep `samples/` lean — ignore local data drops

Building test fixtures pulls whole genomes + annotations into `samples/` locally (GRCh38 primary assembly ~806 MB, `gencode.v50.*` ~112 MB, the xgXerMont training genome ~1.8 GB), and there's a 24 GB legacy `geneid_training/` reference tree at the repo root. None of that should ever be committed — only small derived slices belong in the repo.

Adds ignore rules for those data drops and generalises the `.DS_Store` rule (was two explicit paths) to catch the stray root one. Verified: the big files are now ignored, every currently-tracked fixture (`GRCh38.chr21.fa.gz`, `example*.fa`, `hg38.genome`, the snake fastas, …) is untouched, and `git status` has no untracked noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
