### PR TITLE
geneid-train: --max-intron to set the gene-model max intron directly

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -237,6 +237,7 @@ def _cmd_train(args: argparse.Namespace) -> int:
             models, genome, args.species, seed=args.seed, u12=args.u12,
             u12_splice_thresh=args.u12_splice_thresh, u12_exon_thresh=args.u12_exon_thresh,
             u2_branch=args.u2_branch, branch_weight=args.branch_weight,
+            max_intron=args.max_intron,
         )
     except NotImplementedError as exc:
         sys.stderr.write(f"geneid-train train: {exc}\n")
@@ -317,6 +318,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_train.add_argument("--species", required=True, help="species name for the param header")
     p_train.add_argument("--output", required=True, help="output .param path")
     p_train.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
+    p_train.add_argument(
+        "--max-intron", type=float, default=None,
+        help="override the gene-model max intron length (bp) instead of the p99.9 estimate; "
+             "use a generous safety bound alongside the soft intron-length penalty "
+             "(e.g. 500000 for human)",
+    )
     p_train.add_argument(
         "--seed", type=int, default=0, help="RNG seed for background sampling (reproducibility)"
     )

--- a/training/src/geneid_train/stats/genemodel.py
+++ b/training/src/geneid_train/stats/genemodel.py
@@ -31,6 +31,7 @@ def intron_range(
     short_cap: int = 40,
     long_cap: int = 100_000,
     max_quantile: float = 0.999,
+    max_intron: float | None = None,
 ) -> tuple[float, float]:
     """Return ``(min_intron, max_intron)`` for the gene model.
 
@@ -41,11 +42,19 @@ def intron_range(
     xgXerMont) — and geneid cannot span an intron longer than this max, so a too-low
     value fragments long-intron genes into separate models. A high percentile spans
     essentially all real introns while staying under the safety cap.
+
+    ``max_intron``, when given, overrides the percentile/``long_cap`` computation
+    and is used directly as the max. That is the intended setting alongside the
+    soft intron-length penalty (``Intron_length_model``): the hard max becomes a
+    generous *safety bound* (e.g. 500 kb for human, which admits all but the ~9-35
+    longest introns) while the smooth penalty — not a cliff — grades the long ones.
     """
     shortest = min(intron_lengths)
     lo = shortest * 0.75
     if lo > short_cap:
         lo = float(short_cap)
+    if max_intron is not None:
+        return lo, float(max_intron)
     hi = _percentile(list(intron_lengths), max_quantile)
     if hi > long_cap:
         hi = float(long_cap)

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -99,6 +99,7 @@ def train(
     u12_exon_thresh: float = 8.0,
     u2_branch: bool = False,
     branch_weight: float = 0.0,
+    max_intron: float | None = None,
 ) -> str:
     """Train a geneid parameter file from complete, filtered gene ``models``.
 
@@ -153,7 +154,7 @@ def train(
     )
 
     intron_lens = [len(s) for s in intron_seqs]
-    lo, hi = intron_range(intron_lens)
+    lo, hi = intron_range(intron_lens, max_intron=max_intron)
     il_model = intron_length_model(intron_lens)
 
     u12_sections = None

--- a/training/tests/test_genemodel.py
+++ b/training/tests/test_genemodel.py
@@ -40,6 +40,15 @@ def test_intron_length_model_recovers_lognormal_params():
     assert sigma == pytest.approx(exp_sigma)
 
 
+def test_intron_range_max_intron_override():
+    lens = [1000] * 999 + [90000]
+    lo, hi = intron_range(lens, max_intron=500_000)
+    assert hi == 500000.0  # used directly, bypassing the p99.9/long_cap path
+    lo2, hi2 = intron_range(lens)  # default is the (much lower) p99.9 estimate
+    assert hi2 < hi
+    assert lo == lo2  # min is unaffected by the override
+
+
 def test_intron_length_model_constant_lengths_zero_sigma():
     mu, sigma = intron_length_model([2000, 2000, 2000])
     assert mu == pytest.approx(math.log(2000))


### PR DESCRIPTION
## `train --max-intron`: set the gene-model max intron directly

Part of the human testbed. Alongside the soft intron-length penalty the hard cap should be a *generous safety bound*, not the p99.9 discriminator. This adds an `intron_range(max_intron=...)` override and a `geneid-train train --max-intron <bp>` flag that set the gene-model max directly, bypassing the p99.9/`long_cap` estimate.

For human: `--max-intron 500000` admits every intron up to 500 kb (the penalty grades them) and hard-excludes only the ~9-35 ultralong ones — whereas p99.9 would clip much more aggressively. Default `None` preserves the existing behaviour.

Verified: 125 tests pass (1 new), ruff clean; retrained the chr12 human param with `--max-intron 500000` → gene model `3.75:500000`, `Intron_length_model 7.1788 1.51411` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
