### PR TITLE
geneid-train: default the gene-model max intron to a fixed 500 kb

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -22,6 +22,7 @@ from .prepare.base import (
     filter_non_overlapping,
 )
 from .prepare.classify import classify_report
+from .stats.genemodel import DEFAULT_MAX_INTRON
 
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
@@ -327,10 +328,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_train.add_argument("--output", required=True, help="output .param path")
     p_train.add_argument("--min-aa", type=int, default=100, help="minimum protein length (aa)")
     p_train.add_argument(
-        "--max-intron", type=float, default=None,
-        help="override the gene-model max intron length (bp) instead of the p99.9 estimate; "
-             "use a generous safety bound alongside the soft intron-length penalty "
-             "(e.g. 500000 for human)",
+        "--max-intron", type=float, default=DEFAULT_MAX_INTRON,
+        help="gene-model max intron length (bp); defaults to a fixed 500000 safety bound "
+             "for every genome, leaving the soft intron-length penalty to grade long "
+             "introns. Pass a value to widen/tighten it (e.g. 1000000 for a large genome)",
     )
     p_train.add_argument(
         "--seed", type=int, default=0, help="RNG seed for background sampling (reproducibility)"

--- a/training/src/geneid_train/stats/genemodel.py
+++ b/training/src/geneid_train/stats/genemodel.py
@@ -10,6 +10,13 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 
+# Default gene-model max intron length (bp). Fixed and genome-independent: with the
+# soft intron-length penalty (``Intron_length_model``) doing the real length tuning
+# via its weight, the hard max only needs to be a generous safety bound. 500 kb
+# admits all but a handful of the longest human introns; smaller genomes never
+# approach it, so the penalty weight -- not this cap -- controls effective length.
+DEFAULT_MAX_INTRON = 500_000
+
 
 def _percentile(values: Sequence[float], q: float) -> float:
     """The ``q`` quantile (0..1) by linear interpolation between order statistics."""

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -16,7 +16,12 @@ from .prepare.base import GeneModel
 from .prepare.sites import collect_sites
 from .stats.background import from_genome
 from .stats.coding import choose_orders, derive_coding_potential, format_markov_matrix
-from .stats.genemodel import format_range, intron_length_model, intron_range
+from .stats.genemodel import (
+    DEFAULT_MAX_INTRON,
+    format_range,
+    intron_length_model,
+    intron_range,
+)
 from .stats.sites import (
     Matrix,
     format_profile,
@@ -99,7 +104,7 @@ def train(
     u12_exon_thresh: float = 8.0,
     u2_branch: bool = False,
     branch_weight: float = 0.0,
-    max_intron: float | None = None,
+    max_intron: float | None = DEFAULT_MAX_INTRON,
 ) -> str:
     """Train a geneid parameter file from complete, filtered gene ``models``.
 
@@ -117,6 +122,12 @@ def train(
     observed branch positions, and spliced in with ``Branch_point_score_weight``
     (default 0 = the branch is scored and reported, ``bp_score``/``bp_pos``, without
     contributing to splice-site selection).
+
+    ``max_intron`` sets the gene-model hard max intron length and defaults to
+    ``DEFAULT_MAX_INTRON`` (500 kb) for every genome: with the soft intron-length
+    penalty grading long introns, the hard max is only a generous safety bound and
+    no longer needs to be estimated per genome. Pass an explicit value to widen or
+    tighten that bound; pass ``None`` to fall back to the data-driven p99.9 estimate.
     """
     if not models:
         raise ValueError("no gene models to train on")

--- a/training/tests/test_cli.py
+++ b/training/tests/test_cli.py
@@ -1,0 +1,17 @@
+from geneid_train.cli import build_parser
+from geneid_train.stats.genemodel import DEFAULT_MAX_INTRON
+
+BASE = ["train", "--gff", "a.gff3", "--fastas", "g.fa",
+        "--species", "sp", "--output", "out.param"]
+
+
+def test_train_max_intron_defaults_to_fixed_500kb():
+    # The gene-model max intron defaults to a genome-independent 500 kb safety bound;
+    # the soft intron-length penalty (not this cap) does the real length tuning.
+    args = build_parser().parse_args(BASE)
+    assert args.max_intron == DEFAULT_MAX_INTRON == 500_000
+
+
+def test_train_max_intron_override():
+    args = build_parser().parse_args([*BASE, "--max-intron", "1000000"])
+    assert args.max_intron == 1_000_000

--- a/training/tests/test_train.py
+++ b/training/tests/test_train.py
@@ -123,3 +123,4 @@ def test_train_end_to_end_produces_valid_param():
     assert p.has("Markov_Transition_probability_matrix")
     gm = "".join(p._find("General_Gene_Model").raw)
     assert "200:Infinity" in gm  # intergenic range injected
+    assert ":500000" in gm  # fixed 500 kb max-intron default (not the p99.9 estimate)


### PR DESCRIPTION
Makes the gene-model **max intron length a fixed 500 kb default for every genome**, instead of the per-genome p99.9 estimate. With the soft intron-length penalty (`Intron_length_model` + weight) now doing the real length tuning, the hard max only needs to be a generous safety bound — a cliff-like hard cap is exactly what the penalty was built to replace, and keeping it generous lets long-intron genes be *graded* rather than *fragmented*.

**Changes**
- New `DEFAULT_MAX_INTRON = 500_000` in `stats.genemodel`.
- `train()` and the `train --max-intron` CLI both default to it. An explicit `--max-intron` still overrides (e.g. `1000000` for a large genome); passing `max_intron=None` to `train()` still falls back to the p99.9 estimate as a library escape hatch.
- `intron_range()`'s pure-function p99.9 default is left unchanged (still available + unit-tested).

**Tests**
- `test_cli.py` (new): fast checks that `--max-intron` defaults to 500000 and that an override flows through.
- `test_train.py`: the end-to-end integration test now asserts the emitted gene model carries `:500000`.
- 131 unit tests pass; ruff clean; integration `train` end-to-end passes on xgXerMont (14 s).

**Behavioral note (backward-compat):** the penalty weight still defaults to 0, so a freshly trained *default* param now admits introns up to 500 kb **with no penalty**. That is the intended "generous cap + tune λ" workflow — set a weight (or tune it via `optimize`) to constrain effective intron length. Existing params are unaffected (their caps are already baked in); only newly trained params change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)