### PR TITLE
geneid-train: default the soft intron-length penalty ON (weight 0.5)

### DIFF
--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -22,7 +22,7 @@ from .prepare.base import (
     filter_non_overlapping,
 )
 from .prepare.classify import classify_report
-from .stats.genemodel import DEFAULT_MAX_INTRON
+from .stats.genemodel import DEFAULT_INTRON_LENGTH_WEIGHT, DEFAULT_MAX_INTRON
 
 _U12_MARKERS = ("U12_Splice_Score_Threshold", "U12_Branch_point_profile")
 
@@ -246,7 +246,7 @@ def _cmd_train(args: argparse.Namespace) -> int:
             models, genome, args.species, seed=args.seed, u12=args.u12,
             u12_splice_thresh=args.u12_splice_thresh, u12_exon_thresh=args.u12_exon_thresh,
             u2_branch=args.u2_branch, branch_weight=args.branch_weight,
-            max_intron=args.max_intron,
+            max_intron=args.max_intron, intron_length_weight=args.intron_length_weight,
         )
     except NotImplementedError as exc:
         sys.stderr.write(f"geneid-train train: {exc}\n")
@@ -332,6 +332,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="gene-model max intron length (bp); defaults to a fixed 500000 safety bound "
              "for every genome, leaving the soft intron-length penalty to grade long "
              "introns. Pass a value to widen/tighten it (e.g. 1000000 for a large genome)",
+    )
+    p_train.add_argument(
+        "--intron-length-weight", type=float, default=DEFAULT_INTRON_LENGTH_WEIGHT,
+        help="soft intron-length penalty strength (lambda); defaults to 0.5 (penalty ON). "
+             "Pass 0 to emit the intron-length model but leave the penalty off, or tune it "
+             "per genome with `optimize --tune-intron-length`",
     )
     p_train.add_argument(
         "--seed", type=int, default=0, help="RNG seed for background sampling (reproducibility)"

--- a/training/src/geneid_train/param/assemble.py
+++ b/training/src/geneid_train/param/assemble.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from importlib.resources import files
 
 from ..core.param import Param
+from ..stats.genemodel import DEFAULT_INTRON_LENGTH_WEIGHT
 from .u12 import U12Sections
 
 
@@ -42,6 +43,7 @@ def assemble_param(
     u12_splice_thresh: float = 9.0,
     u12_exon_thresh: float = 8.0,
     intron_length_model: tuple[float, float] | None = None,
+    intron_length_weight: float = DEFAULT_INTRON_LENGTH_WEIGHT,
 ) -> str:
     """Build a full geneid param. Profile/Markov args are geneid-format data
     lines (from ``stats.sites.format_profile`` / ``stats.coding.format_markov_matrix``);
@@ -83,14 +85,14 @@ def assemble_param(
 
     if intron_length_model is not None:
         # Soft intron-length penalty: the log-normal (mu, sigma) over ln(length)
-        # plus its weight (lambda). The weight is emitted at 0 = off, so the model
-        # is carried but inert until the optimizer (or a user) turns it on; geneid
-        # reads both in the optional-scalar block before Exon_weights.
+        # plus its weight (lambda). The weight defaults to DEFAULT_INTRON_LENGTH_WEIGHT
+        # (0.5 = ON); pass 0 to carry the model inert. geneid reads both in the
+        # optional-scalar block before Exon_weights.
         mu, sigma = intron_length_model
         p.insert_text_before(
             "Exon_weights",
             f"Intron_length_model\n{mu:.6g} {sigma:.6g}\n"
-            f"Intron_length_score_weight\n0\n",
+            f"Intron_length_score_weight\n{intron_length_weight:g}\n",
         )
 
     text = p.to_text()

--- a/training/src/geneid_train/stats/genemodel.py
+++ b/training/src/geneid_train/stats/genemodel.py
@@ -17,6 +17,18 @@ from collections.abc import Sequence
 # approach it, so the penalty weight -- not this cap -- controls effective length.
 DEFAULT_MAX_INTRON = 500_000
 
+# Default soft intron-length penalty weight (lambda), emitted into
+# ``Intron_length_score_weight``. Nonzero => the penalty is ON out of the box, so
+# the generous 500 kb hard cap does not admit unpenalised long introns. 0.5 was
+# picked from a weight sweep on human, snake and xgXerMont: it prunes the great
+# majority of the (almost entirely spurious) ab-initio introns beyond L0 with no
+# sensitivity cost, while keeping the real long introns that a weight >= 1 starts
+# to remove. Real long introns are best recovered via -R evidence, which bypasses
+# the penalty, so a moderately aggressive default is safe. Tunable per genome via
+# ``optimize --tune-intron-length``.
+DEFAULT_INTRON_LENGTH_WEIGHT = 0.5
+
+
 
 def _percentile(values: Sequence[float], q: float) -> float:
     """The ``q`` quantile (0..1) by linear interpolation between order statistics."""

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -17,6 +17,7 @@ from .prepare.sites import collect_sites
 from .stats.background import from_genome
 from .stats.coding import choose_orders, derive_coding_potential, format_markov_matrix
 from .stats.genemodel import (
+    DEFAULT_INTRON_LENGTH_WEIGHT,
     DEFAULT_MAX_INTRON,
     format_range,
     intron_length_model,
@@ -105,6 +106,7 @@ def train(
     u2_branch: bool = False,
     branch_weight: float = 0.0,
     max_intron: float | None = DEFAULT_MAX_INTRON,
+    intron_length_weight: float = DEFAULT_INTRON_LENGTH_WEIGHT,
 ) -> str:
     """Train a geneid parameter file from complete, filtered gene ``models``.
 
@@ -128,6 +130,10 @@ def train(
     penalty grading long introns, the hard max is only a generous safety bound and
     no longer needs to be estimated per genome. Pass an explicit value to widen or
     tighten that bound; pass ``None`` to fall back to the data-driven p99.9 estimate.
+
+    ``intron_length_weight`` is the soft-penalty strength (lambda) emitted with the
+    intron-length model; it defaults to ``DEFAULT_INTRON_LENGTH_WEIGHT`` (0.5 = the
+    penalty is ON). Pass 0 to carry the model but leave the penalty off.
     """
     if not models:
         raise ValueError("no gene models to train on")
@@ -185,6 +191,7 @@ def train(
         intron_range=format_range(lo, hi),
         intergenic_range="200:Infinity",
         intron_length_model=il_model,
+        intron_length_weight=intron_length_weight,
         u12=u12_sections,
         u12_splice_thresh=u12_splice_thresh,
         u12_exon_thresh=u12_exon_thresh,

--- a/training/tests/test_assemble.py
+++ b/training/tests/test_assemble.py
@@ -92,10 +92,29 @@ def test_assemble_param_injects_intron_length_model():
         template=_tiny_template() + "Exon_weights\n1 1 1 1\n",
         intron_length_model=(7.5, 1.25),
     )
-    # model + its (off-by-default) weight land as an optional block before Exon_weights
+    # model + its weight land as an optional block before Exon_weights; the weight
+    # defaults to 0.5 (penalty ON)
     assert "Intron_length_model\n7.5 1.25\n" in out
-    assert "Intron_length_score_weight\n0\n" in out
+    assert "Intron_length_score_weight\n0.5\n" in out
     assert out.index("Intron_length_model") < out.index("Exon_weights")
+
+
+def test_assemble_param_intron_length_weight_override():
+    kw = dict(
+        species="Testus_specius",
+        start_profile=["8 3 -7 0", "1 A 0.5"],
+        acceptor_profile=["30 28 -7 1 0 1", "1 AA 0.1"],
+        donor_profile=["8 1 -7 1 0 1", "1 AA 0.2"],
+        markov_order=5,
+        markov_initial=["AAAAA 0 0 -0.5"],
+        markov_transition=["AAAAAA 0 0 -0.8"],
+        intron_range="24.75:25394.023",
+        intergenic_range="200:Infinity",
+        template=_tiny_template() + "Exon_weights\n1 1 1 1\n",
+        intron_length_model=(7.5, 1.25),
+    )
+    assert "Intron_length_score_weight\n0\n" in assemble_param(**kw, intron_length_weight=0)
+    assert "Intron_length_score_weight\n1.5\n" in assemble_param(**kw, intron_length_weight=1.5)
 
 
 def test_assemble_param_omits_intron_length_model_when_absent():

--- a/training/tests/test_cli.py
+++ b/training/tests/test_cli.py
@@ -1,5 +1,8 @@
 from geneid_train.cli import build_parser
-from geneid_train.stats.genemodel import DEFAULT_MAX_INTRON
+from geneid_train.stats.genemodel import (
+    DEFAULT_INTRON_LENGTH_WEIGHT,
+    DEFAULT_MAX_INTRON,
+)
 
 BASE = ["train", "--gff", "a.gff3", "--fastas", "g.fa",
         "--species", "sp", "--output", "out.param"]
@@ -15,3 +18,14 @@ def test_train_max_intron_defaults_to_fixed_500kb():
 def test_train_max_intron_override():
     args = build_parser().parse_args([*BASE, "--max-intron", "1000000"])
     assert args.max_intron == 1_000_000
+
+
+def test_train_intron_length_weight_defaults_to_half():
+    # The soft intron-length penalty is ON by default (weight 0.5).
+    args = build_parser().parse_args(BASE)
+    assert args.intron_length_weight == DEFAULT_INTRON_LENGTH_WEIGHT == 0.5
+
+
+def test_train_intron_length_weight_override():
+    args = build_parser().parse_args([*BASE, "--intron-length-weight", "0"])
+    assert args.intron_length_weight == 0.0

--- a/training/tests/test_train.py
+++ b/training/tests/test_train.py
@@ -124,3 +124,5 @@ def test_train_end_to_end_produces_valid_param():
     gm = "".join(p._find("General_Gene_Model").raw)
     assert "200:Infinity" in gm  # intergenic range injected
     assert ":500000" in gm  # fixed 500 kb max-intron default (not the p99.9 estimate)
+    assert "Intron_length_model" in text  # soft intron-length model emitted
+    assert "Intron_length_score_weight\n0.5\n" in text  # penalty ON by default (weight 0.5)


### PR DESCRIPTION
Defaults the soft intron-length penalty **ON** by emitting `Intron_length_score_weight 0.5` from the trainer (was `0`).

## Why
With #52's fixed 500 kb hard cap, a default-trained param carried the intron-length model but left the penalty **off** (weight 0) — so it admitted introns up to 500 kb entirely unpenalised. This turns the penalty on so it actually grades long introns.

## Why 0.5
A weight sweep on **human** (GENCODE chr14), **xgXerMont** (curated ref), and **snake** (Hemorrhois):

| genome | L0 | false long introns @w0 | @0.5 | @1 | real long introns kept |
|---|---|---|---|---|---|
| human chr14:20–30M | 27 kb | 41 (all false) | 3 | 2 | n/a (TP_far=0 at every weight) |
| xgXerMont SUPER_1:40–70M | 16.7 kb | 210/212 false | ~47 | ~25 | **2 → 2 → 1** (lost at w1) |
| snake SUPER_1:1–20M | 26.6 kb | 49 | 7 | 4 | — (no ref; gene structure plateaus by 0.5) |

- Ab-initio **massively over-predicts** introns beyond L0, and almost all are false.
- Weight 0.5 prunes **77–93%** of them across all three, with **no sensitivity cost** (overall intron SN flat).
- xgXerMont keeps **both** real long introns at 0.5; a weight **≥1 starts removing real ones**.
- The weight is genome-portable — L0 already normalises per genome and the GeneScore scales are comparable.
- Real long introns are best recovered via `-R` evidence (which bypasses the penalty), so a moderately aggressive default is safe.

## Changes
- `DEFAULT_INTRON_LENGTH_WEIGHT = 0.5` in `stats.genemodel`.
- `assemble_param` / `train()` / `train --intron-length-weight` all default to it; pass `0` to carry the model inert, or tune per genome with `optimize --tune-intron-length`.
- Tests: assemble emits 0.5 (+ honours an override), CLI default/override, integration asserts the trained param carries weight 0.5.

geneid's own C-side global weight default stays `0`, so params **without** the section (older params) are unaffected. 134 unit tests pass; ruff clean; integration `train` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)