### PR TITLE
htslib build: bake HTSLIB_PREFIX/lib into the binary RPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ OBJECTS = $(OBJ)/BackupGenes.o $(OBJ)/PeakEdgeScore.o $(OBJ)/GetTranscriptTermin
 HTSLIB_PREFIX ?= /usr/local
 ifdef WITH_HTSLIB
 OPTS += -DWITH_HTSLIB -I$(HTSLIB_PREFIX)/include
-HTSLIBS = -L$(HTSLIB_PREFIX)/lib -lhts
+# -L is a LINK-time path; -Wl,-rpath bakes the same dir into the binary's
+# runtime search path so it finds libhts.so.* without LD_LIBRARY_PATH or a
+# module load. (Harmless when htslib comes from a module / the default prefix.)
+HTSLIBS = -L$(HTSLIB_PREFIX)/lib -Wl,-rpath,$(HTSLIB_PREFIX)/lib -lhts
 OBJECTS += $(OBJ)/bamcov.o $(OBJ)/ReadIntronsBam.o
 else
 HTSLIBS =

--- a/README.md
+++ b/README.md
@@ -128,10 +128,16 @@ Dependencies:
     >make WITH_HTSLIB=1 HTSLIB_PREFIX=/opt/homebrew        # e.g. macOS/Homebrew
     >make WITH_HTSLIB=1 HTSLIB_PREFIX=/path/to/htslib
 
+    The build bakes HTSLIB_PREFIX/lib into the binary's runtime search path
+    (-Wl,-rpath), so the resulting geneid finds libhts.so.* on its own -- no
+    "module load" or LD_LIBRARY_PATH needed at run time. (If you ever move the
+    htslib install, either rebuild or set
+    LD_LIBRARY_PATH=<prefix>/lib:$LD_LIBRARY_PATH.)
+
     The default build (plain "make") never references htslib; BAM input just
     isn't available in that binary. Install htslib from
     https://github.com/samtools/htslib (or "brew install htslib",
-    "apt-get install libhts-dev", etc.).
+    "apt-get install libhts-dev", a cluster module, etc.).
 
 Type:
 >geneid -h


### PR DESCRIPTION
A `WITH_HTSLIB` build done via `HTSLIB_PREFIX` (not a cluster module) linked fine but failed at **run time**:

```
./bin/geneid: error while loading shared libraries: libhts.so.3: cannot open shared object file
```

`-L$(HTSLIB_PREFIX)/lib` is only a **link-time** path -- it isn't recorded in the binary, so the runtime loader (`ld.so`) had no way to find `libhts.so.*`. `module load HTSlib` masked this because it sets `LD_LIBRARY_PATH`.

Fix: add `-Wl,-rpath,$(HTSLIB_PREFIX)/lib` to the htslib link flags, baking that dir into the binary's runtime search path (`RUNPATH` on Linux, `LC_RPATH` on macOS). geneid then finds `libhts.so.*` on its own -- no module load, no `LD_LIBRARY_PATH`. Harmless when htslib comes from a module or the default prefix.

```sh
make WITH_HTSLIB=1 HTSLIB_PREFIX=/software/HTSlib/1.22.1-GCC-14.3.0
./bin/geneid ...    # just works
```

README updated with the runtime note + an `LD_LIBRARY_PATH` fallback. Verified the rpath is embedded (`readelf -d bin/geneid | grep RUNPATH` on Linux; `LC_RPATH` via `otool -l` on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)