### PR TITLE
geneid-train: UTR gene model (train --utr) + retrofit subcommand

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -77,8 +77,9 @@ Train a parameter file, then tune and evaluate it:
 
 ```bash
 # GFF3 annotation + genome -> a complete geneid .param
+# add --utr for a UTR-aware gene model (geneid -u with -S/-Y RNA-seq coverage)
 geneid-train train --gff annotation.gff3 --fastas genome.fa \
-    --species Genus_species --output Genus_species.param [--u12] [--u2-branch]
+    --species Genus_species --output Genus_species.param [--utr] [--u12] [--u2-branch]
 
 # grid/search the exon weights against a held-out set
 geneid-train optimize --param Genus_species.param \
@@ -89,6 +90,21 @@ geneid-train evaluate predictions.gff annotation.gff
 geneid-train jackknife --gff annotation.gff3 --fastas genome.fa \
     --species Genus_species --eval-fastas eval.fa --eval-gff eval.gff3
 ```
+
+Retrofit an existing (CDS-only) param with newer capabilities, non-destructively:
+
+```bash
+# add a UTR-aware gene model + the human soft intron-length model (weight 0 = inert)
+geneid-train retrofit Genus_species.param -o Genus_species.rnaseq.param \
+    --utr --intron-length human
+```
+
+`--utr` reuses the param's own trained intron range and sets the intergenic
+minimum to 0 (neighbouring UTRs may abut/overlap). `--intron-length` takes
+`human` or an explicit `mu,sigma`; the weight defaults to 0 (no prediction
+change) — set `--intron-length-weight` or retrain per species to enable the
+penalty. Both injections are skipped if the param already has them. (U12
+retrofit and multi-isochore params are planned follow-ups.)
 
 `optimize`, `evaluate`, and `jackknife` need a compiled `geneid` binary on your
 `PATH` (or pass `--geneid /path/to/geneid`); build it from the repo root with

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -247,6 +247,7 @@ def _cmd_train(args: argparse.Namespace) -> int:
             u12_splice_thresh=args.u12_splice_thresh, u12_exon_thresh=args.u12_exon_thresh,
             u2_branch=args.u2_branch, branch_weight=args.branch_weight,
             max_intron=args.max_intron, intron_length_weight=args.intron_length_weight,
+            utr=args.utr,
         )
     except NotImplementedError as exc:
         sys.stderr.write(f"geneid-train train: {exc}\n")
@@ -254,6 +255,40 @@ def _cmd_train(args: argparse.Namespace) -> int:
     with open(args.output, "w") as fh:
         fh.write(param_text)
     print(f"wrote parameter file: {args.output}")
+    return 0
+
+
+def _cmd_retrofit(args: argparse.Namespace) -> int:
+    from .param.gene_model import HUMAN_INTRON_LENGTH_MODEL
+    from .param.retrofit import retrofit_param
+
+    if not (args.utr or args.intron_length):
+        sys.stderr.write("retrofit: nothing to do (pass --utr and/or --intron-length)\n")
+        return 2
+
+    intron_length = None
+    if args.intron_length:
+        if args.intron_length == "human":
+            intron_length = HUMAN_INTRON_LENGTH_MODEL
+        else:
+            try:
+                mu, sigma = (float(x) for x in args.intron_length.split(","))
+            except ValueError:
+                sys.stderr.write("retrofit: --intron-length must be 'human' or 'mu,sigma'\n")
+                return 2
+            intron_length = (mu, sigma)
+
+    try:
+        out = retrofit_param(
+            open(args.param).read(), utr=args.utr, intron_length=intron_length,
+            intron_length_weight=args.intron_length_weight,
+        )
+    except (NotImplementedError, ValueError) as exc:
+        sys.stderr.write(f"geneid-train retrofit: {exc}\n")
+        return 2
+    with open(args.output, "w") as fh:
+        fh.write(out)
+    print(f"wrote retrofitted parameter file: {args.output}")
     return 0
 
 
@@ -366,7 +401,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="Branch_point_score_weight: contribution of the branch score to the acceptor "
              "score (default 0 = scored and reported via bp_score/bp_pos but not counted)",
     )
+    p_train.add_argument(
+        "--utr", action="store_true",
+        help="emit a UTR-aware gene model so geneid -u (with -S/-Y RNA-seq coverage) predicts "
+             "UTRs; intergenic minimum drops to 0 so neighbouring UTRs may abut/overlap",
+    )
     p_train.set_defaults(func=_cmd_train)
+
+    p_retro = sub.add_parser(
+        "retrofit",
+        help="add UTR and/or the intron-length model to an existing .param (non-destructive)",
+    )
+    p_retro.add_argument("param", help="existing .param to retrofit")
+    p_retro.add_argument("-o", "--output", required=True, help="output .param path")
+    p_retro.add_argument(
+        "--utr", action="store_true",
+        help="inject a UTR-aware gene model (reuses the param's own intron range; intergenic "
+             "minimum 0). Skipped if the gene model already has UTR rules",
+    )
+    p_retro.add_argument(
+        "--intron-length", metavar="human|mu,sigma", default=None,
+        help="inject a soft intron-length model: 'human' for the bundled human log-normal, or "
+             "explicit 'mu,sigma'. Skipped if the param already has one",
+    )
+    p_retro.add_argument(
+        "--intron-length-weight", type=float, default=0.0,
+        help="Intron_length_score_weight (lambda) for the injected model; default 0 = inert "
+             "(no prediction change) until you enable it or retrain per species",
+    )
+    p_retro.set_defaults(func=_cmd_retrofit)
 
     p_opt = sub.add_parser(
         "optimize", help="grid-search exon/site weights against a held-out set (maximise SNSP)"

--- a/training/src/geneid_train/core/param.py
+++ b/training/src/geneid_train/core/param.py
@@ -137,6 +137,13 @@ class Param:
     def vector(self, keyword: str, index: int = 0) -> list[str]:
         return self.scalar(keyword, index).split()
 
+    def data_lines(self, keyword: str, index: int = 0) -> list[str]:
+        """Every data line of a section, stripped (skips the keyword line and any
+        comment/blank lines). Used to read multi-line sections like the gene
+        model where the first line alone is not enough."""
+        block = self._find(keyword, index)
+        return [block.raw[i].strip() for i in block.data_line_indices()]
+
     def set_scalar(self, keyword: str, value: object, index: int = 0) -> None:
         """Replace the single data line of a section, preserving line ending."""
         block = self._find(keyword, index)

--- a/training/src/geneid_train/param/assemble.py
+++ b/training/src/geneid_train/param/assemble.py
@@ -19,6 +19,7 @@ from importlib.resources import files
 
 from ..core.param import Param
 from ..stats.genemodel import DEFAULT_INTRON_LENGTH_WEIGHT
+from .gene_model import utr_gene_model_lines
 from .u12 import U12Sections
 
 
@@ -44,6 +45,7 @@ def assemble_param(
     u12_exon_thresh: float = 8.0,
     intron_length_model: tuple[float, float] | None = None,
     intron_length_weight: float = DEFAULT_INTRON_LENGTH_WEIGHT,
+    utr: bool = False,
 ) -> str:
     """Build a full geneid param. Profile/Markov args are geneid-format data
     lines (from ``stats.sites.format_profile`` / ``stats.coding.format_markov_matrix``);
@@ -68,6 +70,12 @@ def assemble_param(
     p.set_scalar("Markov_order", markov_order)
     p.replace_block_data("Markov_Initial_probability_matrix", markov_initial)
     p.replace_block_data("Markov_Transition_probability_matrix", markov_transition)
+
+    if utr:
+        # Swap the CDS-only gene model for a UTR-aware one; the intragenic CDS
+        # intron distance keeps the @INTRON_RANGE@ sentinel (filled below), the
+        # intergenic minimum drops to 0 (neighbouring UTRs may abut/overlap).
+        p.replace_block_data("General_Gene_Model", utr_gene_model_lines("@INTRON_RANGE@"))
 
     if u12 is not None:
         # order matters only in that each optional profile must precede the fixed

--- a/training/src/geneid_train/param/gene_model.py
+++ b/training/src/geneid_train/param/gene_model.py
@@ -1,0 +1,115 @@
+"""GenAmic gene-model rules for UTR-aware prediction.
+
+The bundled ``template.param`` carries a CDS-only gene model. Turning on UTR
+prediction (geneid ``-u`` with ``-S``/``-Y`` coverage) needs the gene model to
+declare the UTR exon types and their connections, so ``assemble`` (``train
+--utr``) and ``retrofit --utr`` swap in the block built here.
+
+Two deliberate choices vs the legacy hand-made human RNA-seq param:
+  * the intergenic minimum distance is 0 (not 60): a gene's UTRs extend it, and
+    neighbouring genes' UTRs routinely abut or overlap, so 0 is the sane floor;
+  * the canonical exon-type name ``UTR_5prime_Internal_Half`` is used throughout
+    (the legacy param had a ``UTR_5Internal_Half`` typo that never matched).
+
+The UTR exon types must match geneid's include/geneid.h sUTR* definitions.
+"""
+
+from __future__ import annotations
+
+# Human soft intron-length model (log-normal mu, sigma over ln(intron length)),
+# from the chr12 training set. A reasonable default to inject when retrofitting a
+# param that has no Intron_length_model; species without a fit should keep the
+# penalty weight at 0 (see retrofit).
+HUMAN_INTRON_LENGTH_MODEL: tuple[float, float] = (7.1788, 1.51411)
+
+UTR_INTERGENIC = "0:Infinity"
+
+
+def _rule(antecedent: str, consequent: str, drange: str) -> str:
+    """One gene-model rule line: antecedent, consequent, distance range. geneid
+    tokenizes on whitespace, so the padding is purely for human readability."""
+    return f"{antecedent:<56} {consequent:<56} {drange}"
+
+
+def utr_gene_model_lines(intron_range: str, intergenic: str = UTR_INTERGENIC) -> list[str]:
+    """Data lines for a UTR-aware ``General_Gene_Model`` section.
+
+    ``intron_range`` is the ``min:max`` token for the intragenic CDS intron
+    distance (a real value when retrofitting, or the ``@INTRON_RANGE@`` sentinel
+    when assembling from the template). ``intergenic`` defaults to ``0:Infinity``.
+    """
+    lines: list[str] = []
+
+    lines.append("# INTRAgenic connections (CDS)")
+    lines.append(_rule("First+:Internal+", "Internal+:Terminal+", intron_range))
+    lines.append(_rule("Internal-:Terminal-", "First-:Internal-", intron_range))
+    for a, b in (
+        ("First+", "Intron+"), ("Internal+", "Intron+"),
+        ("Intron+", "Internal+"), ("Intron+", "Terminal+"),
+        ("Intron-", "First-"), ("Internal-", "Intron-"),
+        ("Intron-", "Internal-"), ("Terminal-", "Intron-"),
+    ):
+        lines.append(_rule(a, b, "1:1"))
+
+    lines.append("# UTR exons: attach to the coding gene and splice among themselves")
+    lines.append(_rule("UTR_First_Half+:UTR_5prime_Internal_Half+", "First+:Single+", "1:1"))
+    lines.append(_rule("Terminal+:Single+", "UTR_Terminal_Half+:UTR_3prime_Internal_Half+", "1:1"))
+    lines.append(_rule("First-:Single-", "UTR_First_Half-:UTR_5prime_Internal_Half-", "1:1"))
+    lines.append(_rule("UTR_Terminal_Half-:UTR_3prime_Internal_Half-", "Terminal-:Single-", "1:1"))
+    lines.append(_rule("UTR_First+", "UTR_5prime_Intron+:UTR_3prime_Intron+", "1:1"))
+    lines.append(_rule("UTR_Internal+", "UTR_5prime_Intron+:UTR_3prime_Intron+", "1:1"))
+    lines.append(_rule("UTR_3prime_Internal_Half+", "UTR_3prime_Intron+", "1:1"))
+    lines.append(_rule("UTR_5prime_Intron+", "UTR_Internal+:UTR_5prime_Internal_Half+", "1:1"))
+    lines.append(_rule("UTR_3prime_Intron+", "UTR_Terminal+", "1:1"))
+    lines.append(_rule("UTR_5prime_Intron-:UTR_3prime_Intron-", "UTR_First-", "1:1"))
+    lines.append(_rule("UTR_5prime_Intron-:UTR_3prime_Intron-", "UTR_Internal-", "1:1"))
+    lines.append(_rule("UTR_3prime_Intron-", "UTR_3prime_Internal_Half-", "1:1"))
+    lines.append(_rule("UTR_Internal-:UTR_5prime_Internal_Half-", "UTR_5prime_Intron-", "1:1"))
+    lines.append(_rule("UTR_Terminal-", "UTR_3prime_Intron-", "1:1"))
+
+    lines.append("# External features (promoter / poly-A signal)")
+    lines.append(_rule("Promoter+", "First+:Single+", "50:4000"))
+    lines.append(_rule("First-:Single-", "Promoter-", "50:4000"))
+    lines.append(_rule("Terminal+:Single+", "aataaa+", "50:4000"))
+    lines.append(_rule("aataaa-", "Terminal-:Single-", "50:4000"))
+
+    lines.append("# INTERgenic connections (UTR-aware; min 0 so neighbouring UTRs may overlap)")
+    fwd_end = "aataaa+:Terminal+:Single+:UTR_Terminal+:UTR_Terminal_Half+"
+    fwd_start = "Single+:First+:Promoter+:UTR_First+:UTR_First_Half+"
+    rev_end = "Promoter-:First-:Single-:UTR_First-:UTR_First_Half-"
+    rev_start = "Single-:Terminal-:aataaa-:UTR_Terminal-:UTR_Terminal_Half-"
+    lines.append(_rule(fwd_end, fwd_start, intergenic))
+    lines.append(_rule(fwd_end, rev_start, intergenic))
+    lines.append(_rule(rev_end, fwd_start, intergenic))
+    lines.append(_rule(rev_end, rev_start, intergenic))
+
+    lines.append("# BEGINNING and END of prediction")
+    lines.append(_rule(
+        "Begin+",
+        "First+:Internal+:Terminal+:Single+:UTR_First+:UTR_First_Half+:UTR_5prime_Internal_Half+",
+        "0:Infinity"))
+    lines.append(_rule(
+        "Begin-",
+        "First-:Internal-:Terminal-:Single-:UTR_Terminal_Half-:UTR_3prime_Internal_Half-:UTR_Terminal-",
+        "0:Infinity"))
+    lines.append(_rule(
+        "First+:Internal+:Terminal+:Single+:UTR_Terminal_Half+:UTR_Terminal+:UTR_3prime_Internal_Half+",
+        "End+", "0:Infinity"))
+    lines.append(_rule(
+        "First-:Internal-:Terminal-:Single-:UTR_First-:UTR_First_Half-:UTR_5prime_Internal_Half-",
+        "End-", "0:Infinity"))
+    return lines
+
+
+def extract_intron_range(param) -> str:  # noqa: ANN001 (Param, avoid import cycle)
+    """Return the intragenic CDS intron ``min:max`` from a param's gene model
+    (the ``First+:Internal+ -> Internal+:Terminal+`` rule). Raises if the gene
+    model does not have the expected standard structure."""
+    for line in param.data_lines("General_Gene_Model"):
+        toks = line.split()
+        if len(toks) >= 3 and toks[0] == "First+:Internal+":
+            return toks[2]
+    raise ValueError(
+        "gene model has no 'First+:Internal+' intragenic rule; cannot determine "
+        "the intron range to preserve (non-standard gene model?)"
+    )

--- a/training/src/geneid_train/param/retrofit.py
+++ b/training/src/geneid_train/param/retrofit.py
@@ -1,0 +1,73 @@
+"""Retrofit an existing geneid parameter file with newer capabilities.
+
+Older params (and anything the trainer emitted before these features) are
+CDS-only. ``retrofit`` injects, non-destructively and idempotently, the pieces
+needed for the modern RNA-seq workflow onto an existing param:
+
+  * ``--utr``: a UTR-aware gene model (so ``geneid -u`` with ``-S``/``-Y``
+    coverage predicts UTRs), reusing the param's own trained intron range and
+    dropping the intergenic minimum to 0;
+  * ``--intron-length``: the soft intron-length penalty section (log-normal
+    mu/sigma + weight), defaulting the weight to 0 (inert) so it never changes
+    predictions until deliberately enabled.
+
+U12 retrofit is a planned follow-up (it needs the bundled profiles re-registered
+onto the target param's donor/acceptor geometry -- see param/u12.py).
+
+Only single-isochore params are supported for now (the trainer produces those;
+multi-isochore params like human.rnaseq.param are already UTR-capable).
+"""
+
+from __future__ import annotations
+
+from ..core.param import Param
+from .gene_model import HUMAN_INTRON_LENGTH_MODEL, extract_intron_range, utr_gene_model_lines
+
+
+def _has_utr(param: Param) -> bool:
+    return any("UTR_" in line for line in param.data_lines("General_Gene_Model"))
+
+
+def retrofit_param(
+    text: str,
+    *,
+    utr: bool = False,
+    intron_length: tuple[float, float] | None = None,
+    intron_length_weight: float = 0.0,
+) -> str:
+    """Return the retrofitted param text. ``intron_length`` may be
+    ``HUMAN_INTRON_LENGTH_MODEL`` or an explicit ``(mu, sigma)``."""
+    p = Param.from_text(text)
+
+    if p.has("number_of_isochores") and p.num_isochores > 1:
+        raise NotImplementedError(
+            f"retrofit supports single-isochore params only (found "
+            f"{p.num_isochores} isochores); multi-isochore support is a follow-up"
+        )
+
+    if utr:
+        if _has_utr(p):
+            print("retrofit: gene model already has UTR rules; leaving it unchanged")
+        else:
+            intron_range = extract_intron_range(p)
+            p.replace_block_data("General_Gene_Model", utr_gene_model_lines(intron_range))
+
+    if intron_length is not None:
+        if p.has("Intron_length_model"):
+            print("retrofit: param already has an Intron_length_model; leaving it unchanged")
+        else:
+            mu, sigma = intron_length
+            src = "human default" if intron_length == HUMAN_INTRON_LENGTH_MODEL else "supplied"
+            p.insert_text_before(
+                "Exon_weights",
+                "# Soft intron-length penalty: log-normal (mu sigma) over ln(intron length)\n"
+                f"# + weight (lambda). mu/sigma below are the {src} values; for another\n"
+                "# species either retrain (geneid-train optimize --tune-intron-length) or\n"
+                "# keep the weight at 0 to use the hard gene-model max-distance gate instead.\n"
+                "Intron_length_model\n"
+                f"{mu:.6g} {sigma:.6g}\n"
+                "Intron_length_score_weight\n"
+                f"{intron_length_weight:g}\n",
+            )
+
+    return p.to_text()

--- a/training/src/geneid_train/train.py
+++ b/training/src/geneid_train/train.py
@@ -107,6 +107,7 @@ def train(
     branch_weight: float = 0.0,
     max_intron: float | None = DEFAULT_MAX_INTRON,
     intron_length_weight: float = DEFAULT_INTRON_LENGTH_WEIGHT,
+    utr: bool = False,
 ) -> str:
     """Train a geneid parameter file from complete, filtered gene ``models``.
 
@@ -195,6 +196,7 @@ def train(
         u12=u12_sections,
         u12_splice_thresh=u12_splice_thresh,
         u12_exon_thresh=u12_exon_thresh,
+        utr=utr,
     )
 
     if u2_branch:

--- a/training/tests/test_gene_model.py
+++ b/training/tests/test_gene_model.py
@@ -1,0 +1,38 @@
+import pytest
+
+from geneid_train.core.param import Param
+from geneid_train.param.gene_model import extract_intron_range, utr_gene_model_lines
+
+
+def test_utr_lines_use_canonical_names_and_zero_intergenic():
+    lines = utr_gene_model_lines("40:10000")
+    text = "\n".join(lines)
+    # canonical exon-type names (geneid.h sUTR*), not the legacy typo
+    assert "UTR_5prime_Internal_Half" in text
+    assert "UTR_5Internal_Half" not in text
+    assert "40:10000" in text  # the intron range is carried through verbatim
+    # the four intergenic rules must use a 0 minimum (UTRs may abut/overlap)
+    inter = [ln for ln in lines
+             if ln.startswith(("aataaa+:Terminal+", "Promoter-:First-"))]
+    assert len(inter) == 4
+    assert all(ln.split()[-1] == "0:Infinity" for ln in inter)
+
+
+def test_utr_lines_preserve_sentinel_for_assembly():
+    # when assembling from the template the range is still the sentinel
+    assert any("@INTRON_RANGE@" in ln for ln in utr_gene_model_lines("@INTRON_RANGE@"))
+
+
+def test_extract_intron_range():
+    p = Param.from_text(
+        "General_Gene_Model\n"
+        "First+:Internal+  Internal+:Terminal+  40:23712.339\n"
+        "First+  Intron+  1:1\n"
+    )
+    assert extract_intron_range(p) == "40:23712.339"
+
+
+def test_extract_intron_range_raises_on_nonstandard():
+    p = Param.from_text("General_Gene_Model\nWeird+  Rule+  1:1\n")
+    with pytest.raises(ValueError):
+        extract_intron_range(p)

--- a/training/tests/test_retrofit.py
+++ b/training/tests/test_retrofit.py
@@ -1,0 +1,53 @@
+import pytest
+
+from geneid_train.core.param import Param
+from geneid_train.param.gene_model import HUMAN_INTRON_LENGTH_MODEL
+from geneid_train.param.retrofit import retrofit_param
+
+# minimal single-isochore CDS-only param: a gene model with the standard
+# intragenic rule, and an Exon_weights anchor for the intron-length insertion.
+MINI = (
+    "number_of_isochores\n1\n"
+    "General_Gene_Model\n"
+    "First+:Internal+  Internal+:Terminal+  40:9000\n"
+    "First+  Intron+  1:1\n"
+    "Exon_weights\n1 1 1 1\n"
+)
+
+
+def test_retrofit_utr_adds_rules_and_preserves_range():
+    out = retrofit_param(MINI, utr=True)
+    p = Param.from_text(out)
+    gm = p.data_lines("General_Gene_Model")
+    assert any("UTR_First_Half" in ln for ln in gm)
+    assert any(ln.split()[-1] == "0:Infinity" for ln in gm)  # UTR intergenic min 0
+    intragenic = next(ln for ln in gm if ln.startswith("First+:Internal+"))
+    assert intragenic.split()[-1] == "40:9000"  # the param's own intron range kept
+
+
+def test_retrofit_intron_length_human_inserted_before_exon_weights():
+    out = retrofit_param(MINI, intron_length=HUMAN_INTRON_LENGTH_MODEL, intron_length_weight=0.0)
+    p = Param.from_text(out)
+    assert p.scalar("Intron_length_model") == "7.1788 1.51411"
+    assert p.scalar("Intron_length_score_weight") == "0"
+    kws = p.keywords()
+    assert kws.index("Intron_length_model") < kws.index("Exon_weights")
+
+
+def test_retrofit_is_idempotent():
+    once = retrofit_param(MINI, utr=True, intron_length=HUMAN_INTRON_LENGTH_MODEL)
+    twice = retrofit_param(once, utr=True, intron_length=HUMAN_INTRON_LENGTH_MODEL)
+    assert once == twice  # second pass detects both are present and injects nothing
+
+
+def test_retrofit_rejects_multi_isochore():
+    multi = MINI.replace("number_of_isochores\n1\n", "number_of_isochores\n3\n")
+    with pytest.raises(NotImplementedError):
+        retrofit_param(multi, utr=True)
+
+
+def test_retrofit_roundtrips_other_sections_unchanged():
+    # a section we don't touch must be byte-identical afterwards
+    src = MINI + "Some_Other_Section\n0.5\n"
+    out = retrofit_param(src, utr=True)
+    assert "Some_Other_Section\n0.5\n" in out


### PR DESCRIPTION
Closes the gap you spotted: the trainer template was **CDS-only**, so `geneid-train`-produced params couldn't do UTR prediction (`-u`) and had no soft intron-length model — my RNA-seq/BAM testing only ever used the hand-curated `human.rnaseq.param`.

### 1. `train --utr` (a)
`assemble_param(utr=True)` swaps in a **UTR-aware `General_Gene_Model`** (`param/gene_model.py`). It declares the UTR exon types + connections using the **canonical `geneid.h` `sUTR*` names** (fixing the legacy `UTR_5Internal_Half` typo, which never matched), keeps the trained `@INTRON_RANGE@` for CDS introns, and sets the intergenic **minimum to 0** — a gene's UTRs extend it and neighbouring UTRs routinely abut/overlap, so 60 bp made no sense (your point).

### 2. `geneid-train retrofit` (b)
```
geneid-train retrofit <param> -o <out> [--utr] [--intron-length human|mu,sigma] [--intron-length-weight W]
```
Non-destructively adds UTR and/or the soft intron-length model to an **existing** param (`param/retrofit.py`):
- `--utr` reuses the param's *own* trained intron range;
- `--intron-length` injects the log-normal (human default `7.1788 1.51411`) with a commented weight **defaulting to 0** (inert until you enable it or retrain per species);
- both are **idempotent** (skip if already present); single-isochore for now.

(U12 retrofit + multi-isochore are the planned follow-ups; the snake RNA-seq BAM test is the other.)

### Validated end-to-end
Retrofit the CDS-only **snake** param with `--utr --intron-length human` → a valid v1.6 param that **predicts a `UTR_Terminal_Half` exon** under `-3U -u -S` (synthetic coverage); intron range preserved, intron-length section present with weight 0. New tests (`test_gene_model`, `test_retrofit`) 9 pass; full trainer suite **159 passed / 20 skipped**; ruff clean. Trainer README updated.

Core helper: `Param.data_lines()` (read all data lines of a section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)