### PR TITLE
geneid-train retrofit: add --u12 (bundled U12 profile trio + gates)

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -94,17 +94,19 @@ geneid-train jackknife --gff annotation.gff3 --fastas genome.fa \
 Retrofit an existing (CDS-only) param with newer capabilities, non-destructively:
 
 ```bash
-# add a UTR-aware gene model + the human soft intron-length model (weight 0 = inert)
+# UTR-aware gene model + human soft intron-length model (weight 0 = inert) + U12
 geneid-train retrofit Genus_species.param -o Genus_species.rnaseq.param \
-    --utr --intron-length human
+    --utr --intron-length human --u12
 ```
 
 `--utr` reuses the param's own trained intron range and sets the intergenic
 minimum to 0 (neighbouring UTRs may abut/overlap). `--intron-length` takes
 `human` or an explicit `mu,sigma`; the weight defaults to 0 (no prediction
 change) — set `--intron-length-weight` or retrain per species to enable the
-penalty. Both injections are skipped if the param already has them. (U12
-retrofit and multi-isochore params are planned follow-ups.)
+penalty. `--u12` injects the bundled pan-taxon U12 profile trio + acceptance
+gates so `geneid -U` predicts U12 introns (the profiles carry their own geneid
+geometry, so they drop into any param). Each injection is skipped if the param
+already has it. (Multi-isochore params are a planned follow-up.)
 
 `optimize`, `evaluate`, and `jackknife` need a compiled `geneid` binary on your
 `PATH` (or pass `--geneid /path/to/geneid`); build it from the repo root with

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -262,8 +262,8 @@ def _cmd_retrofit(args: argparse.Namespace) -> int:
     from .param.gene_model import HUMAN_INTRON_LENGTH_MODEL
     from .param.retrofit import retrofit_param
 
-    if not (args.utr or args.intron_length):
-        sys.stderr.write("retrofit: nothing to do (pass --utr and/or --intron-length)\n")
+    if not (args.utr or args.intron_length or args.u12):
+        sys.stderr.write("retrofit: nothing to do (pass --utr, --intron-length and/or --u12)\n")
         return 2
 
     intron_length = None
@@ -282,6 +282,8 @@ def _cmd_retrofit(args: argparse.Namespace) -> int:
         out = retrofit_param(
             open(args.param).read(), utr=args.utr, intron_length=intron_length,
             intron_length_weight=args.intron_length_weight,
+            u12=args.u12, u12_splice_thresh=args.u12_splice_thresh,
+            u12_exon_thresh=args.u12_exon_thresh,
         )
     except (NotImplementedError, ValueError) as exc:
         sys.stderr.write(f"geneid-train retrofit: {exc}\n")
@@ -428,6 +430,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--intron-length-weight", type=float, default=0.0,
         help="Intron_length_score_weight (lambda) for the injected model; default 0 = inert "
              "(no prediction change) until you enable it or retrain per species",
+    )
+    p_retro.add_argument(
+        "--u12", action="store_true",
+        help="inject the bundled pan-taxon U12 profile trio + acceptance gates so geneid -U "
+             "predicts U12 introns. Skipped if the param already has U12 profiles",
+    )
+    p_retro.add_argument(
+        "--u12-splice-thresh", type=float, default=9.0,
+        help="U12_Splice_Score_Threshold for --u12 (default 9, conservative; lower over-calls)",
+    )
+    p_retro.add_argument(
+        "--u12-exon-thresh", type=float, default=8.0,
+        help="U12_Exon_Score_Threshold for --u12 (default 8)",
     )
     p_retro.set_defaults(func=_cmd_retrofit)
 

--- a/training/src/geneid_train/param/retrofit.py
+++ b/training/src/geneid_train/param/retrofit.py
@@ -9,10 +9,12 @@ needed for the modern RNA-seq workflow onto an existing param:
     dropping the intergenic minimum to 0;
   * ``--intron-length``: the soft intron-length penalty section (log-normal
     mu/sigma + weight), defaulting the weight to 0 (inert) so it never changes
-    predictions until deliberately enabled.
-
-U12 retrofit is a planned follow-up (it needs the bundled profiles re-registered
-onto the target param's donor/acceptor geometry -- see param/u12.py).
+    predictions until deliberately enabled;
+  * ``--u12``: the bundled pan-taxon U12 (minor-spliceosome) profile trio plus
+    the U12 acceptance-score gates, so ``geneid -U`` predicts U12 introns. The
+    profiles carry their own geneid geometry (offset/length, from the reference
+    U12 param -- see param/u12.py), so they drop into any param's Donor/Acceptor
+    slot; nothing genome-specific is re-registered here.
 
 Only single-isochore params are supported for now (the trainer produces those;
 multi-isochore params like human.rnaseq.param are already UTR-capable).
@@ -22,6 +24,7 @@ from __future__ import annotations
 
 from ..core.param import Param
 from .gene_model import HUMAN_INTRON_LENGTH_MODEL, extract_intron_range, utr_gene_model_lines
+from .u12 import load_bundled_u12
 
 
 def _has_utr(param: Param) -> bool:
@@ -34,6 +37,9 @@ def retrofit_param(
     utr: bool = False,
     intron_length: tuple[float, float] | None = None,
     intron_length_weight: float = 0.0,
+    u12: bool = False,
+    u12_splice_thresh: float = 9.0,
+    u12_exon_thresh: float = 8.0,
 ) -> str:
     """Return the retrofitted param text. ``intron_length`` may be
     ``HUMAN_INTRON_LENGTH_MODEL`` or an explicit ``(mu, sigma)``."""
@@ -69,5 +75,24 @@ def retrofit_param(
                 "Intron_length_score_weight\n"
                 f"{intron_length_weight:g}\n",
             )
+
+    if u12:
+        # geneid enables a U12 subtype only when its full profile trio is present
+        # (branch + donor + acceptor); the bundle carries GT-AG and AT-AC.
+        if p.has("U12gtag_Donor_profile"):
+            print("retrofit: param already has U12 profiles; leaving them unchanged")
+        else:
+            sections = load_bundled_u12()
+            # optional profiles must precede the required profile they extend
+            p.insert_text_before("Acceptor_profile", sections.acceptor_side)
+            p.insert_text_before("Donor_profile", sections.donor_side)
+            # the U12 acceptance gates (without them geneid's -1000 default
+            # mass-mislabels U2 GT-AG as U12); read before Exon_weights
+            if not p.has("U12_Splice_Score_Threshold"):
+                p.insert_text_before(
+                    "Exon_weights",
+                    f"U12_Splice_Score_Threshold\n{u12_splice_thresh:g}\n"
+                    f"U12_Exon_Score_Threshold\n{u12_exon_thresh:g}\n",
+                )
 
     return p.to_text()

--- a/training/tests/test_retrofit.py
+++ b/training/tests/test_retrofit.py
@@ -4,10 +4,13 @@ from geneid_train.core.param import Param
 from geneid_train.param.gene_model import HUMAN_INTRON_LENGTH_MODEL
 from geneid_train.param.retrofit import retrofit_param
 
-# minimal single-isochore CDS-only param: a gene model with the standard
-# intragenic rule, and an Exon_weights anchor for the intron-length insertion.
+# minimal single-isochore CDS-only param: Donor/Acceptor_profile anchors (for the
+# U12 insertion), the standard gene-model intragenic rule, and an Exon_weights
+# anchor (for the intron-length + U12-threshold insertions).
 MINI = (
     "number_of_isochores\n1\n"
+    "Donor_profile\n8 1 -7 1 0 1\n1 AA 0\n"
+    "Acceptor_profile\n30 28 -7 1 0 1\n1 AA 0\n"
     "General_Gene_Model\n"
     "First+:Internal+  Internal+:Terminal+  40:9000\n"
     "First+  Intron+  1:1\n"
@@ -34,10 +37,25 @@ def test_retrofit_intron_length_human_inserted_before_exon_weights():
     assert kws.index("Intron_length_model") < kws.index("Exon_weights")
 
 
+def test_retrofit_u12_inserts_trio_and_gates_in_the_right_slots():
+    out = retrofit_param(MINI, u12=True)
+    p = Param.from_text(out)
+    for name in ("U12_Branch_point_profile", "U12gtag_Donor_profile", "U12atac_Donor_profile",
+                 "U12gtag_Acceptor_profile", "U12atac_Acceptor_profile"):
+        assert p.has(name)
+    assert p.scalar("U12_Splice_Score_Threshold") == "9"
+    kws = p.keywords()
+    # optional profiles precede the required profile they extend
+    assert kws.index("U12gtag_Donor_profile") < kws.index("Donor_profile")
+    assert kws.index("U12_Branch_point_profile") < kws.index("Acceptor_profile")
+    assert kws.index("U12_Splice_Score_Threshold") < kws.index("Exon_weights")
+
+
 def test_retrofit_is_idempotent():
-    once = retrofit_param(MINI, utr=True, intron_length=HUMAN_INTRON_LENGTH_MODEL)
-    twice = retrofit_param(once, utr=True, intron_length=HUMAN_INTRON_LENGTH_MODEL)
-    assert once == twice  # second pass detects both are present and injects nothing
+    kw = dict(utr=True, intron_length=HUMAN_INTRON_LENGTH_MODEL, u12=True)
+    once = retrofit_param(MINI, **kw)
+    twice = retrofit_param(once, **kw)
+    assert once == twice  # second pass detects all present and injects nothing
 
 
 def test_retrofit_rejects_multi_isochore():


### PR DESCRIPTION
Third retrofit capability (follows the UTR + intron-length work in #69).

`geneid-train retrofit <param> -o <out> --u12` injects the bundled **pan-taxon U12** (minor-spliceosome) profile trio — `U12_Branch_point_profile` + GT-AG/AT-AC donor & acceptor — plus the `U12_Splice_Score_Threshold` / `U12_Exon_Score_Threshold` gates, so `geneid -U` predicts U12 introns on an existing CDS-only param.

Reuses `u12.load_bundled_u12()` and the **same insertion points as `train --u12`** (optional profiles before the required `Donor_profile`/`Acceptor_profile`; gates before `Exon_weights`). The bundled profiles carry their own geneid geometry (offset/length from the reference U12 param), so they drop into any single-isochore param — nothing genome-specific is re-registered. Idempotent.

### Validated
`retrofit param/human1iso.param --u12` → geneid loads the branch profile + U12 gates and scores U12 sites; via `-J -O` on the MORC3 locus it classifies the U12 **AT-AC** intron (36337947-36338773) **exactly like the reference `human3isoU12.param`**. The *hard* GT-AG U12 is called U2 — the expected precision/sensitivity tradeoff of the pan-taxon bundle vs native human U12 profiles (identical to what `train --u12` yields; and a genome retrofitting U12 has no native profiles anyway).

`test_retrofit`: +U12 slot-order test, idempotency now covers all three injections; suite **160 passed / 20 skipped**; ruff clean. README updated.

Remaining retrofit follow-up: multi-isochore params. (The snake RNA-seq BAM end-to-end test is separate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)