### PR TITLE
geneid-train: RNA-seq evaluation harness (benchmark subcommand)

### DIFF
--- a/training/src/geneid_train/benchmark.py
+++ b/training/src/geneid_train/benchmark.py
@@ -1,0 +1,212 @@
+"""Benchmark geneid predictions against a GENCODE reference (MANE Select).
+
+Turns "does this RNA-seq mode help?" into SN/SP numbers. Two pieces:
+
+  * ``gencode_mane_gp`` converts a GENCODE GFF3 into geneid's gp-format CDS
+    truth for one sequence -- the MANE Select transcript of each protein-coding
+    gene, its CDS exons typed First/Internal/Terminal/Single (transcription
+    order) and grouped by transcript, with the per-locus info line evaluate.py
+    expects (field 5 = sequence length).
+  * ``run_benchmark`` runs geneid over the sequence in several evidence modes
+    (ab initio, +coverage, +UTR, +BAM, ...) and scores each with
+    :func:`geneid_train.evaluate.evaluate_files`, so the deltas show which mode
+    (and knob) helps or hurts.
+
+Mode A (refine ab-initio) today; the same harness will score Mode B
+(evidence-gated reconstruction) once that lands.
+"""
+
+from __future__ import annotations
+
+import gzip
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from .evaluate import (
+    Accuracy,
+    Exon,
+    Totals,
+    _by_strand,
+    _exact_matches,
+    _gene_matches,
+    _no_overlap_count,
+    _overlap_nt,
+    accumulate,
+    read_annotation_gff,
+    read_prediction_gff,
+)
+
+_TYPED = ("First", "Internal", "Terminal", "Single")
+
+
+def _merge(exons: list[Exon]) -> dict[str, list[Exon]]:
+    """Per-strand union of exon intervals, so overlapping isoforms don't
+    double-count in the nucleotide-precision overlap (which assumes a
+    non-overlapping reference)."""
+    out: dict[str, list[Exon]] = {}
+    for strand, es in _by_strand(exons).items():
+        merged: list[list[int]] = []
+        for s, e in sorted((x.start, x.end) for x in es):
+            if merged and s <= merged[-1][1]:
+                merged[-1][1] = max(merged[-1][1], e)
+            else:
+                merged.append([s, e])
+        out[strand] = [Exon(s, e, strand, "m") for s, e in merged]
+    return out
+
+
+def evaluate_asymmetric(pred_gff: str, recall_gp: str, precision_gp: str) -> Accuracy:
+    """Recall (SN) scored against the canonical (MANE) reference; precision (SP)
+    scored against all annotated CDS isoforms. Denominators are the prediction.
+    A predicted feature counts toward precision if it matches *any* isoform, so
+    predicting a real non-canonical transcript is not penalized as a false call."""
+    pred = read_prediction_gff(pred_gff)
+    prec = {loc.name: loc for loc in read_annotation_gff(precision_gp)}
+
+    r = Totals()          # recall side (vs canonical): tp/tpe/tpg + pred denominators
+    tp_u = tpe_a = tpg_a = we_a = 0   # precision numerators (vs all isoforms)
+    for locus in read_annotation_gff(recall_gp):
+        p = pred.get(locus.name, [])
+        accumulate(p, locus.exons, locus.length, r)
+        allx = prec[locus.name].exons if locus.name in prec else []
+        pred_s, all_s, all_m = _by_strand(p), _by_strand(allx), _merge(allx)
+        for st in ("+", "-"):
+            tp_u += _overlap_nt(pred_s.get(st, []), all_m.get(st, []))
+            tpe_a += _exact_matches(pred_s.get(st, []), all_s.get(st, []))
+        tpg_a += _gene_matches(p, allx)
+        we_a += _no_overlap_count(p, allx)
+
+    sn, sp = _sd(r.tp, r.cds_real), _sd(tp_u, r.cds_pred)
+    sne, spe = _sd(r.tpe, r.exr), _sd(tpe_a, r.exp)
+    sng, spg = _sd(r.tpg, r.ger), _sd(tpg_a, r.gep)
+    return Accuracy(
+        sn=sn, sp=sp, cc=0.0,
+        sne=sne, spe=spe, snsp=(sne + spe) / 2,
+        sng=sng, spg=spg, snspg=(sng + spg) / 2,
+        ra_me=_sd(r.me, r.exr), ra_we=_sd(we_a, r.exp), totals=r,
+    )
+
+
+def _sd(a: float, b: float) -> float:
+    return a / b if b else 0.0
+
+
+def _open(path: str | Path):
+    p = str(path)
+    return gzip.open(p, "rt") if p.endswith(".gz") else open(p)
+
+
+def _attrs(col9: str) -> dict[str, str]:
+    return dict(kv.split("=", 1) for kv in col9.split(";") if "=" in kv)
+
+
+def fasta_seqlen(fasta: str | Path, seqid: str) -> int:
+    """Length of the ``seqid`` record in a FASTA (the value geneid sees, so the
+    gp info line matches). The header token is the id up to first whitespace."""
+    n, active = 0, False
+    with _open(fasta) as fh:
+        for line in fh:
+            if line.startswith(">"):
+                if active:
+                    break
+                active = line[1:].split()[0] == seqid
+            elif active:
+                n += len(line.strip())
+    if not active and n == 0:
+        raise ValueError(f"sequence {seqid!r} not found in {fasta}")
+    return n
+
+
+def gencode_cds_gp(gff3_path: str | Path, seqid: str, seqlen: int, *, canonical_only: bool) -> str:
+    """gp-format CDS truth for ``seqid``, CDS exons typed and grouped by transcript.
+
+    ``canonical_only=True`` keeps one MANE Select transcript per protein-coding
+    gene (the recall reference); ``False`` keeps every CDS-bearing transcript
+    (all isoforms -- the precision reference). GENCODE is feature-ordered
+    (transcript before its CDS), so a single pass suffices."""
+    strand: dict[str, str] = {}
+    cds: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    with _open(gff3_path) as fh:
+        for line in fh:
+            if line.startswith("#"):
+                continue
+            f = line.rstrip("\n").split("\t")
+            if len(f) < 9 or f[0] != seqid:
+                continue
+            if f[2] == "transcript":
+                a = _attrs(f[8])
+                mane = "MANE_Select" in a.get("tag", "") and a.get("gene_type") == "protein_coding"
+                if mane or not canonical_only:
+                    strand[a["ID"]] = f[6]
+            elif f[2] == "CDS":
+                parent = _attrs(f[8]).get("Parent", "")
+                if parent in strand:
+                    cds[parent].append((int(f[3]), int(f[4])))
+
+    # info line first (evaluate reads field 5 as the locus length), then exons
+    lines = [f"{seqid}\tgencode\tinfo\t1\t{seqlen}\t.\t.\t.\tinfo"]
+    for tid, exons in cds.items():
+        exons.sort()
+        ordered = exons if strand[tid] == "+" else list(reversed(exons))
+        n = len(ordered)
+        for i, (s, e) in enumerate(ordered):
+            if n == 1:
+                typ = "Single"
+            else:
+                typ = "First" if i == 0 else "Terminal" if i == n - 1 else "Internal"
+            lines.append(f"{seqid}\tgencode\t{typ}\t{s}\t{e}\t.\t{strand[tid]}\t.\t{tid}")
+    return "\n".join(lines) + "\n"
+
+
+def gencode_mane_gp(gff3_path: str | Path, seqid: str, seqlen: int) -> str:
+    """The canonical (MANE Select) CDS truth -- the recall reference."""
+    return gencode_cds_gp(gff3_path, seqid, seqlen, canonical_only=True)
+
+
+def run_geneid(geneid_bin: str, param: str, fasta: str, flags: tuple[str, ...] = ()) -> str:
+    """Run ``geneid -G <flags> -P param fasta`` and keep the typed-CDS-exon
+    prediction lines (First/Internal/Terminal/Single)."""
+    out = subprocess.run(
+        [geneid_bin, "-G", *flags, "-P", param, fasta],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    kept = [ln for ln in out.splitlines()
+            if len(f := ln.split("\t")) >= 9 and f[2] in _TYPED]
+    return "\n".join(kept) + "\n"
+
+
+@dataclass
+class ModeResult:
+    name: str
+    accuracy: Accuracy
+
+
+def run_benchmark(
+    geneid_bin: str, param: str, fasta: str, recall_gp: str, precision_gp: str,
+    modes: list[tuple[str, tuple[str, ...]]], workdir: str | Path,
+) -> list[ModeResult]:
+    """Score each ``(name, flags)`` mode: recall vs the canonical truth
+    ``recall_gp``, precision vs the all-isoform truth ``precision_gp``."""
+    work = Path(workdir)
+    work.mkdir(parents=True, exist_ok=True)
+    results = []
+    for name, flags in modes:
+        pred = work / f"pred.{name}.gff"
+        pred.write_text(run_geneid(geneid_bin, param, fasta, flags))
+        results.append(ModeResult(name, evaluate_asymmetric(str(pred), recall_gp, precision_gp)))
+    return results
+
+
+def format_table(results: list[ModeResult]) -> str:
+    """A compact SN/SP table (nucleotide, exon, gene levels)."""
+    hdr = f"{'mode':<16}{'nSN':>7}{'nSP':>7}{'eSN':>7}{'eSP':>7}{'eSNSP':>7}{'gSN':>7}{'gSP':>7}"
+    rows = [hdr, "-" * len(hdr)]
+    for r in results:
+        a = r.accuracy
+        rows.append(
+            f"{r.name:<16}{a.sn:>7.3f}{a.sp:>7.3f}{a.sne:>7.3f}{a.spe:>7.3f}"
+            f"{a.snsp:>7.3f}{a.sng:>7.3f}{a.spg:>7.3f}"
+        )
+    return "\n".join(rows)

--- a/training/src/geneid_train/cli.py
+++ b/training/src/geneid_train/cli.py
@@ -164,6 +164,37 @@ def _cmd_evaluate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_benchmark(args: argparse.Namespace) -> int:
+    from pathlib import Path
+
+    from .benchmark import fasta_seqlen, format_table, gencode_cds_gp, run_benchmark
+
+    work = Path(args.workdir)
+    work.mkdir(parents=True, exist_ok=True)
+    seqlen = fasta_seqlen(args.fasta, args.seqid)
+    recall = work / f"{args.seqid}.mane.gp"        # canonical -> recall
+    precision = work / f"{args.seqid}.all.gp"      # all isoforms -> precision
+    recall.write_text(gencode_cds_gp(args.gff3, args.seqid, seqlen, canonical_only=True))
+    precision.write_text(gencode_cds_gp(args.gff3, args.seqid, seqlen, canonical_only=False))
+
+    base = tuple(args.base_flags.split()) if args.base_flags else ()
+    strand = ("-y", args.strand) if args.strand else ()
+    modes: list[tuple[str, tuple[str, ...]]] = [("abinitio", base)]
+    if args.coverage:
+        modes += [("cov", (*base, "-S", args.coverage)),
+                  ("cov+u", (*base, "-u", "-S", args.coverage))]
+    if args.bam:
+        modes += [("bam", (*base, *strand, "-Y", args.bam)),
+                  ("bam+u", (*base, "-u", *strand, "-Y", args.bam))]
+
+    res = run_benchmark(
+        args.geneid, args.param, args.fasta, str(recall), str(precision), modes, work)
+    print(f"# {args.seqid}: {seqlen} bp | SN=recall vs MANE, "
+          f"SP=precision vs all isoforms | {len(res)} mode(s)")
+    print(format_table(res))
+    return 0
+
+
 def _cmd_optimize(args: argparse.Namespace) -> int:
     from .optimize import coordinate_descent, global_optimize, optimize, uniform_point
 
@@ -495,6 +526,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_eval.add_argument("predictions", help="geneid prediction GFF (typed CDS exons)")
     p_eval.add_argument("annotations", help="annotation GFF in gp convention (per-locus info line)")
     p_eval.set_defaults(func=_cmd_evaluate)
+
+    p_bench = sub.add_parser(
+        "benchmark",
+        help="score geneid vs a GENCODE MANE reference over one sequence, per evidence mode",
+    )
+    p_bench.add_argument("--gff3", required=True, help="GENCODE GFF3(.gz) reference annotation")
+    p_bench.add_argument("--seqid", required=True, help="sequence to benchmark (e.g. chr21)")
+    p_bench.add_argument("--fasta", required=True, help="genome FASTA containing --seqid")
+    p_bench.add_argument("--param", required=True, help="geneid param file (shared across modes)")
+    p_bench.add_argument("--geneid", default="geneid", help="geneid binary (default: on PATH)")
+    p_bench.add_argument("--workdir", default="benchmark_out", help="dir for truth + predictions")
+    p_bench.add_argument("--base-flags", default="", help="flags shared by all modes")
+    p_bench.add_argument("--coverage", help="bigWig 'plus.bw,minus.bw' -> adds cov / cov+u modes")
+    p_bench.add_argument("--bam", help="RNA-seq BAM -> adds bam / bam+u modes")
+    p_bench.add_argument("--strand", help="library strandedness for --bam (e.g. fr, rf)")
+    p_bench.set_defaults(func=_cmd_benchmark)
 
     p_conv = sub.add_parser("convert", help="convert GFF2 or GTF annotation to canonical GFF3")
     p_conv.add_argument("--from", dest="from_", required=True, choices=["gff2", "gtf"])

--- a/training/tests/test_benchmark.py
+++ b/training/tests/test_benchmark.py
@@ -1,0 +1,135 @@
+"""Truth-prep for the benchmark harness: GENCODE GFF3 -> geneid gp format."""
+
+from geneid_train.benchmark import (
+    evaluate_asymmetric,
+    fasta_seqlen,
+    gencode_cds_gp,
+    gencode_mane_gp,
+)
+
+# gene A: '+' strand, MANE, protein-coding, 3 CDS -> First/Internal/Terminal.
+# gene B: '-' strand, MANE, protein-coding, 2 CDS -> transcription order is the
+#         high-coord exon First, low-coord exon Terminal.
+# gene C: MANE but NOT protein-coding -> excluded.
+# gene D: protein-coding but NOT MANE (an alternative isoform) -> excluded.
+GFF3 = """\
+##gff-version 3
+chr9\tX\tgene\t100\t900\t.\t+\t.\tID=gA
+chr9\tX\ttranscript\t100\t900\t.\t+\t.\tID=txA;Parent=gA;gene_type=protein_coding;tag=basic,MANE_Select
+chr9\tX\tCDS\t100\t150\t.\t+\t0\tID=c1;Parent=txA
+chr9\tX\tCDS\t300\t360\t.\t+\t0\tID=c2;Parent=txA
+chr9\tX\tCDS\t800\t900\t.\t+\t0\tID=c3;Parent=txA
+chr9\tX\ttranscript\t100\t900\t.\t+\t.\tID=txD;Parent=gA;gene_type=protein_coding;tag=basic
+chr9\tX\tCDS\t100\t200\t.\t+\t0\tID=d1;Parent=txD
+chr9\tX\ttranscript\t2000\t2600\t.\t-\t.\tID=txB;Parent=gB;gene_type=protein_coding;tag=MANE_Select
+chr9\tX\tCDS\t2000\t2100\t.\t-\t0\tID=b1;Parent=txB
+chr9\tX\tCDS\t2500\t2600\t.\t-\t0\tID=b2;Parent=txB
+chr9\tX\ttranscript\t3000\t3300\t.\t+\t.\tID=txC;Parent=gC;gene_type=lncRNA;tag=MANE_Select
+chr9\tX\tCDS\t3000\t3300\t.\t+\t0\tID=cc1;Parent=txC
+chr8\tX\ttranscript\t10\t99\t.\t+\t.\tID=txE;Parent=gE;gene_type=protein_coding;tag=MANE_Select
+chr8\tX\tCDS\t10\t99\t.\t+\t0\tID=e1;Parent=txE
+"""
+
+
+def _parse(gp: str):
+    lines = [ln.split("\t") for ln in gp.strip().splitlines()]
+    return lines[0], lines[1:]
+
+
+def test_gencode_mane_gp_filters_and_types(tmp_path):
+    f = tmp_path / "g.gff3"
+    f.write_text(GFF3)
+    info, exons = _parse(gencode_mane_gp(f, "chr9", 5000))
+
+    # info line: field 5 (index 4) is the sequence length
+    assert info[0] == "chr9" and info[4] == "5000"
+
+    # only the two MANE protein-coding chr9 transcripts survive (not C/D/chr8)
+    groups = {e[8] for e in exons}
+    assert groups == {"txA", "txB"}
+
+    by_tid = {tid: [e for e in exons if e[8] == tid] for tid in groups}
+    # '+' gene: types follow genomic order
+    assert [e[2] for e in by_tid["txA"]] == ["First", "Internal", "Terminal"]
+    # '-' gene: First is the high-coord CDS (transcription order)
+    b = by_tid["txB"]
+    first = next(e for e in b if e[2] == "First")
+    term = next(e for e in b if e[2] == "Terminal")
+    assert (first[3], first[4]) == ("2500", "2600")
+    assert (term[3], term[4]) == ("2000", "2100")
+    assert all(e[6] == "-" for e in b)
+
+
+def test_single_cds_is_typed_single(tmp_path):
+    gff = (
+        "chr1\tX\ttranscript\t1\t9\t.\t+\t.\tID=t;Parent=g;"
+        "gene_type=protein_coding;tag=MANE_Select\n"
+        "chr1\tX\tCDS\t1\t9\t.\t+\t0\tID=c;Parent=t\n"
+    )
+    f = tmp_path / "s.gff3"
+    f.write_text(gff)
+    _, exons = _parse(gencode_mane_gp(f, "chr1", 100))
+    assert len(exons) == 1 and exons[0][2] == "Single"
+
+
+def test_all_isoform_truth_includes_non_mane(tmp_path):
+    f = tmp_path / "g.gff3"
+    f.write_text(GFF3)
+    # canonical: only MANE txA/txB; all: also the non-MANE isoform txD (and txC,
+    # which carries a CDS) -- every CDS-bearing transcript
+    _, mane = _parse(gencode_mane_gp(f, "chr9", 5000))
+    _, allx = _parse(gencode_cds_gp(f, "chr9", 5000, canonical_only=False))
+    assert {e[8] for e in mane} == {"txA", "txB"}
+    assert {"txA", "txB", "txD"} <= {e[8] for e in allx}
+
+
+def _gp(tmp_path, name, rows):
+    p = tmp_path / name
+    lines = ["chr1\tx\tinfo\t1\t100000\t.\t.\t.\ti"]
+    lines += [f"chr1\tx\t{t}\t{s}\t{e}\t.\t+\t.\t{g}" for t, s, e, g in rows]
+    p.write_text("\n".join(lines) + "\n")
+    return str(p)
+
+
+def test_asymmetric_credits_noncanonical_isoform_to_precision(tmp_path):
+    # canonical (recall): a 3-exon transcript; all (precision): also an isoform
+    # whose single exon is (100,200). A prediction of exactly (100,200) matches
+    # NO canonical exon (recall exon SN stays 0) but DOES match the isoform, so
+    # precision credits it (exon SP = 1).
+    recall = _gp(tmp_path, "r.gp", [
+        ("First", 100, 150, "txA"), ("Internal", 300, 360, "txA"),
+        ("Terminal", 800, 900, "txA"),
+    ])
+    precision = _gp(tmp_path, "a.gp", [
+        ("First", 100, 150, "txA"), ("Internal", 300, 360, "txA"),
+        ("Terminal", 800, 900, "txA"), ("Single", 100, 200, "txD"),
+    ])
+    pred = tmp_path / "pred.gff"
+    pred.write_text("chr1\tgeneid\tSingle\t100\t200\t.\t+\t.\tg1\n")
+
+    a = evaluate_asymmetric(str(pred), recall, precision)
+    assert a.sne == 0.0          # exact exon not in the canonical reference
+    assert a.spe == 1.0          # but matches an annotated isoform -> not a false call
+    assert a.spg == 1.0          # gene structure matches the isoform too
+    assert a.sp == 1.0           # every predicted nt lies within an annotated CDS
+    assert 0.0 < a.sn < 1.0      # partial nucleotide overlap with the canonical exon
+
+
+def test_asymmetric_precision_nt_never_exceeds_one_with_overlapping_isoforms(tmp_path):
+    # two isoforms whose CDS overlap; a prediction spanning both must not
+    # double-count (SP <= 1) thanks to the merged reference.
+    recall = _gp(tmp_path, "r.gp", [("Single", 100, 300, "txA")])
+    precision = _gp(tmp_path, "a.gp", [
+        ("Single", 100, 250, "txA"), ("Single", 200, 300, "txB"),
+    ])
+    pred = tmp_path / "pred.gff"
+    pred.write_text("chr1\tgeneid\tSingle\t100\t300\t.\t+\t.\tg1\n")
+    a = evaluate_asymmetric(str(pred), recall, precision)
+    assert a.sp == 1.0
+
+
+def test_fasta_seqlen_picks_named_record(tmp_path):
+    fa = tmp_path / "g.fa"
+    fa.write_text(">chr1 desc\nACGTAC\nGT\n>chr2\nAAAA\n")
+    assert fasta_seqlen(fa, "chr1") == 8
+    assert fasta_seqlen(fa, "chr2") == 4


### PR DESCRIPTION
Adds a `benchmark` subcommand to `geneid-train` that scores geneid predictions against a GENCODE MANE reference over one sequence, per RNA-seq evidence mode (`abinitio` / `cov` / `cov+u` / `bam` / `bam+u`).

## What it does
- Builds geneid **gp-format truth** from a GENCODE GFF3 (`gencode_cds_gp`): one MANE Select transcript per protein-coding gene for the recall side; all CDS-bearing isoforms for the precision side.
- Runs geneid once per evidence mode and scores each via the existing `evaluate.evaluate_files` machinery (nSN/nSP/eSN/eSP/eSNSP/gSN/gSP).

## Asymmetric metric
Recall (SN) is scored vs the **canonical MANE Select** transcript; precision (SP) is scored vs **all** CDS-bearing isoforms, with overlapping isoform CDS merged into a union first so nucleotide SP is not double-counted. This avoids penalizing recall for skipped non-canonical isoforms and precision for predicting a real non-canonical transcript.

## Usage
```
geneid-train benchmark --gff3 gencode.v50.annotation.gff3.gz --seqid chr21 \
  --fasta chr21.hardmask.fa --param human.rnaseq.param --geneid ../bin/geneid \
  --bam pancreas.chr21.bam --strand rf
```

## Tests
`tests/test_benchmark.py` (6 tests). Full suite: 166 passed, 20 skipped; ruff clean. Sample data (GENCODE GFF3, BAMs, chr21 FASTA) stays untracked — only `training/` code is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)