### PR TITLE
RNA-seq expression scoring Stage 1: coverage background lambda_bg + MRM decoupling

### DIFF
--- a/include/bamcov.h
+++ b/include/bamcov.h
@@ -60,4 +60,10 @@ typedef void (*bamJunctionCB)(long start, long end, char strand, void* userData)
 long bamJunctionQuery(BamCov* bc, const char* chrom, long start, long end,
                       bamJunctionCB cb, void* userData);
 
+/* Total mapped reads across all references, read from the index meta (like
+   `samtools idxstats`) -- no read scan. Used to set MRM (millions of reads
+   mapped) for the rpkm report when -N is not given. Returns the count, or -1
+   if the index carries no per-reference stats. */
+long bamMappedReads(BamCov* bc);
+
 #endif

--- a/include/geneid.h
+++ b/include/geneid.h
@@ -124,6 +124,15 @@ A. DEFINITIONS
 /* read params */
 #define RREADS 1
 #define COV 15
+/* Coverage-score normalisation: raw per-base depth is divided by COVNORM before
+   it accumulates into sr[] (capped at COV). This is a fixed scoring scale, kept
+   separate from MRM (millions of reads mapped, which normalises only the rpkm
+   report -- see PrintExons.c). Historically both used MRM's default of 15; they
+   were decoupled so MRM can carry the real library size (from -N or estimated
+   from the BAM index) without changing exon scores. With COV=15, a base
+   saturates its coverage score at depth COVNORM*COV = 225. The RNA-seq
+   expression-scoring redesign will replace this per-base scaling entirely. */
+#define COVNORM 15.0
 
 /* Length of allowed UTR including stop codon before intron: used to be 55 */
 #define MAXNMDLENGTH 1000

--- a/src/ProcessHSPs.c
+++ b/src/ProcessHSPs.c
@@ -31,7 +31,6 @@
 extern int BAMSTRAND;   /* -y library type: BAMLIB_NONE (unstranded) / RF / FR */
 #endif
 
-extern float MRM;
 extern int UTR;
 extern int SRP;
 extern float NO_SCORE;
@@ -286,7 +285,7 @@ void ReadScan(packExternalInformation* external,
 				   i++)
 				{
 				  /* Score value */
-				  scoreHSP = (RREADS/MRM) * hsp->sPairs[x][i]->Score;
+				  scoreHSP = (RREADS/COVNORM) * hsp->sPairs[x][i]->Score;
 				  /* / (hsp->sPairs[x][i]->Pos2 - hsp->sPairs[x][i]->Pos1 + 1); */
 				  
 				  /* For each position in the HSP update the array sr */
@@ -305,7 +304,7 @@ void ReadScan(packExternalInformation* external,
 				   i++)
 				{
 				  /* Score value */
-				  scoreHSP = (RREADS/MRM) * hsp->sPairs[x][i]->Score; 
+				  scoreHSP = (RREADS/COVNORM) * hsp->sPairs[x][i]->Score; 
 /* 				    /(hsp->sPairs[x][i]->Pos2 - hsp->sPairs[x][i]->Pos1 + 1); */
 				  
 				  /* For each position in the HSP update the array sr */
@@ -327,7 +326,7 @@ void ReadScan(packExternalInformation* external,
 				   i++)
 				{
 				  /* Score value */
-				  scoreHSP = (RREADS/MRM) * hsp->sPairs[x][i]->Score; 
+				  scoreHSP = (RREADS/COVNORM) * hsp->sPairs[x][i]->Score; 
 /* 				    /(hsp->sPairs[x][i]->Pos2 - hsp->sPairs[x][i]->Pos1 + 1); */
 				  
 				  /* Update the array sr with some positions of current HSPs */
@@ -372,7 +371,7 @@ void ReadScan(packExternalInformation* external,
 				   i++)
 				{
 				  /* Score value */
-				  scoreHSP = (RREADS/MRM) * hsp->sPairs[x][i]->Score;
+				  scoreHSP = (RREADS/COVNORM) * hsp->sPairs[x][i]->Score;
 /* 				  / (hsp->sPairs[x][i]->Pos2 - hsp->sPairs[x][i]->Pos1 + 1); */
 				  
 				  /* For each position in the HSP update the array sr */
@@ -390,7 +389,7 @@ void ReadScan(packExternalInformation* external,
 				   i++)
 				{
 				  /* Score value */
-				  scoreHSP = (RREADS/MRM) * hsp->sPairs[x][i]->Score;
+				  scoreHSP = (RREADS/COVNORM) * hsp->sPairs[x][i]->Score;
 /* 				  /(hsp->sPairs[x][i]->Pos2 - hsp->sPairs[x][i]->Pos1 + 1); */
 				  
 				  /* For each position in the HSP update the array sr */
@@ -411,7 +410,7 @@ void ReadScan(packExternalInformation* external,
 				   i++)
 				{
 				  /* Score value */
-				  scoreHSP = (RREADS/MRM) * hsp->sPairs[x][i]->Score;
+				  scoreHSP = (RREADS/COVNORM) * hsp->sPairs[x][i]->Score;
 /* 				  / (hsp->sPairs[x][i]->Pos2 - hsp->sPairs[x][i]->Pos1 + 1); */
 				  
 				  /* Update the array sr with some positions of current HSPs */
@@ -484,8 +483,10 @@ void HSPScan2(packExternalInformation* external,
  *
  * Stage 1 only REPORTS this value (verbose diagnostic, no scoring change); in
  * Stage 2 it becomes the null of a per-base log-likelihood-ratio coverage term.
- * sr[] holds depth/MRM capped at COV (see CoverAdd), so read depth ~= sr*MRM;
- * we report in depth units. Covered positions are sr[] != NO_SCORE. A strand's
+ * sr[] holds depth/COVNORM capped at COV (see CoverAdd), so read depth ~=
+ * sr*COVNORM; we report in depth units. (COVNORM, the fixed coverage-score
+ * scale, is deliberately NOT MRM -- MRM now carries the real library size for
+ * the rpkm report only.) Covered positions are sr[] != NO_SCORE. A strand's
  * three frame planes are identical copies, so we scan only the first. */
 static void ReportCoverageBackground(packExternalInformation* external,
                                      int Strand, long l1, long l2)
@@ -508,7 +509,7 @@ static void ReportCoverageBackground(packExternalInformation* external,
   for (i = 0; i < len; i++) {
     long depth;
     if (external->sr[frame][i] == NO_SCORE) continue;   /* uncovered */
-    depth = (long)(external->sr[frame][i] * MRM + 0.5);
+    depth = (long)(external->sr[frame][i] * COVNORM + 0.5);
     if (depth < 0) depth = 0;
     if (depth > HISTCAP) depth = HISTCAP;
     hist[depth]++;
@@ -629,7 +630,7 @@ static void FillCoverageFrameless(packExternalInformation* external, int Strand,
       if (UTR) external->readcount[x][i] = 0.0;   /* readcount[] is -u-only (see CoverAdd) */
     }
     for (k = 0; k < niv; k++) {
-      float scoreHSP = (RREADS / MRM) * iv[k].v;
+      float scoreHSP = (RREADS / COVNORM) * iv[k].v;
       long a = (iv[k].s < l1)     ? l1     : iv[k].s;   /* clip to [l1, l2]  */
       long b = (iv[k].e > l2 + 1) ? l2 + 1 : iv[k].e;   /* half-open upper   */
       for (j = a; j < b; j++)

--- a/src/ProcessHSPs.c
+++ b/src/ProcessHSPs.c
@@ -35,6 +35,7 @@ extern float MRM;
 extern int UTR;
 extern int SRP;
 extern float NO_SCORE;
+extern int VRB;         /* -v verbose: gates the Stage-1 coverage-background diagnostic */
 
 
 /* Projection of HSPs: save the maximum for each nucleotide */
@@ -471,6 +472,72 @@ void HSPScan2(packExternalInformation* external,
 }
 
 
+/* --- RNA-seq expression-scoring redesign, Stage 1 -------------------------- *
+ * Estimate a robust background coverage level (lambda_bg) for the current
+ * fragment/strand from the raw per-base coverage in sr[], read BEFORE HSPScan2
+ * turns sr[] into a prefix sum. We use the MEDIAN of covered positions, not the
+ * mean: RNA-seq coverage has a heavy hyper-expressed tail (rRNA, pileups) that
+ * inflates the mean ~16x on real data, so a mean-based null would sit far above
+ * normal genes and penalise them. The median tracks the typical background/low-
+ * expression level and scales with sequencing depth, so deeper data raises the
+ * null and the signal together (the null stays calibrated).
+ *
+ * Stage 1 only REPORTS this value (verbose diagnostic, no scoring change); in
+ * Stage 2 it becomes the null of a per-base log-likelihood-ratio coverage term.
+ * sr[] holds depth/MRM capped at COV (see CoverAdd), so read depth ~= sr*MRM;
+ * we report in depth units. Covered positions are sr[] != NO_SCORE. A strand's
+ * three frame planes are identical copies, so we scan only the first. */
+static void ReportCoverageBackground(packExternalInformation* external,
+                                     int Strand, long l1, long l2)
+{
+  short frame = (Strand == FORWARD) ? 0 : FRAMES;
+  long  len   = l2 - l1 + 1;
+  long  i, covered = 0, run, half, medianDepth = 0;
+  double lambdaBg;
+  /* Depth histogram for the median. Depth is small for the vast majority of
+     bases; a fixed cap with an overflow bin keeps this O(len) and allocation
+     free. The median is a low quantile, so depths >= HISTCAP (all above it)
+     only need counting, not exact binning. */
+  enum { HISTCAP = 1024 };
+  long hist[HISTCAP + 1];
+  char mess[MAXSTRING];
+
+  if (!VRB) return;              /* pure diagnostic; nothing else consumes it yet */
+
+  for (i = 0; i <= HISTCAP; i++) hist[i] = 0;
+  for (i = 0; i < len; i++) {
+    long depth;
+    if (external->sr[frame][i] == NO_SCORE) continue;   /* uncovered */
+    depth = (long)(external->sr[frame][i] * MRM + 0.5);
+    if (depth < 0) depth = 0;
+    if (depth > HISTCAP) depth = HISTCAP;
+    hist[depth]++;
+    covered++;
+  }
+
+  if (covered == 0) {
+    sprintf(mess, "Coverage background [%ld-%ld] %s: no covered bases",
+            l1, l2, (Strand == FORWARD) ? "fwd" : "rvs");
+    printMess(mess);
+    return;
+  }
+
+  half = (covered + 1) / 2;
+  run = 0;
+  for (i = 0; i <= HISTCAP; i++) {
+    run += hist[i];
+    if (run >= half) { medianDepth = i; break; }
+  }
+  lambdaBg = medianDepth + 1.0;   /* + pseudocount */
+  sprintf(mess,
+          "Coverage background [%ld-%ld] %s: covered %ld/%ld (%.1f%%), "
+          "median depth %ld, lambda_bg %.1f",
+          l1, l2, (Strand == FORWARD) ? "fwd" : "rvs",
+          covered, len, 100.0 * (double) covered / (double) len,
+          medianDepth, lambdaBg);
+  printMess(mess);
+}
+
 /* Management function to score and filter exons */
 void ProcessHSPs(long l1,
                 long l2,
@@ -487,6 +554,7 @@ void ProcessHSPs(long l1,
 	  if (UTR){
 	    printMess("Preprocessing read information: step 1");
 	    ReadScan(external,hsp,Strand,l1,l2);
+	    ReportCoverageBackground(external, Strand, l1, l2);
 	  }else{
 	    printMess("Preprocessing homology information: step 1");
 	    HSPScan(external,hsp,Strand,l1,l2);
@@ -600,6 +668,7 @@ void ProcessCoverageBigWig(long l1, long l2, int Strand,
 
   FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
   free(buf.a);
+  ReportCoverageBackground(external, Strand, l1, l2);
 
   printMess("Preprocessing bigWig coverage: step 2");
   HSPScan2(external, NULL, Strand, l1, l2);
@@ -643,6 +712,7 @@ void ProcessCoverageBam(long l1, long l2, int Strand,
 
   FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
   free(buf.a);
+  ReportCoverageBackground(external, Strand, l1, l2);
 
   printMess("Preprocessing BAM coverage: step 2");
   HSPScan2(external, NULL, Strand, l1, l2);

--- a/src/bamcov.c
+++ b/src/bamcov.c
@@ -74,6 +74,30 @@ void bamClose(BamCov* bc)
   free(bc);
 }
 
+/* Sum mapped reads over every reference from the index meta -- the same numbers
+   `samtools idxstats` prints, obtained without touching alignment records.
+   hts_idx_get_stat returns <0 for a reference with no index bin, which covers
+   both a reference that simply has no reads (common: a chr21-only subset BAM
+   still carries the full header) and a statless index. We skip such references
+   (count them as 0) and fail (return -1) only when NO reference carries stats,
+   so a subset BAM still yields the true library size. */
+long bamMappedReads(BamCov* bc)
+{
+  int nref, tid, anystat = 0;
+  long total = 0;
+
+  if (bc == NULL || bc->idx == NULL) return -1;
+  nref = hts_idx_nseq(bc->idx);
+  for (tid = 0; tid < nref; tid++) {
+    uint64_t mapped = 0, unmapped = 0;
+    if (hts_idx_get_stat(bc->idx, tid, &mapped, &unmapped) < 0)
+      continue;                 /* reference with no reads / no per-ref stats */
+    anystat = 1;
+    total += (long) mapped;
+  }
+  return anystat ? total : -1;
+}
+
 long bamCoverageQuery(BamCov* bc, const char* chrom, long start, long end,
                       char wantStrand, int libMode, bwIntervalCB cb, void* userData)
 {

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -105,8 +105,14 @@ long
   HI=0;
 
 float
-  /* Millions of reads mapped */
+  /* Millions of reads mapped (rpkm normalisation). Default 15.0 is a
+     placeholder; -N overrides it, and for a BAM input it is estimated from the
+     index when -N is absent (see MRMset). */
 MRM=15.0;
+
+/* Set to 1 when the user passes -N, so BAM auto-estimation of MRM does not
+   override an explicit value. */
+int MRMset=0;
 
 /* Optional Predicted Gene Prefix */
 char  GenePrefix[MAXSTRING]="";
@@ -391,6 +397,27 @@ int main (int argc, char *argv[])
 	      /* Coverage fills sr[] to score exons with or without -u; -u adds UTR
 		 prediction (and the rpkm report) on top. */
 	      printMess("Reading RNA-seq coverage from indexed BAM (per-split range queries)...");
+#ifdef WITH_HTSLIB
+	      /* rpkm needs the real library size. When -N was not given, take it
+		 from the BAM index (mapped reads, in millions) instead of the
+		 15.0 placeholder. This affects only the rpkm report, not scoring
+		 (coverage scores use the fixed COVNORM scale). */
+	      if (!MRMset)
+		{
+		  long nreads = bamMappedReads(external->bam);
+		  if (nreads > 0)
+		    {
+		      MRM = (float) nreads / 1.0e6f;
+		      sprintf(mess,
+			      "MRM (millions of reads mapped) estimated from BAM index: "
+			      "%ld reads -> %.3f (override with -N)", nreads, MRM);
+		      printMess(mess);
+		    }
+		  else
+		    printMess("BAM index carries no mapped-read stats; "
+			      "rpkm uses default MRM (set it with -N)");
+		}
+#endif
 	    }
 	  else if (external->bwPlus != NULL)
 	    {

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -40,6 +40,7 @@ extern int  SFP,SDP,SAP,STP,
             scanORF, XML, cDNA, PSEQ, tDNA,
             SGE, SCOREANNOT;
 extern float EW,EvidenceEW,MRM;
+extern int MRMset;   /* set here when -N is given, so a BAM's index is not used to estimate MRM */
 extern long LOW,HI;
 extern int BAMSTRAND;   /* -y library strandedness for BAM -S coverage */
 
@@ -81,7 +82,8 @@ void printHelp()
 
   printf("\t-j  <coord>: Begin prediction at this coordinate\n");
   printf("\t-k  <coord>: End prediction at this coordinate\n");  
-  printf("\t-N  <num_reads>: Millions of reads mapped to genome\n");  
+  printf("\t-N  <num_reads>: Millions of reads mapped to genome (rpkm report; for a\n"
+	 "\t     BAM input this is estimated from the index when -N is omitted)\n");
   printf("\t-W: Only Forward sense prediction (Watson)\n");
   printf("\t-C: Only Reverse sense prediction (Crick)\n");
   printf("\t-U: Allow U12 introns (Requires appropriate U12 parameters to be set in the parameter file)\n");
@@ -302,6 +304,7 @@ void readargv (int argc,char* argv[],
 		break;
 	  case 'N': MRM = strtof(optarg,&dummy3);
 		/* assembly-compatible: reads-mapped (rpkm reporting), allowed under -O */
+		MRMset = 1;   /* explicit value: suppress BAM-index auto-estimation */
 		NOpt++;
 		break;
 	  case 'U': U12++;


### PR DESCRIPTION
First stage of the RNA-seq expression-scoring redesign, plus a related MRM fix.

## Part 1 -- robust coverage background `lambda_bg` (foundation, no scoring change)
Adds `ReportCoverageBackground()` in `src/ProcessHSPs.c`: for each fragment/strand it estimates

```
lambda_bg = median(covered per-base depth) + pseudocount
```

read from `sr[]` **before** `HSPScan2` turns it into a prefix sum.

- **Median, not mean** -- real RNA-seq coverage has a heavy hyper-expressed tail (rRNA/pileups) that inflates the mean ~16x (chr21: mean 64 vs median 4). A mean-based null would penalise normal genes.
- **Depth-scaling safe** -- per-fragment, so it rises with sequencing depth; null and signal scale together (deeper data should help, not hurt).
- **Read-coverage paths only** (BAM, bigWig, `-u` ReadScan); never the protein-homology path.
- **Diagnostic only** (`-v` -> stderr); nothing consumes it yet. In Stage 2 it becomes the null of a per-base Poisson log-likelihood-ratio term.

## Part 2 -- decouple MRM (library size) from the coverage-score scale
`MRM` ("millions of reads mapped") was doing double duty: rpkm normalisation **and** scaling the live coverage score (`scoreHSP = depth/MRM`), with a placeholder default of 15.0.

- New `COVNORM` (fixed 15.0) is the coverage-score normalisation; all `scoreHSP` sites + the Stage-1 depth reconstruction use it, so **exon scores no longer depend on MRM** (value unchanged -> byte-identical).
- `MRM` now carries only the real library size for the rpkm report. For a BAM input with no `-N`, it is **estimated from the index meta** (`bamMappedReads()`, like `samtools idxstats`, no read scan; empty references skipped so subset BAMs work). `-N` still overrides.

## Validation
- All **16 regression cases byte-identical**; clean build with and without htslib, no new warnings.
- `lambda_bg` on real pancreas chr21 BAM over MORC3: `median depth 5, lambda_bg 6.0`.
- MRM estimate matches `samtools idxstats` exactly (`15528190 -> 15.528`); rpkm scales inversely with MRM (ratio exactly 2.0); predicted structure identical across MRM values.

## Next (Stage 2)
Wire the per-base Poisson LLR `c*log(k) - (k-1)*lambda_bg` behind a default-off param flag and measure `bam+u` on the eval harness (#72). The LLR is MRM-independent (self-calibrates via `lambda_bg`), so it supersedes COVNORM's scoring role.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code