### PR TITLE
RNA-seq expression scoring Stage 2: Poisson per-base LLR coverage term

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -737,6 +737,13 @@ typedef struct s_packExternalInformation
   float** sr;
   float** readcount;
 
+  /* RNA-seq expression scoring: robust background coverage rate (median covered
+     read depth + pseudocount) for the current fragment/strand, set by the
+     coverage paths just before HSPScan2. It is the null of the per-base Poisson
+     log-likelihood-ratio term (-L). -1 = not computed (protein-homology path,
+     or no covered bases) => HSPScan2 keeps the legacy per-base coverage term. */
+  float covLambdaBg;
+
   /* -S RNA-seq coverage supplied as bigWig (per-split range queries) instead of
      a text HSP file. bwPlus/bwMinus are the +/- strand signals (equal when the
      signal is unstranded); both NULL => the text ReadHSP path is used. curLocus

--- a/src/ProcessHSPs.c
+++ b/src/ProcessHSPs.c
@@ -35,6 +35,8 @@ extern int UTR;
 extern int SRP;
 extern float NO_SCORE;
 extern int VRB;         /* -v verbose: gates the Stage-1 coverage-background diagnostic */
+extern int EXPRLLR;     /* -L: Poisson per-base expression LLR coverage scoring */
+extern float LLRK, LLRW;/* -L fold-change k (>1); -Q weight/scale of the LLR term */
 
 
 /* Projection of HSPs: save the maximum for each nucleotide */
@@ -437,18 +439,28 @@ void HSPScan2(packExternalInformation* external,
   float previousScore;
   float previousReadCount;
   short frameStart, frameEnd;
-  
+  /* -L expression LLR: replace the legacy per-base coverage term with a Poisson
+     two-state log-likelihood ratio, covered depth vs the background rate
+     covLambdaBg. Term = LLRW*(depth*log(k) - (k-1)*lambda_bg): <=0 at/below
+     background (so uncovered/low-coverage bases are neutral-to-negative rather
+     than rewarded), positive only for genuine enrichment. Gated on a valid
+     covLambdaBg (>0), so the protein-homology path and empty fragments keep the
+     legacy term -> default off (-L absent) is byte-identical. */
+  int   useLLR = (EXPRLLR && external->covLambdaBg > 0.0);
+  double logk  = useLLR ? log((double) LLRK) : 0.0;
+  double bgTerm = useLLR ? ((double) LLRK - 1.0) * (double) external->covLambdaBg : 0.0;
+
   if (Strand == FORWARD)
     {
-	  frameStart = 0; 
+	  frameStart = 0;
 	  frameEnd = FRAMES;
 	}
   else
 	{
-	  frameStart = FRAMES; 
+	  frameStart = FRAMES;
 	  frameEnd = 2*FRAMES;
 	}
-  
+
   for(x=frameStart; x < frameEnd; x++)
     {
       previousScore = 0.0;
@@ -457,7 +469,18 @@ void HSPScan2(packExternalInformation* external,
       for (i=l1; i<=l2; i++)
 		{
 		  /* Accumulating step */
-		  if (UTR){
+		  if (useLLR){
+		    /* sr[] holds depth/COVNORM (NO_SCORE if uncovered -> depth 0) */
+		    double depth = (external->sr[x][i-l1] == NO_SCORE)
+		                   ? 0.0 : (double) external->sr[x][i-l1] * COVNORM;
+		    double llr = (double) LLRW * (depth * logk - bgTerm);
+		    external->sr[x][i-l1] = previousScore + (float) llr;
+		    previousScore = external->sr[x][i-l1];
+		    if (UTR){
+		      external->readcount[x][i-l1] = previousReadCount + external->readcount[x][i-l1];
+		      previousReadCount = external->readcount[x][i-l1];
+		    }
+		  }else if (UTR){
 		    external->sr[x][i-l1] = previousScore + log(external->sr[x][i-l1] + 1);
 		    previousScore = external->sr[x][i-l1];
 		    external->readcount[x][i-l1] = previousReadCount + external->readcount[x][i-l1];
@@ -467,29 +490,30 @@ void HSPScan2(packExternalInformation* external,
 		    previousScore = external->sr[x][i-l1];
 		  }
 		}
-    }  
+    }
 }
 
 
-/* --- RNA-seq expression-scoring redesign, Stage 1 -------------------------- *
+/* --- RNA-seq expression-scoring redesign ---------------------------------- *
  * Estimate a robust background coverage level (lambda_bg) for the current
  * fragment/strand from the raw per-base coverage in sr[], read BEFORE HSPScan2
- * turns sr[] into a prefix sum. We use the MEDIAN of covered positions, not the
- * mean: RNA-seq coverage has a heavy hyper-expressed tail (rRNA, pileups) that
- * inflates the mean ~16x on real data, so a mean-based null would sit far above
- * normal genes and penalise them. The median tracks the typical background/low-
+ * turns sr[] into a prefix sum, and store it in external->covLambdaBg for the
+ * per-base LLR term (-L). We use the MEDIAN of covered positions, not the mean:
+ * RNA-seq coverage has a heavy hyper-expressed tail (rRNA, pileups) that inflates
+ * the mean ~16x on real data, so a mean-based null would sit far above normal
+ * genes and penalise them. The median tracks the typical background/low-
  * expression level and scales with sequencing depth, so deeper data raises the
  * null and the signal together (the null stays calibrated).
  *
- * Stage 1 only REPORTS this value (verbose diagnostic, no scoring change); in
- * Stage 2 it becomes the null of a per-base log-likelihood-ratio coverage term.
- * sr[] holds depth/COVNORM capped at COV (see CoverAdd), so read depth ~=
- * sr*COVNORM; we report in depth units. (COVNORM, the fixed coverage-score
- * scale, is deliberately NOT MRM -- MRM now carries the real library size for
- * the rpkm report only.) Covered positions are sr[] != NO_SCORE. A strand's
- * three frame planes are identical copies, so we scan only the first. */
-static void ReportCoverageBackground(packExternalInformation* external,
-                                     int Strand, long l1, long l2)
+ * Computed only when needed (-L expression LLR, or -v diagnostic); the value is
+ * also printed under -v. sr[] holds depth/COVNORM capped at COV (see CoverAdd),
+ * so read depth ~= sr*COVNORM; lambda_bg is in depth units. (COVNORM, the fixed
+ * coverage-score scale, is deliberately NOT MRM -- MRM carries the real library
+ * size for the rpkm report only.) Covered positions are sr[] != NO_SCORE. A
+ * strand's three frame planes are identical copies, so we scan only the first.
+ * covLambdaBg = -1 (no covered bases) leaves HSPScan2 on the legacy term. */
+static void ComputeCoverageBackground(packExternalInformation* external,
+                                      int Strand, long l1, long l2)
 {
   short frame = (Strand == FORWARD) ? 0 : FRAMES;
   long  len   = l2 - l1 + 1;
@@ -503,7 +527,8 @@ static void ReportCoverageBackground(packExternalInformation* external,
   long hist[HISTCAP + 1];
   char mess[MAXSTRING];
 
-  if (!VRB) return;              /* pure diagnostic; nothing else consumes it yet */
+  external->covLambdaBg = -1.0;             /* default: not computed */
+  if (!EXPRLLR && !VRB) return;             /* only needed for -L or -v */
 
   for (i = 0; i <= HISTCAP; i++) hist[i] = 0;
   for (i = 0; i < len; i++) {
@@ -517,10 +542,12 @@ static void ReportCoverageBackground(packExternalInformation* external,
   }
 
   if (covered == 0) {
-    sprintf(mess, "Coverage background [%ld-%ld] %s: no covered bases",
-            l1, l2, (Strand == FORWARD) ? "fwd" : "rvs");
-    printMess(mess);
-    return;
+    if (VRB) {
+      sprintf(mess, "Coverage background [%ld-%ld] %s: no covered bases",
+              l1, l2, (Strand == FORWARD) ? "fwd" : "rvs");
+      printMess(mess);
+    }
+    return;                                  /* covLambdaBg stays -1 */
   }
 
   half = (covered + 1) / 2;
@@ -530,13 +557,16 @@ static void ReportCoverageBackground(packExternalInformation* external,
     if (run >= half) { medianDepth = i; break; }
   }
   lambdaBg = medianDepth + 1.0;   /* + pseudocount */
-  sprintf(mess,
-          "Coverage background [%ld-%ld] %s: covered %ld/%ld (%.1f%%), "
-          "median depth %ld, lambda_bg %.1f",
-          l1, l2, (Strand == FORWARD) ? "fwd" : "rvs",
-          covered, len, 100.0 * (double) covered / (double) len,
-          medianDepth, lambdaBg);
-  printMess(mess);
+  external->covLambdaBg = (float) lambdaBg;
+  if (VRB) {
+    sprintf(mess,
+            "Coverage background [%ld-%ld] %s: covered %ld/%ld (%.1f%%), "
+            "median depth %ld, lambda_bg %.1f",
+            l1, l2, (Strand == FORWARD) ? "fwd" : "rvs",
+            covered, len, 100.0 * (double) covered / (double) len,
+            medianDepth, lambdaBg);
+    printMess(mess);
+  }
 }
 
 /* Management function to score and filter exons */
@@ -555,7 +585,7 @@ void ProcessHSPs(long l1,
 	  if (UTR){
 	    printMess("Preprocessing read information: step 1");
 	    ReadScan(external,hsp,Strand,l1,l2);
-	    ReportCoverageBackground(external, Strand, l1, l2);
+	    ComputeCoverageBackground(external, Strand, l1, l2);
 	  }else{
 	    printMess("Preprocessing homology information: step 1");
 	    HSPScan(external,hsp,Strand,l1,l2);
@@ -669,7 +699,7 @@ void ProcessCoverageBigWig(long l1, long l2, int Strand,
 
   FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
   free(buf.a);
-  ReportCoverageBackground(external, Strand, l1, l2);
+  ComputeCoverageBackground(external, Strand, l1, l2);
 
   printMess("Preprocessing bigWig coverage: step 2");
   HSPScan2(external, NULL, Strand, l1, l2);
@@ -713,7 +743,7 @@ void ProcessCoverageBam(long l1, long l2, int Strand,
 
   FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
   free(buf.a);
-  ReportCoverageBackground(external, Strand, l1, l2);
+  ComputeCoverageBackground(external, Strand, l1, l2);
 
   printMess("Preprocessing BAM coverage: step 2");
   HSPScan2(external, NULL, Strand, l1, l2);

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -473,6 +473,7 @@ packExternalInformation* RequestMemoryExternalInformation()
   p->bwMinus = NULL;
   p->curLocus = NULL;
   p->bam = NULL;   /* -S BAM handle: NULL until the -S ingest sniffs a BAM */
+  p->covLambdaBg = -1.0;   /* set per fragment by the coverage paths (-L LLR) */
 
   return(p);
 }

--- a/src/ScoreExons.c
+++ b/src/ScoreExons.c
@@ -52,6 +52,7 @@ extern float EW;
 extern float U12EW;
 extern int SRP;
 extern float NO_SCORE;
+extern int EXPRLLR;   /* -L: with the expression LLR the background is baked into the per-base term */
 extern int U12GTAG;
 extern int U12ATAC;
 extern float RSSMARKOVSCORE;
@@ -341,7 +342,7 @@ float ScoreHSPexon(exonGFF* exon,
   /*   sprintf(mess,"iniExonRel: %ld endExonRel: %ld   iniExon: %ld  endExon: %ld  Score: %f  ValEnd: %f  ValIni: %f",iniExon,endExon,exon->Acceptor->Position,exon->Donor->Position,Score,external->sr[trueFrame][endExon],external->sr[trueFrame][(iniExon>0)?iniExon-1:iniExon]); */
   /*   	  printMess(mess); */
   /* } */
-  if (UTR && flank > 0){
+  if (UTR && flank > 0 && !EXPRLLR){   /* LLR bakes background into the per-base term */
     left = MAX(0,(iniExon - flank));
     right = MIN((l2-l1),endExon + flank);
 

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -114,6 +114,18 @@ MRM=15.0;
    override an explicit value. */
 int MRMset=0;
 
+/* RNA-seq expression scoring: Poisson two-state per-base log-likelihood ratio.
+   EXPRLLR toggles it on (default off -> legacy log(cov+1)/raw coverage term).
+   Enabled by -L, which also sets LLRK (the expressed/background fold-change k>1);
+   LLRW (-Q) scales the LLR contribution (the term is on a different scale from
+   the legacy one, so this tunes it vs coding/site scores; HSPFactor also weights
+   it). Per-base term = LLRW * (depth*log(LLRK) - (LLRK-1)*covLambdaBg). */
+int   EXPRLLR=0;
+float LLRK=2.0;    /* fold-change; -L overrides. k=2 was the harness optimum */
+float LLRW=0.01;   /* -Q default; 0.01 tuned on human.rnaseq/pancreas chr21 (bam+u).
+                      w scales the LLR vs coding/site scores, so it depends on the
+                      param file and library depth -- re-tune -Q per dataset. */
+
 /* Optional Predicted Gene Prefix */
 char  GenePrefix[MAXSTRING]="";
   

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -41,6 +41,8 @@ extern int  SFP,SDP,SAP,STP,
             SGE, SCOREANNOT;
 extern float EW,EvidenceEW,MRM;
 extern int MRMset;   /* set here when -N is given, so a BAM's index is not used to estimate MRM */
+extern int EXPRLLR;        /* -L: enable Poisson per-base expression LLR coverage scoring */
+extern float LLRK, LLRW;   /* -L fold-change k (>1); -Q weight/scale of the LLR term */
 extern long LOW,HI;
 extern int BAMSTRAND;   /* -y library strandedness for BAM -S coverage */
 
@@ -48,7 +50,7 @@ extern int BAMSTRAND;   /* -y library strandedness for BAM -S coverage */
 extern char* optarg;
 extern int optind;
 
-char* USAGE="NAME\n\tgeneid - a program to annotate genomic sequences\nSYNOPSIS\n\tgeneid\t[-bdaefitnxszru]\n\t\t[-TDAZU]\n\t\t[-p gene_prefix]\n\t\t[-G] [-3] [-X] [-M] [-m]\n\t\t[-WCF] [-o] [-J]\n\t\t[-j lower_bound_coord]\n\t\t[-k upper_bound_coord]\n\t\t[-N numer_nt_mapped]\n\t\t[-O <gff_exons_file>]\n\t\t[-R <gff_annotation-file>]\n\t\t[-S <gff_homology_file>]\n\t\t[-Y reads.bam]\n\t\t[-y library_type]\n\t\t[-P <parameter_file>]\n\t\t[-E exonweight]\n\t\t[-V evidence_exonweight]\n\t\t[-Bv] [-h]\n\t\t<locus_seq_in_fasta_format>\nRELEASE\n\t" GENEID_RELEASE "\n";
+char* USAGE="NAME\n\tgeneid - a program to annotate genomic sequences\nSYNOPSIS\n\tgeneid\t[-bdaefitnxszru]\n\t\t[-TDAZU]\n\t\t[-p gene_prefix]\n\t\t[-G] [-3] [-X] [-M] [-m]\n\t\t[-WCF] [-o] [-J]\n\t\t[-j lower_bound_coord]\n\t\t[-k upper_bound_coord]\n\t\t[-N numer_nt_mapped]\n\t\t[-L fold_change] [-Q llr_weight]\n\t\t[-O <gff_exons_file>]\n\t\t[-R <gff_annotation-file>]\n\t\t[-S <gff_homology_file>]\n\t\t[-Y reads.bam]\n\t\t[-y library_type]\n\t\t[-P <parameter_file>]\n\t\t[-E exonweight]\n\t\t[-V evidence_exonweight]\n\t\t[-Bv] [-h]\n\t\t<locus_seq_in_fasta_format>\nRELEASE\n\t" GENEID_RELEASE "\n";
 
 void printHelp()
 {
@@ -84,6 +86,11 @@ void printHelp()
   printf("\t-k  <coord>: End prediction at this coordinate\n");  
   printf("\t-N  <num_reads>: Millions of reads mapped to genome (rpkm report; for a\n"
 	 "\t     BAM input this is estimated from the index when -N is omitted)\n");
+  printf("\t-L  <k>: enable Poisson expression LLR coverage scoring, fold-change k>1\n"
+	 "\t     (expressed/background); default off (legacy log(cov+1)/raw term).\n"
+	 "\t     Recommended start: -L 2 -Q 0.01 (tuned on human RNA-seq bam+u)\n");
+  printf("\t-Q  <w>: weight/scale of the -L LLR term (default 0.01; re-tune per\n"
+	 "\t     param file and library depth)\n");
   printf("\t-W: Only Forward sense prediction (Watson)\n");
   printf("\t-C: Only Reverse sense prediction (Crick)\n");
   printf("\t-U: Allow U12 introns (Requires appropriate U12 parameters to be set in the parameter file)\n");
@@ -196,7 +203,7 @@ void readargv (int argc,char* argv[],
   char *dummy2;
   char *dummy3;
   /* Reading setup options */
-  while ((c = getopt(argc,argv,"oO:bdaefitnsrxj:k:N:p:UDATzZXmMG3BvE:V:R:S:WCFP:huJy:Y:")) != -1)
+  while ((c = getopt(argc,argv,"oO:bdaefitnsrxj:k:N:p:UDATzZXmMG3BvE:V:R:S:WCFP:huJy:Y:L:Q:")) != -1)
     switch(c)
       {
       case 'B': BEG++; 
@@ -306,6 +313,13 @@ void readargv (int argc,char* argv[],
 		/* assembly-compatible: reads-mapped (rpkm reporting), allowed under -O */
 		MRMset = 1;   /* explicit value: suppress BAM-index auto-estimation */
 		NOpt++;
+		break;
+	  case 'L': EXPRLLR = 1;   /* enable Poisson expression LLR coverage scoring */
+		LLRK = strtof(optarg,&dummy3);
+		if (LLRK <= 1.0)
+		  printError("-L expects a fold-change k > 1 (expressed/background)");
+		break;
+	  case 'Q': LLRW = strtof(optarg,&dummy3);   /* LLR weight/scale */
 		break;
 	  case 'U': U12++;
 		/* assembly-compatible: U12 intron typing, allowed under -O */


### PR DESCRIPTION
Stage 2 of the RNA-seq expression-scoring redesign: replace the additive coverage term with a statistically grounded per-base **Poisson log-likelihood ratio**.

## Problem
The current exon coverage score is additive with no null model -- `log(cov+1)` under `-u`, raw coverage otherwise -- so *background* transcription is rewarded, not neutral. That drives `-u` over-fragmentation and no-`-u` 3' CDS creep, and on chr21 it over-predicts genes 3.6x (774 predicted vs 214 MANE).

## Change
Per base, score covered depth against the robust background rate `lambda_bg` (the Stage-1 median) under a two-state Poisson model:

```
term = LLRW * (depth*log(k) - (k-1)*lambda_bg)
```

`<= 0` at or below background (uncovered/low-coverage bases are neutral-to-negative rather than rewarded), positive only for genuine enrichment. It is affine in depth, so the prefix-sum architecture in `HSPScan2` is preserved.

- **`-L <k>`** enables it (fold-change `k>1`); **default OFF** keeps the legacy term -> **byte-identical** (all 16 regression cases pass).
- **`-Q <w>`** scales the term vs coding/site scores (`HSPFactor` also weights it).
- `lambda_bg` is stored in `external->covLambdaBg` by the coverage paths, computed only under `-L`/`-v`; the protein-homology path leaves it `-1`, so the LLR never applies there. Uncovered bases (`sr==NO_SCORE`, and note `NO_SCORE=-0.35`) count as depth 0.
- The dead local-flank background subtraction in `ScoreHSPexon` is bypassed under `-L`.

## Harness result (pancreas chr21 `bam+u`, hard-masked; recall vs MANE, precision vs all isoforms)

| | eSN | eSP | eSNSP | gSN | gSP | pred genes |
|---|---|---|---|---|---|---|
| baseline | .681 | .496 | .588 | .112 | .035 | 774 |
| **-L 2 -Q 0.01** | .662 | **.764** | **.713** | **.145** | **.178** | **197** |
| -L 2 -Q 0.015 | .656 | .757 | .707 | .150 | .168 | 214 |

**eSP +0.27**, the 3.6x over-prediction collapses to the MANE count (774 -> ~200; MANE=214), sensitivity essentially held (eSN -0.02), and *exact* genes go **up** (gSN .112 -> .145). Robust across `w in [0.005,0.03]`, `k in {2,3}`; higher `k`/`w` degrade (coverage over-dominates). Defaults set to the optimum (`k=2, w=0.01`).

## Caveat / next
`w` scales the LLR against coding/site scores, so its optimum depends on the param file and library depth -- re-tune `-Q` per dataset. Stage 3: negative-binomial variant (overdispersion), fold the weight into the param/training so it is learned per genome, and a multi-BAM depth-scaling check.

Builds clean with and without htslib, no new warnings.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code