### PR TITLE
RNA-seq expression scoring Stage 5: multi-library evidence (-Y a.bam,b.bam,...)

### DIFF
--- a/include/geneid.h
+++ b/include/geneid.h
@@ -146,6 +146,17 @@ A. DEFINITIONS
 #define LLR_TRIM 0.01
 #define LLR_MINLAMBDA 0.05
 
+/* -Y a.bam,b.bam,... : how many RNA-seq libraries may be combined in one run.
+   Libraries are NOT merged: each keeps its own lambda_bg and its per-base LLR is
+   combined with MAX (see FillCoverageLLR). Merging (samtools merge or summing
+   depth) pools BACKGROUNDS, and lambda_bg is tissue biology, not depth --
+   measured across 5 human total-RNA libraries it spans 14x PER READ (pancreas
+   0.028/Mread, heart 0.403/Mread) -- so a pooled null is wrong for every library
+   in the pool. Measured: merging degraded from N=3 on, and a REDUNDANT library
+   (a 2nd brain region adding 0 new genes) still cost gSN .178->.168 purely by
+   contributing background. MAX makes a redundant library neutral instead. */
+#define MAXBAMS 32
+
 /* Length of allowed UTR including stop codon before intron: used to be 55 */
 #define MAXNMDLENGTH 1000
 
@@ -764,9 +775,19 @@ typedef struct s_packExternalInformation
      per-fragment on chr21 the null swung ~400x (median 0.01, max 20). Estimating
      it once per sequence fixes the density term by construction and leaves a
      mean that is exactly linear in sequencing depth. */
+  /* >0 once the fill has written per-base LLR values into sr[] (so HSPScan2 just
+     prefix-sums them); -1 = legacy per-base term (protein homology, text HSP
+     path, -L absent, or no usable coverage). */
   float covLambdaBg;
-  float covLambdaGlobal[2];          /* [0]=FORWARD, [1]=REVERSE; -1 = not yet computed */
+  /* Per sequence+strand+LIBRARY background: [0]=FORWARD, [1]=REVERSE. Each
+     library keeps its OWN null -- see MAXBAMS for why pooling is wrong. */
+  float covLambdaGlobal[2][MAXBAMS];
   char  covLambdaLocus[MAXSTRING];   /* sequence covLambdaGlobal was computed for */
+  /* Scratch, LENGTHSi each: covTmp = one library's per-base depth; covComb = the
+     running per-base MAX of the libraries' LLRs. */
+  float* covTmp;
+  float* covComb;    /* best LLR seen so far, per base */
+  float* covComb2;   /* 2nd-best, so -K 2 can require two libraries to agree */
 
   /* -S RNA-seq coverage supplied as bigWig (per-split range queries) instead of
      a text HSP file. bwPlus/bwMinus are the +/- strand signals (equal when the
@@ -778,7 +799,12 @@ typedef struct s_packExternalInformation
 
   /* -S RNA-seq coverage supplied as an indexed BAM (htslib, WITH_HTSLIB build);
      NULL => not a BAM. Coverage is derived per fragment, unstranded. */
+  /* -S/-Y RNA-seq coverage from indexed BAM(s) (htslib, WITH_HTSLIB build).
+     bam == bams[0] (or NULL) so existing "is this BAM mode?" checks still read
+     naturally; nBams > 1 means several libraries combined by MAX, never merged. */
   BamCov* bam;
+  BamCov* bams[MAXBAMS];
+  int     nBams;
 } packExternalInformation;
 
 /* Hash-bucket entry identifying one already-backed-up exon (see DumpHash.c);
@@ -1118,7 +1144,7 @@ long ReadExonsBigBed(struct BigBed* bb, packExternalInformation* external, dict*
    or (when absent) from the splice motif in `Sequence` (forward, 1-based via
    Sequence[pos-1]). BamCov is the htslib reader (include/bamcov.h); only reached
    in a WITH_HTSLIB build (external side never opens a BAM otherwise). */
-long ReadIntronsBam(BamCov* bc, packExternalInformation* external, dict* d,
+long ReadIntronsBam(BamCov** bcs, int nbcs, packExternalInformation* external, dict* d,
 		    char* Locus, long l1, long l2, long ownedLo, long ownedHi,
 		    char* Sequence, long LengthSequence);
 

--- a/src/ProcessHSPs.c
+++ b/src/ProcessHSPs.c
@@ -25,6 +25,7 @@
 *************************************************************************/
 
 #include "geneid.h"
+#include <float.h>
 #include "bigwig.h"
 #ifdef WITH_HTSLIB
 #include "bamcov.h"
@@ -37,6 +38,7 @@ extern float NO_SCORE;
 extern int VRB;         /* -v verbose: gates the Stage-1 coverage-background diagnostic */
 extern int EXPRLLR;     /* -L: Poisson per-base expression LLR coverage scoring */
 extern float LLRK, LLRW;/* -L fold-change k (>1); -Q weight/scale of the LLR term */
+extern int LLRMINLIBS;  /* -K: libraries that must support a base (order statistic) */
 
 
 /* Projection of HSPs: save the maximum for each nucleotide */
@@ -461,10 +463,12 @@ void HSPScan2(packExternalInformation* external,
      Gated on a valid covLambdaBg (>0), so the protein-homology path and
      coverage-free fragments keep the legacy term -> default off (-L absent) is
      byte-identical. */
-  int    useLLR = (EXPRLLR && external->covLambdaBg > 0.0);
-  double logk   = useLLR ? log((double) LLRK) : 0.0;
-  double invLam = useLLR ? 1.0 / (double) external->covLambdaBg : 0.0;
-  double bgTerm = useLLR ? ((double) LLRK - 1.0) : 0.0;
+  /* covLambdaBg > 0 means the coverage fill already wrote finished per-base LLR
+     values into sr[] (FillCoverageLLR): the transform has to happen per library,
+     before the MAX, so it cannot be done here. All that is left is the running
+     sum. Legacy paths (protein homology, text HSP, -L absent) keep their
+     per-base term below, so the default stays byte-identical. */
+  int preLLR = (EXPRLLR && external->covLambdaBg > 0.0);
 
   if (Strand == FORWARD)
     {
@@ -485,12 +489,9 @@ void HSPScan2(packExternalInformation* external,
       for (i=l1; i<=l2; i++)
 		{
 		  /* Accumulating step */
-		  if (useLLR){
-		    /* sr[] holds depth/COVNORM (NO_SCORE if uncovered -> depth 0) */
-		    double depth = (external->sr[x][i-l1] == NO_SCORE)
-		                   ? 0.0 : (double) external->sr[x][i-l1] * COVNORM;
-		    double llr = (double) LLRW * (depth * invLam * logk - bgTerm);
-		    external->sr[x][i-l1] = previousScore + (float) llr;
+		  if (preLLR){
+		    /* sr[] already holds this base's LLR: accumulate only. */
+		    external->sr[x][i-l1] = previousScore + external->sr[x][i-l1];
 		    previousScore = external->sr[x][i-l1];
 		    if (UTR){
 		      external->readcount[x][i-l1] = previousReadCount + external->readcount[x][i-l1];
@@ -509,6 +510,43 @@ void HSPScan2(packExternalInformation* external,
     }
 }
 
+
+/* One coverage interval in the CURRENT strand's coordinate frame (genomic for
+   FORWARD, RSequence for REVERSE). */
+typedef struct { long s, e; float v; } covIv;
+
+/* Growable buffer + mapping context for the bwQuery callback. */
+typedef struct {
+  covIv* a;
+  long   n, cap;
+  int    strand;
+  long   L;          /* LengthSequence, for the REVERSE genomic<->RSequence flip */
+} covBuf;
+
+/* bwQuery reports genomic intervals [s,e) 0-based half-open; store each in the
+   1-based position frame the sr[] fill uses (the text HSP path stores GFF
+   1-based coords). FORWARD: 0-based [s,e) -> 1-based half-open [s+1, e+1).
+   REVERSE: the manager runs on RSequence, so genomic 1-based p maps to
+   RSequence coord L-p+1; genomic 0-based [s,e) = 1-based [s+1,e], which reverses
+   to RSequence 1-based [L-e+1, L-s], i.e. half-open [L-e+1, L-s+1). */
+static void covCollect(long s, long e, float v, void* ud)
+{
+  covBuf* b = (covBuf*) ud;
+  long rs, re;
+
+  if (b->strand == FORWARD) { rs = s + 1;        re = e + 1; }
+  else                      { rs = b->L - e + 1; re = b->L - s + 1; }
+
+  if (b->n == b->cap) {
+    b->cap = b->cap ? b->cap * 2 : 64;
+    b->a = (covIv*) realloc(b->a, b->cap * sizeof(covIv));
+    if (b->a == NULL) printError("Not enough memory: bigWig coverage buffer");
+  }
+  b->a[b->n].s = rs;
+  b->a[b->n].e = re;
+  b->a[b->n].v = v;
+  b->n++;
+}
 
 /* --- RNA-seq expression-scoring redesign: global background (lambda_bg) ---- *
  * lambda_bg is the null of the per-base LLR term (-L): the coverage level an
@@ -561,7 +599,7 @@ static void bgCollect(long s, long e, float v, void* ud)
 
 /* Trimmed-mean depth over evenly spaced sample windows of this sequence/strand. */
 static float SampleCoverageBackground(packExternalInformation* external,
-                                      int Strand, long seqLen)
+                                      BamCov* bam, int Strand, long seqLen)
 {
   enum { NWIN = 100, WINLEN = 10000 };
   long hist[BG_HISTCAP + 1];
@@ -582,13 +620,13 @@ static float SampleCoverageBackground(packExternalInformation* external,
     if (gE > seqLen) gE = seqLen;
     if (gE <= gS) continue;
 
-    if (external->bam != NULL) {
+    if (bam != NULL) {
 #ifdef WITH_HTSLIB
       /* Stranded libraries get a per-strand null; unstranded sees every read. */
       char wantStrand = 0;
       if (BAMSTRAND != BAMLIB_NONE)
         wantStrand = (Strand == FORWARD) ? '+' : '-';
-      bamCoverageQuery(external->bam, external->curLocus, gS, gE,
+      bamCoverageQuery(bam, external->curLocus, gS, gE,
                        wantStrand, BAMSTRAND, bgCollect, &b);
 #endif
     } else {
@@ -618,13 +656,16 @@ static float SampleCoverageBackground(packExternalInformation* external,
   return (float) lam;
 }
 
-/* Point external->covLambdaBg at this sequence/strand's global background,
-   computing and caching it on first use for the sequence. Sets -1 when the LLR
-   must not apply (feature off, no coverage handle, or no usable signal). */
+/* Fill this sequence/strand's per-LIBRARY background cache (covLambdaGlobal[si][b]),
+   computing it on first use for the sequence. Each library keeps its OWN null:
+   lambda_bg is tissue biology, not depth -- across 5 human total-RNA libraries it
+   spans 14x per read -- so one pooled null would be wrong for every library in the
+   pool (see MAXBAMS in geneid.h). */
 static void SetCoverageBackground(packExternalInformation* external,
                                   int Strand, long seqLen)
 {
   int si = (Strand == FORWARD) ? 0 : 1;
+  int b, nlib;
   char mess[MAXSTRING];
 
   external->covLambdaBg = -1.0;
@@ -633,24 +674,152 @@ static void SetCoverageBackground(packExternalInformation* external,
 
   /* New sequence -> drop the cached values. */
   if (strcmp(external->covLambdaLocus, external->curLocus) != 0) {
-    external->covLambdaGlobal[0] = -1.0;
-    external->covLambdaGlobal[1] = -1.0;
+    int s2;
+    for (s2 = 0; s2 < 2; s2++)
+      for (b = 0; b < MAXBAMS; b++)
+        external->covLambdaGlobal[s2][b] = -1.0;
     strncpy(external->covLambdaLocus, external->curLocus, MAXSTRING - 1);
     external->covLambdaLocus[MAXSTRING - 1] = '\0';
   }
 
-  if (external->covLambdaGlobal[si] < 0.0) {
-    external->covLambdaGlobal[si] = SampleCoverageBackground(external, Strand, seqLen);
+  /* bigWig (or the single-bigWig path) has no library array: slot 0, bam NULL. */
+  nlib = (external->nBams > 0) ? external->nBams : 1;
+  for (b = 0; b < nlib; b++) {
+    if (external->covLambdaGlobal[si][b] >= 0.0) continue;
+    external->covLambdaGlobal[si][b] =
+      SampleCoverageBackground(external,
+                               (external->nBams > 0) ? external->bams[b] : NULL,
+                               Strand, seqLen);
     if (VRB) {
-      sprintf(mess, "Coverage background %s %s: lambda_bg %.4f (global, sampled)",
+      sprintf(mess, "Coverage background %s %s lib %d/%d: lambda_bg %.4f (global, sampled)",
               external->curLocus, (Strand == FORWARD) ? "fwd" : "rvs",
-              external->covLambdaGlobal[si]);
+              b + 1, nlib, external->covLambdaGlobal[si][b]);
       printMess(mess);
     }
   }
 
-  if (external->covLambdaGlobal[si] >= LLR_MINLAMBDA)
-    external->covLambdaBg = external->covLambdaGlobal[si];
+  /* Legacy single-source path keeps using covLambdaBg directly. */
+  if (nlib == 1 && external->covLambdaGlobal[si][0] >= LLR_MINLAMBDA)
+    external->covLambdaBg = external->covLambdaGlobal[si][0];
+}
+
+/* Query ONE library's coverage for this fragment as per-base DEPTH into dst[]
+   (0 where uncovered), saturating exactly like CoverAdd does (COV*COVNORM). */
+static void QueryLibDepth(packExternalInformation* external, BamCov* bam, int Strand,
+                          long l1, long l2, long LengthSequence, float* dst)
+{
+  covBuf buf;
+  long gS, gE, i, k, j, len = l2 - l1 + 1;
+
+  buf.a = NULL; buf.n = 0; buf.cap = 0;
+  buf.strand = Strand; buf.L = LengthSequence;
+
+  if (Strand == FORWARD) { gS = l1 - 1; gE = l2 + 2; }
+  else                   { gS = LengthSequence - 2 - l2; gE = LengthSequence - l1 + 1; }
+  if (gS < 0) gS = 0;
+
+  for (i = 0; i < len; i++) dst[i] = 0.0;
+
+  if (bam != NULL) {
+#ifdef WITH_HTSLIB
+    char wantStrand = 0;
+    if (BAMSTRAND != BAMLIB_NONE)
+      wantStrand = (Strand == FORWARD) ? '+' : '-';
+    if (external->curLocus != NULL)
+      bamCoverageQuery(bam, external->curLocus, gS, gE,
+                       wantStrand, BAMSTRAND, covCollect, &buf);
+#endif
+  } else {
+    BigWig* bw = (Strand == FORWARD) ? external->bwPlus : external->bwMinus;
+    if (bw != NULL && external->curLocus != NULL)
+      bwQuery(bw, external->curLocus, gS, gE, covCollect, &buf);
+  }
+
+  for (k = 0; k < buf.n; k++) {
+    long a = (buf.a[k].s < l1)     ? l1     : buf.a[k].s;
+    long z = (buf.a[k].e > l2 + 1) ? l2 + 1 : buf.a[k].e;
+    for (j = a; j < z; j++) {
+      float d = dst[j - l1] + buf.a[k].v;
+      dst[j - l1] = (d > (float)(COV * COVNORM)) ? (float)(COV * COVNORM) : d;
+    }
+  }
+  free(buf.a);
+}
+
+/* -L fill: write the per-base LLR straight into sr[], combining libraries by MAX.
+ *
+ * The LLR must be computed PER LIBRARY and only then combined, because each
+ * library has its own lambda_bg: you cannot max (or sum) raw depths across
+ * libraries whose backgrounds differ 14x. MAX gives union semantics -- "expressed
+ * in ANY tissue", which is what annotation wants -- and makes a redundant library
+ * NEUTRAL (max of a duplicate changes nothing) where merging made it actively
+ * harmful (measured: a 2nd brain region adding 0 new genes still cost gSN
+ * .178->.168 purely by contributing background). Summing LLRs instead would be
+ * AND-ish and would kill exactly the tissue-specific genes extra tissues are for.
+ *
+ * sr[] then holds the finished per-base term, so HSPScan2 only prefix-sums it.
+ * Returns 0 when no library has usable signal here (caller keeps the legacy term). */
+static int FillCoverageLLR(packExternalInformation* external, int Strand,
+                           long l1, long l2, long LengthSequence)
+{
+  short frameStart = (Strand == FORWARD) ? 0 : FRAMES;
+  short frameEnd   = frameStart + FRAMES;
+  int   si   = (Strand == FORWARD) ? 0 : 1;
+  long  len  = l2 - l1 + 1;
+  double logk = log((double) LLRK);
+  double km1  = (double) LLRK - 1.0;
+  int    nlib = (external->nBams > 0) ? external->nBams : 1;
+  int    b, nvalid = 0, useSecond;
+  long   i;
+  short  x;
+
+  if (UTR)
+    for (i = 0; i < len; i++) external->readcount[frameStart][i] = 0.0;
+
+  /* Track the best (covComb) and 2nd best (covComb2) per-base LLR across the
+     libraries, so -K can pick which order statistic to score with. */
+  for (i = 0; i < len; i++) {
+    external->covComb[i]  = -FLT_MAX;
+    external->covComb2[i] = -FLT_MAX;
+  }
+
+  for (b = 0; b < nlib; b++) {
+    float lam = external->covLambdaGlobal[si][b];
+    if (lam < LLR_MINLAMBDA) continue;          /* this library has nothing usable here */
+
+    QueryLibDepth(external, (external->nBams > 0) ? external->bams[b] : NULL,
+                  Strand, l1, l2, LengthSequence, external->covTmp);
+
+    for (i = 0; i < len; i++) {
+      float llr = (float) ((double) LLRW *
+                  (((double) external->covTmp[i] / (double) lam) * logk - km1));
+      if (llr > external->covComb[i]) {
+        external->covComb2[i] = external->covComb[i];
+        external->covComb[i]  = llr;
+      } else if (llr > external->covComb2[i]) {
+        external->covComb2[i] = llr;
+      }
+      if (UTR) external->readcount[frameStart][i] += external->covTmp[i];
+    }
+    nvalid++;
+  }
+
+  if (nvalid == 0) return 0;                    /* no usable library */
+
+  /* -K n: score with the n-th highest library. With fewer libraries than -K, fall
+     back to the max, so one library behaves the same however -K is set. */
+  useSecond = (LLRMINLIBS >= 2 && nvalid >= 2);
+
+  /* The signal has no reading frame: replicate into the strand's 3 frame planes. */
+  for (x = frameStart; x < frameEnd; x++)
+    for (i = 0; i < len; i++) {
+      external->sr[x][i] = useSecond ? external->covComb2[i] : external->covComb[i];
+      if (UTR && x != frameStart)
+        external->readcount[x][i] = external->readcount[frameStart][i];
+    }
+
+  external->covLambdaBg = 1.0;   /* >0 = sr[] already holds the per-base LLR */
+  return 1;
 }
 
 /* Management function to score and filter exons */
@@ -688,43 +857,6 @@ void ProcessHSPs(long l1,
  *  of the preloaded HSP list. Fills sr[] to score exons whether or not -u is  *
  *  set; readcount[] (rpkm) is only touched under -u (see CoverAdd).          *
  * ------------------------------------------------------------------------- */
-
-/* One coverage interval in the CURRENT strand's coordinate frame (genomic for
-   FORWARD, RSequence for REVERSE). */
-typedef struct { long s, e; float v; } covIv;
-
-/* Growable buffer + mapping context for the bwQuery callback. */
-typedef struct {
-  covIv* a;
-  long   n, cap;
-  int    strand;
-  long   L;          /* LengthSequence, for the REVERSE genomic<->RSequence flip */
-} covBuf;
-
-/* bwQuery reports genomic intervals [s,e) 0-based half-open; store each in the
-   1-based position frame the sr[] fill uses (the text HSP path stores GFF
-   1-based coords). FORWARD: 0-based [s,e) -> 1-based half-open [s+1, e+1).
-   REVERSE: the manager runs on RSequence, so genomic 1-based p maps to
-   RSequence coord L-p+1; genomic 0-based [s,e) = 1-based [s+1,e], which reverses
-   to RSequence 1-based [L-e+1, L-s], i.e. half-open [L-e+1, L-s+1). */
-static void covCollect(long s, long e, float v, void* ud)
-{
-  covBuf* b = (covBuf*) ud;
-  long rs, re;
-
-  if (b->strand == FORWARD) { rs = s + 1;        re = e + 1; }
-  else                      { rs = b->L - e + 1; re = b->L - s + 1; }
-
-  if (b->n == b->cap) {
-    b->cap = b->cap ? b->cap * 2 : 64;
-    b->a = (covIv*) realloc(b->a, b->cap * sizeof(covIv));
-    if (b->a == NULL) printError("Not enough memory: bigWig coverage buffer");
-  }
-  b->a[b->n].s = rs;
-  b->a[b->n].e = re;
-  b->a[b->n].v = v;
-  b->n++;
-}
 
 /* Fill sr[]/readcount[] over fragment [l1,l2] from a frameless coverage stream.
    The signal has no reading frame, so it is replicated identically into all
@@ -780,12 +912,20 @@ void ProcessCoverageBigWig(long l1, long l2, int Strand,
   if (gS < 0) gS = 0;
 
   printMess("Preprocessing bigWig coverage: step 1");
-  if (bw != NULL && external->curLocus != NULL)
-    bwQuery(bw, external->curLocus, gS, gE, covCollect, &buf);
-
-  FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
-  free(buf.a);
   SetCoverageBackground(external, Strand, LengthSequence);
+
+  if (EXPRLLR && FillCoverageLLR(external, Strand, l1, l2, LengthSequence))
+    {
+      free(buf.a);
+    }
+  else
+    {
+      external->covLambdaBg = -1.0;
+      if (bw != NULL && external->curLocus != NULL)
+        bwQuery(bw, external->curLocus, gS, gE, covCollect, &buf);
+      FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
+      free(buf.a);
+    }
 
   printMess("Preprocessing bigWig coverage: step 2");
   HSPScan2(external, NULL, Strand, l1, l2);
@@ -823,13 +963,24 @@ void ProcessCoverageBam(long l1, long l2, int Strand,
     wantStrand = (Strand == FORWARD) ? '+' : '-';
 
   printMess("Preprocessing BAM coverage: step 1");
-  if (external->bam != NULL && external->curLocus != NULL)
-    bamCoverageQuery(external->bam, external->curLocus, gS, gE,
-                     wantStrand, BAMSTRAND, covCollect, &buf);
-
-  FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
-  free(buf.a);
   SetCoverageBackground(external, Strand, LengthSequence);
+
+  /* -L: score each library against its OWN background and combine by MAX (this
+     is the only path that supports several libraries; they are never merged).
+     Otherwise fall back to the legacy single-source depth fill. */
+  if (EXPRLLR && FillCoverageLLR(external, Strand, l1, l2, LengthSequence))
+    {
+      free(buf.a);
+    }
+  else
+    {
+      external->covLambdaBg = -1.0;            /* legacy per-base term in HSPScan2 */
+      if (external->bam != NULL && external->curLocus != NULL)
+        bamCoverageQuery(external->bam, external->curLocus, gS, gE,
+                         wantStrand, BAMSTRAND, covCollect, &buf);
+      FillCoverageFrameless(external, Strand, l1, l2, buf.a, buf.n);
+      free(buf.a);
+    }
 
   printMess("Preprocessing BAM coverage: step 2");
   HSPScan2(external, NULL, Strand, l1, l2);

--- a/src/ReadIntronsBam.c
+++ b/src/ReadIntronsBam.c
@@ -82,21 +82,29 @@ static int cmpJunc(const void* a, const void* b){
    the same non-overlapping per-fragment assignment ReadExonsBigBed makes -- so
    each distinct junction is committed in exactly one fragment. Returns the
    number of evidence exon slots produced (including frame/intron replicas). */
-long ReadIntronsBam(BamCov* bc, packExternalInformation* external, dict* d,
+/* Junctions from ONE OR MORE libraries. Unlike coverage -- where each library
+   needs its own lambda_bg and they are combined by MAX, because merging pools
+   backgrounds -- junctions have no background to pool, so several libraries are
+   simply UNIONed here. The existing sort+tally below then sums read support
+   across libraries for free: an intron seen in three tissues gets their combined
+   support, which is exactly the wanted semantics. */
+long ReadIntronsBam(BamCov** bcs, int nbcs, packExternalInformation* external, dict* d,
                     char* Locus, long l1, long l2, long ownedLo, long ownedHi,
                     char* Sequence, long LengthSequence){
   packEvidence* ev = external->evidence[0];
   juncList L = { NULL, 0, 0 };
   long lastAcceptor = -INFI;
   long i;
+  int b;
 
   ev->nvExons = 0;
   ev->nvSites = 0;
 
   /* Reads overlapping [l1,l2+1) (0-based); ownership (below) is in 1-based
      acceptor units, matching the GFF/bigBed evidence assignment. */
-  if (bamJunctionQuery(bc, Locus, l1, l2 + 1, collectCB, &L) < 0)
-    printError("BAM junction query failed");
+  for (b = 0; b < nbcs; b++)
+    if (bamJunctionQuery(bcs[b], Locus, l1, l2 + 1, collectCB, &L) < 0)
+      printError("BAM junction query failed");
 
   /* Junctions with no read-tag strand ('.') get one from the splice motif; this
      depends only on (start,end), so all '.' copies of a junction resolve alike

--- a/src/RequestMemory.c
+++ b/src/RequestMemory.c
@@ -473,12 +473,29 @@ packExternalInformation* RequestMemoryExternalInformation()
   p->bwMinus = NULL;
   p->curLocus = NULL;
   p->bam = NULL;   /* -S BAM handle: NULL until the -S ingest sniffs a BAM */
+  p->nBams = 0;
+  {
+    int b;
+    for (b = 0; b < MAXBAMS; b++) p->bams[b] = NULL;
+  }
+  /* Scratch for the -L multi-library fill (see FillCoverageLLR): one library's
+     depth, and the running per-base MAX of the libraries' LLRs. */
+  if ((p->covTmp = (float*) calloc(LENGTHSi, sizeof(float))) == NULL)
+    printError("Not enough memory: coverage scratch (covTmp)");
+  if ((p->covComb = (float*) calloc(LENGTHSi, sizeof(float))) == NULL)
+    printError("Not enough memory: coverage scratch (covComb)");
+  if ((p->covComb2 = (float*) calloc(LENGTHSi, sizeof(float))) == NULL)
+    printError("Not enough memory: coverage scratch (covComb2)");
   /* -L expression LLR background: covLambdaBg is set per fragment from the
      per-sequence/strand cache, which is filled on first use (see
      SetCoverageBackground). -1 = not computed -> legacy per-base term. */
   p->covLambdaBg = -1.0;
-  p->covLambdaGlobal[0] = -1.0;
-  p->covLambdaGlobal[1] = -1.0;
+  {
+    int si, b;
+    for (si = 0; si < 2; si++)
+      for (b = 0; b < MAXBAMS; b++)
+        p->covLambdaGlobal[si][b] = -1.0;
+  }
   p->covLambdaLocus[0] = '\0';
 
   return(p);

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -133,6 +133,31 @@ float LLRK=50.0;
    against coding/site scores, so it remains param-file dependent. */
 float LLRW=0.0007;
 
+/* -K: how many libraries must support a base before it counts as expressed, i.e.
+   which order statistic of the per-library LLRs is used (1 = the MAX = union,
+   2 = the 2nd highest = "at least two agree", ...).
+   MAX alone is monotonically permissive: with N libraries a base is called if ANY
+   of them shows a peak, so false positives grow ~proportionally to N -- measured
+   across 5 libraries, predicted genes climbed 199->309 against a MANE truth of
+   214 while eSP fell .770->.679. Requiring two libraries kills single-library
+   noise (rank-1 only) while keeping genes that are expressed in several tissues.
+   The tension: a genuinely TISSUE-SPECIFIC gene is rank-1 by definition, so -K 2
+   drops it -- which is exactly what extra tissues were added to catch. Hence a
+   knob rather than a hardcoded rule. Default 1 = max (previous behaviour).
+   With fewer libraries than -K, the effective order falls back to the max, so a
+   single library behaves identically however -K is set (and -Y with one BAM is
+   unchanged by this default).
+   DEFAULT 2, measured on 5 human total-RNA libraries (chr21 vs MANE=214): -K 2
+   beat -K 1 by eSNSP +.024/+.031 at N=4/5 and cut predicted genes 309->254, and
+   -- unlike max (peaks N=3 then decays) or samtools merge (peaks N=2 then
+   decays) -- it still IMPROVES as libraries are added (.727 -> .728), which is
+   the whole point of feeding geneid many tissues. It also handles a redundant
+   library almost neutrally (+.001 eSNSP) where max lost .006. Counter-intuitively
+   it RAISES sensitivity too (eSN .658 -> .744 from N=3 to N=5): with more
+   libraries more real genes have two supporters, so the rule relaxes with scale
+   while rank-1 noise stays suppressed. -K 1 restores the plain union/max. */
+int LLRMINLIBS=2;
+
 /* Optional Predicted Gene Prefix */
 char  GenePrefix[MAXSTRING]="";
   
@@ -170,6 +195,41 @@ long NUMSITES,NUMEXONS,MAXBACKUPSITES,MAXBACKUPEXONS,NUMU12SITES,NUMU12EXONS,NUM
 
 /* Accounting time and results */
 account *m;
+
+
+#ifdef WITH_HTSLIB
+/* Open a comma-separated list of indexed BAMs into out[], returning the count.
+   Returns 0 when the FIRST element is not a BAM, so the caller can fall through
+   to the bigWig / text paths (this doubles as the format sniff, like bamOpen
+   alone did). A later element failing is fatal rather than skipped: silently
+   dropping a library would quietly change the evidence a run was given.
+   Several libraries are kept SEPARATE on purpose -- each kes its own lambda_bg
+   and they are combined by MAX, never merged (see MAXBAMS in geneid.h). */
+static int openBamList(const char* spec, BamCov** out, const char* what)
+{
+  char buf[MAXSTRING];
+  char err[MAXSTRING];
+  char* tok;
+  int n = 0;
+
+  strncpy(buf, spec, MAXSTRING - 1);
+  buf[MAXSTRING - 1] = '\0';
+  for (tok = strtok(buf, ","); tok != NULL; tok = strtok(NULL, ",")) {
+    BamCov* b = bamOpen(tok);
+    if (b == NULL) {
+      if (n == 0) return 0;                  /* not a BAM: let the caller sniff on */
+      sprintf(err, "%s: cannot open '%s' as an indexed BAM (needs .bai/.csi)", what, tok);
+      printError(err);
+    }
+    if (n >= MAXBAMS) {
+      sprintf(err, "%s: too many BAMs (max %d)", what, MAXBAMS);
+      printError(err);
+    }
+    out[n++] = b;
+  }
+  return n;
+}
+#endif
 
 /************************************************************************
                             geneid MAIN program
@@ -243,7 +303,11 @@ int main (int argc, char *argv[])
   int reading;
   int lastSplit;
   BigBed* evBB = NULL;    /* non-NULL => -R evidence is a bigBed, queried per split */
-  BamCov* evBam = NULL;   /* non-NULL => -R evidence is a BAM (introns), per split */
+  BamCov* evBam = NULL;   /* == evBams[0]; non-NULL => -R/-Y evidence is BAM (introns), per split */
+#ifdef WITH_HTSLIB
+  BamCov* evBams[MAXBAMS];   /* -Y a.bam,b.bam: junctions are UNIONed across libraries */
+  int     nEvBams = 0;
+#endif
   long bbOwnedLo = 0;     /* upper acceptor bound owned by the previous fragment */
   char mess[MAXSTRING];
 
@@ -370,8 +434,14 @@ int main (int argc, char *argv[])
 	  if (evBB)
 	    printMess("Reading evidence from bigBed (per-split range queries)...");
 #ifdef WITH_HTSLIB
-	  else if ((evBam = bamOpen(ExonsFile)) != NULL)
-	    printMess("Reading introns from BAM junctions (per-split range queries)...");
+	  else if ((nEvBams = openBamList(ExonsFile, evBams, "-Y/-R introns")) > 0)
+	    {
+	      evBam = evBams[0];
+	      sprintf(mess, "Reading introns from %d BAM%s junctions (per-split range "
+		      "queries; junctions UNIONed, support summed)...",
+		      nEvBams, (nEvBams > 1) ? "s" : "");
+	      printMess(mess);
+	    }
 #endif
 	  else
 	    {
@@ -394,12 +464,30 @@ int main (int argc, char *argv[])
 	  char* comma = strchr(HSPFile, ',');
 	  if (comma != NULL)
 	    {
+	      /* A comma list is either the legacy stranded bigWig pair
+		 (plus.bw,minus.bw) or several BAM libraries. Sniff the first
+		 element: bigWig -> pair; BAM -> list. */
 	      *comma = '\0';
-	      external->bwPlus  = bwOpen(HSPFile);
-	      external->bwMinus = bwOpen(comma + 1);
+	      external->bwPlus = bwOpen(HSPFile);
 	      *comma = ',';
-	      if (external->bwPlus == NULL || external->bwMinus == NULL)
-		printError("-S with two comma-separated files expects stranded bigWigs (plus.bw,minus.bw)");
+	      if (external->bwPlus != NULL)
+		{
+		  *comma = '\0';
+		  external->bwMinus = bwOpen(comma + 1);
+		  *comma = ',';
+		  if (external->bwMinus == NULL)
+		    printError("-S with two comma-separated bigWigs expects plus.bw,minus.bw");
+		}
+	      else
+		{
+#ifdef WITH_HTSLIB
+		  external->nBams = openBamList(HSPFile, external->bams, "-Y/-S coverage");
+		  external->bam = (external->nBams > 0) ? external->bams[0] : NULL;
+#endif
+		  if (external->bam == NULL)
+		    printError("-S/-Y comma list: expected stranded bigWigs (plus.bw,minus.bw) "
+			       "or indexed BAMs (a.bam,b.bam,...)");
+		}
 	    }
 	  else
 	    {
@@ -407,7 +495,11 @@ int main (int argc, char *argv[])
 	      external->bwMinus = external->bwPlus;   /* unstranded: same signal both strands */
 #ifdef WITH_HTSLIB
 	      if (external->bwPlus == NULL)
-		external->bam = bamOpen(HSPFile);   /* not a bigWig: try an indexed BAM */
+		{
+		  external->bams[0] = bamOpen(HSPFile);   /* not a bigWig: try an indexed BAM */
+		  external->nBams = (external->bams[0] != NULL) ? 1 : 0;
+		  external->bam = external->bams[0];
+		}
 #endif
 	    }
 
@@ -626,7 +718,7 @@ int main (int argc, char *argv[])
 					Locus, l1, l2, bbOwnedLo, ownedHi);
 #ifdef WITH_HTSLIB
 		      else
-			ReadIntronsBam(evBam, external, isochores[0]->D,
+			ReadIntronsBam(evBams, nEvBams, external, isochores[0]->D,
 				       Locus, l1, l2, bbOwnedLo, ownedHi,
 				       Sequence, LengthSequence);
 #endif
@@ -770,10 +862,14 @@ int main (int argc, char *argv[])
   if (external->bwPlus != NULL)
     bwClose(external->bwPlus);
 #ifdef WITH_HTSLIB
-  if (external->bam != NULL)
-    bamClose(external->bam);
-  if (evBam != NULL)
-    bamClose(evBam);
+  {
+    int b;
+    for (b = 0; b < external->nBams; b++) bamClose(external->bams[b]);
+  }
+  {
+    int b;
+    for (b = 0; b < nEvBams; b++) bamClose(evBams[b]);
+  }
 #endif
 
   /* 4. The End */

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -43,6 +43,7 @@ extern float EW,EvidenceEW,MRM;
 extern int MRMset;   /* set here when -N is given, so a BAM's index is not used to estimate MRM */
 extern int EXPRLLR;        /* -L: enable Poisson per-base expression LLR coverage scoring */
 extern float LLRK, LLRW;   /* -L fold-change k (>1); -Q weight/scale of the LLR term */
+extern int LLRMINLIBS;     /* -K: libraries required to agree (order statistic of per-library LLRs) */
 extern long LOW,HI;
 extern int BAMSTRAND;   /* -y library strandedness for BAM -S coverage */
 
@@ -92,6 +93,9 @@ void printHelp()
 	 "\t     Recommended start: -L 50 -Q 0.0007 (human RNA-seq, bam+u)\n");
   printf("\t-Q  <w>: weight/scale of the -L LLR term (default 0.0007). Transfers\n"
 	 "\t     across library depths; re-tune per param file\n");
+  printf("\t-K  <n>: with -Y a.bam,b.bam,...: libraries that must support a base\n"
+	 "\t     (default 2 = require two to agree; 1 = max/union). Each library keeps\n"
+	 "\t     its own background; they are never merged. One library ignores this\n");
   printf("\t-W: Only Forward sense prediction (Watson)\n");
   printf("\t-C: Only Reverse sense prediction (Crick)\n");
   printf("\t-U: Allow U12 introns (Requires appropriate U12 parameters to be set in the parameter file)\n");
@@ -204,7 +208,7 @@ void readargv (int argc,char* argv[],
   char *dummy2;
   char *dummy3;
   /* Reading setup options */
-  while ((c = getopt(argc,argv,"oO:bdaefitnsrxj:k:N:p:UDATzZXmMG3BvE:V:R:S:WCFP:huJy:Y:L:Q:")) != -1)
+  while ((c = getopt(argc,argv,"oO:bdaefitnsrxj:k:N:p:UDATzZXmMG3BvE:V:R:S:WCFP:huJy:Y:L:Q:K:")) != -1)
     switch(c)
       {
       case 'B': BEG++; 
@@ -321,6 +325,10 @@ void readargv (int argc,char* argv[],
 		  printError("-L expects a fold-change k > 1 (expressed/background)");
 		break;
 	  case 'Q': LLRW = strtof(optarg,&dummy3);   /* LLR weight/scale */
+		break;
+	  case 'K': LLRMINLIBS = atoi(optarg);   /* libraries required to agree (-Y a,b,c) */
+		if (LLRMINLIBS < 1)
+		  printError("-K expects a library count >= 1 (1 = max/union, 2 = require two)");
 		break;
 	  case 'U': U12++;
 		/* assembly-compatible: U12 intron typing, allowed under -O */


### PR DESCRIPTION
Feed geneid several RNA-seq libraries in one run: `-Y a.bam,b.bam,...`. They are kept **separate**, not merged -- each keeps its own `lambda_bg`, and their per-base LLRs are combined by an order statistic (`-K`). Junctions are unioned with support summed.

> **Correction (this PR was updated).** An earlier 5-library run suggested `-K 2` "keeps improving as libraries are added (.727 -> .728)". That was an artifact of library **order** -- the N=5 point was a redundant 2nd brain region. With liver in its proper greedy slot the curve reads **.727 (N=4) -> .702 (N=5) -> .704 (N=6)**. `-K 2` **peaks at ~4 diverse libraries and then declines**. It is still the best combiner, but it does not scale without bound.

## Why not just `samtools merge`
Merging pools **backgrounds**, and `lambda_bg` turns out to be *tissue biology, not depth*. Measured across the 6 human total-RNA libraries it spans **14x per read**:

| library | reads | lambda_bg | per Mread |
|---|---|---|---|
| pancreas | 15.5M | 0.431 | 0.028 |
| GM12878 | 19.8M | 0.658 | 0.033 |
| parietal lobe | 13.6M | 1.583 | 0.117 |
| liver | 23.2M | 2.157 | 0.093 |
| **heart** | **3.9M** | 1.573 | **0.403** |

Heart has 4x fewer reads than pancreas but a 3.6x higher background. Brain and pancreas do not share a null, so a pooled one is wrong for every library in the pool. Measured consequences of merging (chr21 vs MANE=214):

- `lambda_bg` pooled **0.43 -> 4.79 (11x)**; eSP fell **monotonically** .764 -> .708
- eSNSP peaked at N=2 and **decayed from N=3** (when brain's high background entered)
- a **redundant** library (2nd brain region, **0** new reachable genes) still cost **gSN .178 -> .168** purely by contributing background

## Change
- **`-Y a.bam,b.bam,...`** -- reuses the comma-list pattern from `-S plus.bw,minus.bw`.
- **Coverage:** per-library `lambda_bg` -> per-library LLR -> combined per base. The LLR *must* precede the combine: depths from libraries whose backgrounds differ 14x are not comparable.
- **`-K <n>`** -- which order statistic. `1` = max/union; **`2` (default)** = require two libraries to agree. Max alone is monotonically permissive (a base is called if *any* library peaks), so false positives grow ~proportionally to N: genes **199 -> 309** vs MANE's 214, eSP **.770 -> .679**. `-K 2` holds it: gene count is nearly flat from N=4 (247 -> 248 -> 255).
- **Junctions:** union + summed support -- no background to pool, so no dilution. The existing sort/tally already sums support, so N libraries came free.

## Results (chr21 vs MANE, 6 total-RNA libraries, `-L 50`, greedy order)

| combiner | peak eSNSP | behaviour with N |
|---|---|---|
| single library | .715 | -- |
| `samtools merge` | .716 | peaks N=2, decays |
| `-K 1` (max) | .713 | peaks N=3, decays |
| **`-K 2`** (default) | **.727 @ N=4** | peaks N=4, decays gracefully |

`-K 2` at N=4: **eSN .732, eSP .722, eSNSP .727, gSN .187, 247 genes**.

**All three combiners peak and decline.** `-K 2` peaks latest and highest and degrades gracefully rather than sharply -- that is the honest claim. eSP declines monotonically throughout (.741 -> .699), so `-K 2` slows the false-positive pressure without removing it.

## Operating point: ~4 diverse libraries
The reachable-gene curve saturates in the same place, which is the useful part:

| N | added | new | union | % MANE |
|---|---|---|---|---|
| 1 | pancreas | 117 | 117 | 54.7% |
| 2 | GM12878 | +13 | 130 | 60.7% |
| 3 | parietal | +11 | 141 | 65.9% |
| 4 | heart | +4 | 145 | 67.8% |
| 5 | occipital | **+0** | 145 | 67.8% |
| 6 | liver | **+0** | 145 | 67.8% |

**32% of chr21 MANE genes are transcribed in none of the six.** Two brain lobes are perfectly redundant. **More libraries are not better; complementary ones are** -- and both curves independently say to stop around four.

Notable: **liver adds 0 reachable genes yet lifts gSN .187 -> .196** (best of the project) while eSNSP falls -- a library contributing no new genes can still sharpen *exact structure* by acting as a second supporter under `-K 2`.

## Scope / safety
- One library degenerates to the max whatever `-K` says, so `-Y` with a single BAM is unchanged -- **verified byte-identical to `dev`** (non-empty outputs compared; an earlier version of this check was passing vacuously on empty files).
- All **16 regression cases byte-identical** (`-L` absent keeps the legacy term); clean build with and without htslib.
- Tested on 6 libraries, one genome, one param file. `-K 2` as default rests on N>=4 behaviour.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code