### PR TITLE
Junction read-support floor (-I): minimum reads before a junction becomes evidence

### DIFF
--- a/src/ReadIntronsBam.c
+++ b/src/ReadIntronsBam.c
@@ -25,6 +25,7 @@
 extern float EvidenceFactor;
 extern float EvidenceEW;
 extern int FWD, RVS;
+extern int MINJUNCREADS;   /* -I: junction read-support floor (default 1 = off) */
 
 /* One spliced-read junction occurrence (0-based half-open reference coords). */
 typedef struct { long start, end; char strand; } juncRec;
@@ -133,6 +134,7 @@ long ReadIntronsBam(BamCov** bcs, int nbcs, packExternalInformation* external, d
     if (strand != '+' && strand != '-') continue;        /* strand unresolved -> drop */
     if (begin <= ownedLo || begin > ownedHi) continue;   /* owned by another fragment */
     if ((strand == '+' && !FWD) || (strand == '-' && !RVS)) continue;
+    if (readCount < MINJUNCREADS) continue;               /* -I: too little read support */
 
     float score = (float) readCount * EvidenceFactor + EvidenceEW;
     int three = 1;                             /* introns carry no frame -> 3 copies */

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -158,6 +158,25 @@ float LLRW=0.0007;
    while rank-1 noise stays suppressed. -K 1 restores the plain union/max. */
 int LLRMINLIBS=2;
 
+/* -I: minimum reads supporting a junction (summed across all -Y/-R libraries,
+   see ReadIntronsBam) before it becomes Intron evidence. Default 1 = every
+   distinct junction is used, whatever its support. Unlike -K, this fires
+   unconditionally whenever -R/-Y supplies a BAM -- with or without -L -- so
+   raising the default would be a live behaviour change for existing non-LLR
+   junction/structure users with zero regression coverage of that path; default
+   stays 1 (regression-safe, matches every prior behaviour) and -I is opt-in.
+
+   Measured (chr21 vs MANE, human.rnaseq.param): single library, -I 2 gives a
+   small real gain (eSN .660->.670, eSNSP .715->.721) at a small gene-level cost
+   (gSN .145->.140); -I 3 gives nothing further back. Under -K 2 with 4 combined
+   libraries, -I 2 changed NOTHING (byte-identical output) -- with several
+   libraries' read support summed, a genuine junction essentially never lands at
+   exactly 1 read, so the aggregation already does what the floor is for; -I 3
+   there starts trimming real junctions for no gain (gSP .206->.199). Recommended
+   for single/few-library runs: -I 2. Redundant once -K >= 2 aggregates several
+   libraries -- raising it further only costs precision. */
+int MINJUNCREADS=1;
+
 /* Optional Predicted Gene Prefix */
 char  GenePrefix[MAXSTRING]="";
   

--- a/src/readargv.c
+++ b/src/readargv.c
@@ -44,6 +44,7 @@ extern int MRMset;   /* set here when -N is given, so a BAM's index is not used 
 extern int EXPRLLR;        /* -L: enable Poisson per-base expression LLR coverage scoring */
 extern float LLRK, LLRW;   /* -L fold-change k (>1); -Q weight/scale of the LLR term */
 extern int LLRMINLIBS;     /* -K: libraries required to agree (order statistic of per-library LLRs) */
+extern int MINJUNCREADS;    /* -I: minimum read support for a BAM junction to become Intron evidence */
 extern long LOW,HI;
 extern int BAMSTRAND;   /* -y library strandedness for BAM -S coverage */
 
@@ -96,6 +97,10 @@ void printHelp()
   printf("\t-K  <n>: with -Y a.bam,b.bam,...: libraries that must support a base\n"
 	 "\t     (default 2 = require two to agree; 1 = max/union). Each library keeps\n"
 	 "\t     its own background; they are never merged. One library ignores this\n");
+  printf("\t-I  <n>: minimum reads (summed across -Y/-R libraries) supporting a BAM\n"
+	 "\t     junction before it becomes Intron evidence (default 1 = every junction).\n"
+	 "\t     Recommended -I 2 for single/few libraries; redundant once -K >= 2\n"
+	 "\t     aggregates several -- raising it further there only costs precision\n");
   printf("\t-W: Only Forward sense prediction (Watson)\n");
   printf("\t-C: Only Reverse sense prediction (Crick)\n");
   printf("\t-U: Allow U12 introns (Requires appropriate U12 parameters to be set in the parameter file)\n");
@@ -208,7 +213,7 @@ void readargv (int argc,char* argv[],
   char *dummy2;
   char *dummy3;
   /* Reading setup options */
-  while ((c = getopt(argc,argv,"oO:bdaefitnsrxj:k:N:p:UDATzZXmMG3BvE:V:R:S:WCFP:huJy:Y:L:Q:K:")) != -1)
+  while ((c = getopt(argc,argv,"oO:bdaefitnsrxj:k:N:p:UDATzZXmMG3BvE:V:R:S:WCFP:huJy:Y:L:Q:K:I:")) != -1)
     switch(c)
       {
       case 'B': BEG++; 
@@ -329,6 +334,10 @@ void readargv (int argc,char* argv[],
 	  case 'K': LLRMINLIBS = atoi(optarg);   /* libraries required to agree (-Y a,b,c) */
 		if (LLRMINLIBS < 1)
 		  printError("-K expects a library count >= 1 (1 = max/union, 2 = require two)");
+		break;
+	  case 'I': MINJUNCREADS = atoi(optarg);   /* junction read-support floor (-R/-Y BAM) */
+		if (MINJUNCREADS < 1)
+		  printError("-I expects a read count >= 1 (1 = off, every junction counts)");
 		break;
 	  case 'U': U12++;
 		/* assembly-compatible: U12 intron typing, allowed under -O */


### PR DESCRIPTION
A single spliced read currently commits a junction as Intron evidence with no minimum, whatever its support. On total RNA from a proliferating line especially, a lone read is often misalignment or rare pre-mRNA splicing rather than a real junction. `readCount` was already computed in `ReadIntronsBam` (used for the evidence score), so this is a one-line guard.

## Change
**`-I <n>`** sets a floor on read support before a junction becomes Intron evidence (default **1** = off, every distinct junction counts). It's summed across every `-Y`/`-R` library, so under Stage 5's multi-BAM combining a junction seen once in each of several tissues still clears a floor of 2 or 3.

## Why the default stays 1, not 2
Unlike `-K` (scoped entirely inside `-L`'s `FillCoverageLLR`, so its default-2 only affects LLR runs), `-I` fires **unconditionally** in `ReadIntronsBam` whenever `-R`/`-Y` supplies a BAM -- with or without `-L`. Raising it would be a live behaviour change for existing non-LLR junction/structure users, and the regression suite has no BAM-junction case that would catch it. `-I` ships opt-in instead, the same pattern as `-L`/`-Q`'s "recommended start" note in the help text.

## Results (chr21 vs MANE=214, `human.rnaseq.param`)

| mode | eSN | eSP | eSNSP | gSN | gSP | genes |
|---|---|---|---|---|---|---|
| 1 lib, `-I 1` (default) | .660 | .770 | .715 | .145 | .176 | 199 |
| 1 lib, `-I 2` | **.670** | .772 | **.721** | .140 | .172 | 198 |
| 1 lib, `-I 3` | .660 | .768 | .714 | .140 | .171 | 199 |
| 4 lib (`-K 2`), `-I 1` | .732 | .722 | .727 | .187 | .206 | 247 |
| 4 lib (`-K 2`), `-I 2` | **.732** | **.722** | **.727** | **.187** | **.206** | **247** |
| 4 lib (`-K 2`), `-I 3` | .729 | .722 | .725 | .187 | .199 | 246 |

**Single library:** `-I 2` is a small real gain (eSN +.010, eSNSP +.006) at a tiny gene-level cost; `-I 3` gives nothing further back.

**4-library `-K 2` combo:** `-I 2` is **byte-identical** to `-I 1` -- with several libraries' read support summed, a genuine junction essentially never lands at exactly 1 read, so aggregation already does what the floor is for. `-I 3` there only trims real junctions for no gain (gSP .206 -> .199).

**Recommended:** `-I 2` for single/few-library runs; redundant (or mildly harmful) once `-K >= 2` aggregates several libraries.

## Scope / safety
All **16 regression cases byte-identical** (default `-I 1` is a true no-op: `readCount` is always >= 1 by construction); clean build with and without htslib. Built on top of the merged Stage 5 (#76).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code