### PR TITLE
docs: RNA-seq expression pipeline in the README (+ fix stale -K comment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,18 +183,64 @@ external evidence (annotations, protein homology and RNA-seq) are:
               the common Illumina protocol), "fr" (forward), or "none"
               (unstranded, the default).
 
-  -Y <reads.bam>
-              (WITH_HTSLIB) Convenience: use ONE indexed BAM as BOTH intron
-              evidence (-R junctions) AND RNA-seq coverage (-S), instead of
-              passing the same file to -R and -S separately.
+  -Y <reads.bam[,reads2.bam,...]>
+              (WITH_HTSLIB) Use an indexed BAM as BOTH intron evidence
+              (-R junctions) AND RNA-seq coverage (-S), instead of passing the
+              same file to -R and -S separately. A comma-separated list combines
+              several RNA-seq libraries in one run -- see "Multiple libraries".
+
+RNA-seq expression scoring (-L)
+
+  By default the coverage signal (-S / -Y) scores an exon with an additive
+  per-base term that has no null model, so background transcription is rewarded
+  and the score grows with sequencing depth. -L replaces that with a two-state
+  Poisson log-likelihood ratio against the sequence's own background coverage:
+  a base scores > 0 only where it is genuinely enriched over that background,
+  and the score depends on fold-enrichment rather than raw depth, so it does not
+  drift with library size. This cuts the over-prediction the additive term
+  produces on deep data while keeping (and sharpening) real genes.
+
+  -L <k>      Enable expression LLR scoring. k is the enrichment of an expressed
+              exon over the genome-wide mean coverage (tens, not units, because
+              most of a genome is untranscribed). Off by default (legacy term).
+              Recommended start for human RNA-seq: -L 50 -Q 0.0007 with -u.
+  -Q <w>      Weight of the -L term against the coding/site scores (default
+              0.0007). It transfers across library depths but depends on the
+              parameter file's factors, so re-tune it if you change param files.
+  -N <M>      Millions of reads mapped, used only for the rpkm= report attribute
+              (-u). For a BAM it is estimated from the index; -N overrides that.
+
+Multiple libraries (-Y a.bam,b.bam,... and -K)
+
+  Give -Y a comma-separated list to combine several RNA-seq libraries. They are
+  NOT merged: each keeps its OWN background estimate (which is tissue biology,
+  not depth -- across human total-RNA libraries it varies several-fold per read),
+  and their per-base LLRs are combined by an order statistic. Junctions are
+  unioned across libraries with read support summed.
+
+  -K <n>      How many libraries must support a base for it to count as expressed
+              (default 2 = require two to agree; 1 = max / union). Requiring two
+              suppresses single-library noise, whose false-positive rate would
+              otherwise grow with the number of libraries. A single -Y BAM
+              ignores -K. Diminishing returns set in around ~4 diverse tissues.
+  -I <n>      Minimum reads (summed across all -Y/-R libraries) supporting a BAM
+              junction before it becomes intron evidence (default 1 = every
+              junction). -I 2 helps a little for a single library; it is
+              redundant once -K >= 2 aggregates several.
 
 BAM inputs must be coordinate-sorted and indexed (a .bai/.csi alongside).
 For BAM introns, the junction strand is taken from the read's XS tag, else the
 minimap2 ts tag, else the GT-AG/CT-AC splice motif.
 
-For example, RNA-seq-guided prediction from a single STAR/minimap2 BAM
-(htslib build):
->bin/geneid -3U -u -Y aligned.bam -P param/human.rnaseq.param genome.fa
+Examples (htslib build). Single STAR/minimap2 BAM, expression-scored with UTRs
+(-y sets the library strandedness):
+>bin/geneid -3U -u -y rf -L 50 -Q 0.0007 -Y aligned.bam \
+            -P param/human.rnaseq.param genome.fa
+
+Several tissue BAMs combined (each keeps its own background; two must agree):
+>bin/geneid -3U -u -y rf -L 50 -Q 0.0007 -K 2 \
+            -Y brain.bam,liver.bam,heart.bam,testis.bam \
+            -P param/human.rnaseq.param genome.fa
 
 ***************************************
 

--- a/src/geneid.c
+++ b/src/geneid.c
@@ -147,15 +147,17 @@ float LLRW=0.0007;
    With fewer libraries than -K, the effective order falls back to the max, so a
    single library behaves identically however -K is set (and -Y with one BAM is
    unchanged by this default).
-   DEFAULT 2, measured on 5 human total-RNA libraries (chr21 vs MANE=214): -K 2
-   beat -K 1 by eSNSP +.024/+.031 at N=4/5 and cut predicted genes 309->254, and
-   -- unlike max (peaks N=3 then decays) or samtools merge (peaks N=2 then
-   decays) -- it still IMPROVES as libraries are added (.727 -> .728), which is
-   the whole point of feeding geneid many tissues. It also handles a redundant
-   library almost neutrally (+.001 eSNSP) where max lost .006. Counter-intuitively
-   it RAISES sensitivity too (eSN .658 -> .744 from N=3 to N=5): with more
-   libraries more real genes have two supporters, so the rule relaxes with scale
-   while rank-1 noise stays suppressed. -K 1 restores the plain union/max. */
+   DEFAULT 2, measured on 6 human total-RNA libraries (chr21 vs MANE=214, greedy
+   order): all three combiners peak and then decline, but -K 2 peaks LATEST and
+   HIGHEST and degrades most gracefully -- eSNSP .727 at N=4 vs samtools merge's
+   .716 at N=2 and max's (-K 1) .713 at N=3 -- while holding the gene count near
+   the truth (247 at N=4 vs max's 309). It also handles a redundant library
+   almost neutrally where max lost .006 eSNSP. It does NOT improve without bound:
+   eSP falls monotonically with N under every combiner (.741 -> .699 here), so
+   -K 2 slows the ~N-proportional false-positive pressure without removing it.
+   Operating point is ~4 DIVERSE libraries (the reachable-gene curve saturates
+   there too); more is not better, complementary is. -K 1 restores plain
+   union/max. */
 int LLRMINLIBS=2;
 
 /* Optional Predicted Gene Prefix */


### PR DESCRIPTION
Documents the RNA-seq expression pipeline that shipped across PRs #72-77. README section E only covered `-R`/`-S`/`-u`/`-y`/`-Y` and predated all of it.

## README
Rewrites the evidence section to cover the real pipeline, each with a short "why" and worked examples:
- **`-L` / `-Q`** -- expression LLR scoring (why the default additive term over-predicts on deep data; what `-L` replaces it with).
- **`-N`** -- rpkm library size (auto-estimated from a BAM).
- **`-Y a.bam,b.bam,...` + `-K`** -- multiple libraries, kept separate (own background each), combined by an order statistic; junctions unioned.
- **`-I`** -- junction read-support floor.
- Two worked examples: a single STAR/minimap2 BAM, and several tissue BAMs combined.

## `-K` comment fix
The `-K` comment in `geneid.c` still claimed `-K 2` *"still IMPROVES as libraries are added (.727 -> .728)"*. That was disproved once the liver library was placed in its proper greedy slot: all three combiners peak and decline; `-K 2` peaks **latest and highest** (.727 at N=4) and degrades most gracefully, but eSP falls monotonically with N, and the operating point is **~4 diverse libraries**. The PR body and commit message were corrected at the time; this in-code comment was the one place the stale claim survived. Comment-only.

## Scope
No behaviour change. Clean build with and without htslib; **16/16 regression byte-identical**.

**Merge ordering:** the `-I` docs correspond to #77 (junction floor), which isn't in `dev` yet. Land #77 first or together so the README doesn't describe a flag absent from the binary.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code