### PR TITLE
docs: rewrite the HTML manual for v1.6 (modern, accurate, responsive)

### DIFF
--- a/docs/chapter1/index.html
+++ b/docs/chapter1/index.html
@@ -1,138 +1,105 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>1. What is geneid? &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a class="current" href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 1</p>
+  <h1>What is geneid?</h1>
+  <p class="lead">geneid predicts genes &mdash; splice sites, exons, and complete
+  gene structures &mdash; along anonymous eukaryotic genomic DNA.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>1. What is <tt>geneid</tt> ?
-</td>
-</table>
+  <p><strong>geneid</strong> is an ab&nbsp;initio gene prediction program: given
+  only a genomic sequence and a species parameter file, it finds candidate
+  signals (start/stop codons and splice sites), builds exons from them, scores
+  each exon by its signals and coding potential, and then assembles the
+  highest-scoring set of compatible exons into gene structures. It can run purely
+  ab&nbsp;initio, or fold in external evidence &mdash; annotations, protein
+  homology, and RNA&#8209;seq &mdash; to improve accuracy.</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#description">Description</a>
-<li> <a href="#web"><tt>geneid</tt> on line</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <p>It is written in ANSI C, has no runtime dependencies beyond zlib (and,
+  optionally, htslib for direct BAM input), and runs on Linux and macOS. A
+  prediction on a bacterial or fungal genome takes seconds; a full vertebrate
+  chromosome, minutes.</p>
+
+  <h2>What it predicts</h2>
+  <ul>
+    <li><strong>Signals</strong> &mdash; start and stop codons, and acceptor and
+      donor splice sites, scored with position weight arrays. Optional
+      branch-point and poly-pyrimidine-tract models refine acceptors, and U12
+      (minor-spliceosome) introns can be modelled and typed.</li>
+    <li><strong>Exons</strong> &mdash; first, internal, terminal and single-gene
+      coding exons, plus UTR exons when RNA&#8209;seq is supplied. Each is scored
+      by its defining sites, a Markov coding-potential model, and any evidence.</li>
+    <li><strong>Genes</strong> &mdash; the optimal chain of frame-compatible exons
+      under a configurable <em>gene model</em>, computed by dynamic programming.</li>
+  </ul>
+
+  <h2>Working with evidence</h2>
+  <p>Beyond ab&nbsp;initio prediction, geneid reads several kinds of external
+  information, each per genomic fragment so large genomes stream rather than load
+  whole:</p>
+  <ul>
+    <li><strong>Annotations</strong> (<code>-R</code>) &mdash; GFF, bigBed, or a
+      BAM of spliced-read junctions &mdash; to guide or force predictions
+      (<a href="../chapter6/index.html">chapter&nbsp;6</a>).</li>
+    <li><strong>Protein homology and RNA&#8209;seq</strong> (<code>-S</code> /
+      <code>-Y</code>) &mdash; HSP alignments, or bigWig / BAM coverage that scores
+      exons by expression, with UTR calling, junction evidence and multi-library
+      support (<a href="../chapter7/index.html">chapter&nbsp;7</a>).</li>
+    <li><strong>Externally-provided exons</strong> (<code>-O</code>) &mdash;
+      assembled into gene structures without ab&nbsp;initio prediction
+      (<a href="../chapter5/index.html">chapter&nbsp;5</a>).</li>
+  </ul>
+
+  <h2>Getting geneid</h2>
+  <p>Source, releases, and the issue tracker are on GitHub; a companion Wiki
+  covers training new parameter files.</p>
+  <div class="tablewrap">
+  <table>
+    <tr><th>Resource</th><th>Location</th></tr>
+    <tr><td>Source &amp; releases</td><td><a href="https://github.com/guigolab/geneid">github.com/guigolab/geneid</a></td></tr>
+    <tr><td>Wiki (training, guides)</td><td><a href="https://github.com/guigolab/geneid/wiki">github.com/guigolab/geneid/wiki</a></td></tr>
+    <tr><td>Home page</td><td><a href="http://genome.crg.es/software/geneid">genome.crg.es/software/geneid</a></td></tr>
+    <tr><td>Contact</td><td><a href="mailto:geneid@crg.es">geneid@crg.es</a></td></tr>
+  </table>
+  </div>
+
+  <div class="callout">
+    <span class="label">License</span>
+    geneid source code, binaries and documentation are distributed under the
+    <strong>GNU General Public License</strong>. Comments, suggestions and bug
+    reports are welcome at <a href="mailto:geneid@crg.es">geneid@crg.es</a>.
+  </div>
+
+  <div class="pagenav">
+    <a href="../index.html"><span class="dir">&larr; Up</span><span>Manual home</span></a>
+    <a class="next" href="../chapter2/index.html"><span class="dir">Next &rarr;</span><span>Signals, exons and genes</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Description:</font>
-<a name ="description"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> is a program to predict genic elements as splice sites, exons
-and genes, along eukaryotic DNA sequences. <tt>geneid</tt> offers some type
-of support to integrate predictions from multiple sources and allows to improve
-the quality of predictions by using sequence homology information.
-<br><p>
-The program is written in <b>ANSI C</b> and runs on <tt>UNIX</tt> operating
-systems such as Linux, Solaris or Irix. Installation, setup and usage
-are pretty fast and simple and there is a wide range of options to configure the
-behaviour of the program engine.
-<br><p>
-<tt>geneid</tt> source code, compiled binaries and documentation are
-available under the GNU GENERAL PUBLIC LICENSE.
-<br><p>
-Comments, suggestions and other questions will be warmly welcomed by the authors.
-</font>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3><tt>geneid</tt> on line:</font>
-<a name ="web"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> homepage including more information about program such as accuracy
-or efficiency (benchmarking) and a <tt>geneid</tt> online webserver service 
-are provided over there:
-
-<ul>
-<li>
-<a href="http://www1.imim.es/software/geneid/index.html"> 
-http://www1.imim.es/software/geneid/index.html</a> (web) 
-<li>
-<a href="http://www1.imim.es/geneid.html">http://www1.imim.es/geneid.html</a> (server)
-</ul>
-
-<br><p>
-<tt>geneid</tt> distribution can be obtained through anonymous ftp to:
-<ul>
-<li><tt>ftp.imim.es</tt> in the directory <tt>/pub/software/geneid</tt>
-</ul>
-
-
-<br><p>
-<tt>geneid</tt> authors e-mail address:
-<ul>
-<li> Enrique Blanco Garcia: <A HREF="mailto:eblanco@imim.es">eblanco@imim.es</a>
-<li> Genis Parra Farre: <A HREF="mailto:gparra@imim.es">gparra@imim.es</a>
-<li> Roderic Guigo i Serra: <A HREF="mailto:rguigo@imim.es">rguigo@imim.es</a>
-</ul>
-<br><p>
-If you need help about <tt>geneid</tt>, send a message to:
-<ul>
-<li> <A HREF="mailto:geneid@imim.es">geneid@imim.es</a>
-</ul>
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter10/index.html
+++ b/docs/chapter10/index.html
@@ -1,164 +1,112 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>10. History &amp; references &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a class="current" href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 10</p>
+  <h1>History &amp; references</h1>
+  <p class="lead">Three decades of geneid, its authors, and how to cite it.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>10. <tt>geneid</tt> history.
-</td>
-</table>
+  <h2>A short history</h2>
+  <p>The <strong>first geneid</strong> was developed at the Molecular Biology
+  Computer Research Resource (Dana-Farber Cancer Institute / Harvard) by Roderic
+  Guig&oacute;, Steen Knudsen, Neil Drake and Temple F. Smith. It was never
+  distributed, but an e-mail server was later set up at the Biomolecular
+  Engineering Research Center (Boston University) by Kathleen Klose and Steen
+  Knudsen.</p>
+  <p>geneid was <strong>rewritten from scratch</strong> at the Institut Municipal
+  d'Investigaci&oacute; M&egrave;dica (IMIM) in Barcelona in late 1999, mostly by
+  Enrique Blanco and Roderic Guig&oacute;, with contributions from Mois&eacute;s
+  Burset and Xavier Messeguer. That version, <strong>v1.0</strong>, was released
+  in July 2000. <strong>v1.1</strong> (2002) added XML output, ORF searching and
+  homology support and roughly doubled the speed; <strong>v1.2</strong> (2004)
+  added multi-FASTA processing, forcing a complete gene, and more species.</p>
+  <p>Development later moved to the <strong>Centre for Genomic Regulation
+  (CRG)</strong> in Barcelona, where Tyler Alioto took on maintenance and
+  continued development. The modern releases add substantial capability:</p>
+  <div class="tablewrap"><table>
+    <tr><th>Era</th><th>What changed</th></tr>
+    <tr><td>v1.4.x</td><td>Grow-on-demand memory (no build-time capacity profiles); build and portability cleanups.</td></tr>
+    <tr><td>v1.5.x</td><td>A Python <strong>geneid-train</strong> trainer; U2 branch-point modelling; <strong>U12</strong> (minor-spliceosome) intron prediction and typing; a soft intron-length model.</td></tr>
+    <tr><td>v1.6.0</td><td>Direct <strong>indexed evidence</strong> &mdash; bigWig / bigBed, and (with htslib) <strong>BAM</strong> coverage and junctions; a statistically grounded <strong>RNA&#8209;seq expression score</strong> (depth-invariant per-base log-likelihood ratio) with UTR calling and <strong>multi-library</strong> combining; GFF3 output.</td></tr>
+  </table></div>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#authors">About the authors</a>
-<li> <a href="#version"><tt>geneid</tt> versions and names</a>
-<li> <a href="#ack">Acknowledgements</a>
-<li> <a href="#biblio">Bibliography</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <h2>On the name</h2>
+  <p>Over the years the program has been written GeneID, GeneId, geneID and
+  Geneid. Since the 1.0 release the canonical spelling &mdash; the one most in
+  keeping with UNIX command names &mdash; is simply <strong>geneid</strong>.</p>
+
+  <h2>Authors</h2>
+  <p>geneid v1.6 is developed by <strong>Enrique Blanco</strong>,
+  <strong>Tyler Alioto</strong> and <strong>Roderic Guig&oacute;</strong> at the
+  CRG. Parameter files have been created by <strong>Gen&iacute;s Parra</strong>,
+  <strong>Francisco C&acirc;mara</strong> and <strong>Tyler Alioto</strong>, with
+  earlier contributions from Mois&eacute;s Burset and Xavier Messeguer.
+  Questions and bug reports are welcome at
+  <a href="mailto:geneid@crg.es">geneid@crg.es</a>.</p>
+
+  <h2>How to cite</h2>
+  <p>For general use, cite the Genome Research paper and the Current Protocols
+  chapter:</p>
+  <ul>
+    <li>G. Parra, E. Blanco and R. Guig&oacute;. <em>geneid in Drosophila.</em>
+      Genome Research 10:511&ndash;515, 2000.</li>
+    <li>E. Blanco, G. Parra and R. Guig&oacute;. <em>Using geneid to identify
+      genes.</em> Current Protocols in Bioinformatics, Unit&nbsp;4.3. John Wiley
+      &amp; Sons.</li>
+  </ul>
+
+  <h2>Bibliography</h2>
+  <ul>
+    <li>R. Guig&oacute;, S. Knudsen, N. Drake and T. F. Smith. <em>Prediction of
+      gene structure.</em> Journal of Molecular Biology 226:141&ndash;157, 1992.</li>
+    <li>S. Knudsen, R. Guig&oacute; and T. F. Smith. <em>GeneID &mdash; a computer
+      server for prediction of genes in DNA sequences.</em> In Proc. 2nd Int.
+      Conf. on Bioinformatics, Supercomputing and Complex Genome Analysis,
+      545&ndash;553. World Scientific, 1993.</li>
+    <li>R. Guig&oacute;. <em>Assembling genes from predicted exons in linear time
+      with dynamic programming.</em> Journal of Computational Biology
+      5:681&ndash;702, 1998.</li>
+    <li>G. Parra, E. Blanco and R. Guig&oacute;. <em>geneid in Drosophila.</em>
+      Genome Research 10:511&ndash;515, 2000.</li>
+    <li>E. Blanco, G. Parra and R. Guig&oacute;. <em>Using geneid to identify
+      genes.</em> Current Protocols in Bioinformatics, Unit&nbsp;4.3, 2002.</li>
+  </ul>
+
+  <h2>Acknowledgements</h2>
+  <p>Early work was supported in part by grants from the Spanish "Plan Nacional de
+  I+D" and the Ministerio de Educaci&oacute;n y Ciencia. geneid is free software
+  under the GNU General Public License.</p>
+
+  <div class="pagenav">
+    <a href="../chapter9/index.html"><span class="dir">&larr; Prev</span><span>Source code &amp; architecture</span></a>
+    <a class="next" href="../index.html"><span class="dir">&uarr; Up</span><span>Manual home</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>About the authors:</font>
-<a name ="authors"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Roderic Guigo, Steen Knudsen, Neil Drake and Temple F. Smith contributed to the first 
-implementation of <tt>geneid</tt> developed at the Molecular Biology Computer Research Resource 
-(Dana Farber Cancer Institute - Hardvard University). It was never distributed , but an e-mail
-server was latter set up at the Biomolecular Engineering Research Center (Boston University).
-Kathleen Klose and Steen Knudsen developed the server.
-<br><p>
-<tt>geneid</tt> was rewritten from scratch at the Institut Municipal d'Investigacions Mediques in 
-Barcelona in late 1999 mostly by Enrique Blanco and Roderic Guigo. Moises Burset also made some 
-contributions to the code as well as Xavier Messeguer from Universitat Politecnica de Catalunya.
-This version called geneid v. 1.0 was released in July, 2000.
-<br><p>
-A new release (2002) called geneid v. 1.1 contained many improvements and fixed bugs. Moreover, a new
-set of command line options were developed including XML format output, searching ORFs,
-usage of sequence homology to get better predictions and so on. Processing speed was 
-increased twice while accuraccy of predictions has been maintained. 
-<br><p>
-This latest version geneid v. 1.2 has been released in 2004. New options has been added to support
-processing of multi-fasta files as well as forcing the prediction of a complete gene in the 
-sequence. New parameter files for more species have been simultaneously delivered with this release.
-</font>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3><tt>geneid</tt> versions and names:</font>
-<a name ="version"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-During many years, <tt>geneid</tt> has been referred to as GeneID, GeneId, geneID or Geneid. Before
-release the 1.0 version, we decided for the simplest, most sensible with UNIX commands 
-nomenclature, name: <tt>geneid</tt>. After that, new releases are enhanced versions of basic 1.0
-so that we selected the numeration 1.1 and 1.2.
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Acknowledgments:</font>
-<a name ="ack"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-This work was partially supported by a grant from "Plan nacional de I+D", BIO98-0443-C02-01,
-and from the "Ministerio de Educacion y Ciencia" (Spain).
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Bibliography:</font>
-<a name ="biblio"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li>
-R.Guigo, S.Knudsen, N.Drake and T.F.Smith. Prediction of gene structure. <i>Journal of molecular
-biology</i>, 226:141-157, 1992.
-<li>
-S.Knudsen, R.Guigo and T.F.Smith. GeneID -- a computer server for prediction of genes in DNA 
-sequences. In H.A.Lim, J.W.Fickett, C.R.Cantor and R.J.Robins, editors, <i>Proceedings on the
-Second International Conference on Bioinformatics, Supercomputing and Complex Genome Analysis</i>,
-pages 545-553. World Scientific, 1993.
-<li>
-R.Guigo. Assembling genes from predicted exons in linear time with dynamic programming. <i>Journal
-of computational biology</i>, 5:681-702, 1998.
-<li>
-G.Parra, E.Blanco and R.Guigo. Geneid in Drosphila. <i>Genome Research</i> 10:511-515, 2000.
-<li>
-E. Blanco, G. Parra and R. Guigó.<i>Using geneid to Identify Genes.</i> In A. D. Baxevanis and D. B. Davison, chief editors: Current Protocols in Bioinformatics. Volume 1, Unit 4.3. John Wiley & Sons Inc., New York, 2002. 
-ISBN: 0-471-25093-7, 2003. 
-</ol>
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter2/index.html
+++ b/docs/chapter2/index.html
@@ -1,203 +1,105 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>2. Signals, exons and genes &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a class="current" href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 2</p>
+  <h1>Signals, exons and genes</h1>
+  <p class="lead">geneid predicts genes hierarchically: signals first, then exons,
+  then the optimal chain of exons.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>2. Signals, exons and genes</td>
-</table>
+  <p>The engine has three stages. First, <strong>signals</strong> (splice sites
+  and start/stop codons) are found and scored along the sequence with position
+  weight arrays. Second, <strong>exons</strong> are built between compatible
+  signals and scored by those sites plus a Markov coding-potential model. Third,
+  the best <strong>gene structure</strong> is assembled from the exons by dynamic
+  programming, maximising the summed exon score subject to a gene model.</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#context">General context</a>
-<li> <a href="#signals">Signals</a>
-<li> <a href="#frames">Frame and remainder</a>
-<li> <a href="#exons">Exons</a>
-<li> <a href="#genes">Genes</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <h2>Signals</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Signal</th><th>Core</th><th>Where</th></tr>
+    <tr><td>Acceptor splice site</td><td>intron ends in <code>AG</code></td><td>intron&rarr;exon boundary</td></tr>
+    <tr><td>Donor splice site</td><td>intron begins <code>GT</code></td><td>exon&rarr;intron boundary</td></tr>
+    <tr><td>Start codon</td><td><code>ATG</code></td><td>start of translation</td></tr>
+    <tr><td>Stop codon</td><td><code>TAA</code>, <code>TAG</code>, <code>TGA</code></td><td>end of translation</td></tr>
+  </table></div>
+  <p>Acceptors can be refined with optional <strong>branch-point</strong> and
+  <strong>poly-pyrimidine-tract</strong> profiles. With <code>-U</code> and the
+  right profiles, geneid also models <strong>U12</strong> (minor-spliceosome)
+  introns &mdash; both <code>GT&ndash;AG</code> and <code>AT&ndash;AC</code>
+  subtypes &mdash; and can type each predicted intron as U2 or U12. All signal
+  profiles live in the parameter file (<a href="../chapter8/index.html">chapter&nbsp;8</a>).</p>
+
+  <h2>Frame and remainder</h2>
+  <p>geneid exons are open reading frames delimited by signals. Two values place
+  each exon in its reading frame:</p>
+  <dl>
+    <dt>Frame</dt>
+    <dd>the number of nucleotides (0, 1, 2) from the exon's first base to the
+    first base of its first <em>complete</em> codon.</dd>
+    <dt>Remainder</dt>
+    <dd>the number of nucleotides (0, 1, 2) left after the last complete codon.
+    It is fixed by the exon's length and frame.</dd>
+  </dl>
+  <div class="callout">
+    <span class="label">Note</span>
+    <code>X</code> denotes an unknown codon in translation &mdash; e.g. when a
+    masked base (<code>N</code>) falls inside the codon.
+  </div>
+
+  <h2>Exons</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Exon type</th><th>Delimited by</th><th>Frame</th><th>Remainder</th></tr>
+    <tr><td>First</td><td>Start &hellip; Donor</td><td>0</td><td>0, 1, 2</td></tr>
+    <tr><td>Internal</td><td>Acceptor &hellip; Donor</td><td>0, 1, 2</td><td>0, 1, 2</td></tr>
+    <tr><td>Terminal</td><td>Acceptor &hellip; Stop</td><td>0, 1, 2</td><td>0</td></tr>
+    <tr><td>Single</td><td>Start &hellip; Stop</td><td>0</td><td>0</td></tr>
+  </table></div>
+  <p>Each exon's score combines its site scores, the coding-potential
+  log-likelihood ratio, and any external evidence, weighted by per-exon-type
+  factors in the parameter file. When RNA&#8209;seq is supplied with
+  <code>-u</code>, geneid additionally builds <strong>UTR exons</strong> to place
+  untranslated 5&prime;/3&prime; ends (<a href="../chapter7/index.html">chapter&nbsp;7</a>).</p>
+
+  <h2>Genes</h2>
+  <p>A gene structure is a series of frame-compatible exons chained under the
+  gene model. Two exons are <strong>frame compatible</strong> when</p>
+  <pre><code>(frame(second) + remainder(first)) mod 3 == 0</code></pre>
+  <p>Exons are connected as long as frame compatibility holds and the gene
+  model's succession and distance rules allow it. geneid finds the single
+  highest-scoring assembly in linear time by dynamic programming; the gene model
+  that governs which chains are legal is described in
+  <a href="../chapter8/index.html">chapter&nbsp;8</a>.</p>
+
+  <div class="pagenav">
+    <a href="../chapter1/index.html"><span class="dir">&larr; Prev</span><span>What is geneid?</span></a>
+    <a class="next" href="../chapter3/index.html"><span class="dir">Next &rarr;</span><span>Installing geneid</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>General context:</font>
-<a name ="context"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> is a program to predict genes in anonymous genomic sequences
-designed with a hierarchical structure. First of all, splice sites and
-start/stop codons are predicted and scored along the DNA sequence by using
-Position Weight Arrays (PWA). Secondly, exons are built from the set of
-predicted signals before. Exons are scored as the sum of the scores
-of the defining sites, plus the log-likelihood ratio of a Markov model
-to distinguish between coding and non-coding DNA. Finally, from the
-set of predicted exons, the best gene structure is assembled maximizing the
-sum of the scores of the assembled exons.
-</font>
 </div>
-</td>
-</table>
-
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Signals:</font>
-<a name ="signals"></td>
-<tr>
-<td>
-<font face="arial black" size=2>
-<tt>geneid</tt> is able to detect the following signals:
-<ul>
-<li> <b>Acceptor splice sites</b>:
-<i>Last intron dinucleotide mandatory <tt>AG</tt></i>.<br>
-Acceptors occur at the limits between intron/exon.
-<br>
-The following signals associated to the acceptors are also detected (optional):
-<ol>
-<li> Branch point
-<li> Poly Pyrimidine Tract
-</ol>
-<li> <b>Donor splice sites</b>:
-<i>First intron dinucleotide mandatory <tt>GT</tt></i>.<br>
-Donors occur at the limits between exon/intron.
-<li> <b>Start codons (translation)</b>:
-<i>First exon first trinucleotide mandatory <tt>ATG</tt></i>.<br>
-Initiation of transcription from mRNA into protein.
-<li> <b>Stop codons (translation)</b>:
-<i>Three possible codons <tt>TAA, TAG and TGA</tt></i>.<br>
-End of transcription from mRNA into protein.
-</ul>
-</font>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Frame and remainder:</font>
-<a name ="frames"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> exons are Open Reading Frames delimitited by signals. Frame
-and remainder are 2 values assigned to exons which have to be understood in
-the following way:
-<br><p>
-<b>FRAME:</b>
-The number of nucleotides (0,1,2) from the first nucleotide in the exon sequence
-to the the first nucleotide in the first COMPLETE codon translated from the
-genomic sequence.
-
-<br><p>
-
-<b>REMAINDER:</b>
-The number of nucleotides left (0,1,2) after the last COMPLETE codon has
-been defined from the exon sequence, given its frame. Therefore, exon
-remainder is completely determined by the length of the exon and its frame.
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Exons:</font>
-<a name ="exons"></td>
-<tr>
-<td>
-<font face="arial black" size=2>
-<tt>geneid</tt> is able to build the following type of exons:
-<ul>
-<li> <b>First exons</b>:
-<i>Delimited by Start and Donor</i>.<br>
-Frame = 0 - Remainder = 0,1,2
-<li> <b>Internal exons</b>:
-<i>Delimited by Acceptor and Donor</i>.<br>
-Frame = 0,1,2 - Remainder = 0,1,2
-<li> <b>Terminal exons</b>:
-<i>Delimited by Acceptor and Stop</i>.<br>
-Frame = 0,1,2 - Remainder = 0
-<li> <b>Single genes</b>:
-<i>Delimited by Start and Stop</i>.<br>
-Frame = 0 - Remainder = 0
-</ul>
-<font color="red">NOTE: The character 'X' denotes unknown codons in the 
-translation process<br>(such those cases in which there are masked 
-nucleotides, "N", within the codon sequence).</font>
-</font>
-</td>
-</table>
-
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Genes:</font>
-<a name ="genes"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Gene structures are series of frame compatible exons that are assembled
-following some fixed rules and restrictions specified in a Gene Model.
-Two exons are frame compatible if the frame of the second exon plus
-the remainder of the first one MODULUS 3 is 0. Predicted exons are connected
-as long as frame compatibility rule and gene model restrictions are
-respected properly.
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter3/index.html
+++ b/docs/chapter3/index.html
@@ -1,163 +1,101 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>3. Installing geneid &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a class="current" href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 3</p>
+  <h1>Installing geneid</h1>
+  <p class="lead">geneid builds from source with a single <code>make</code>. A
+  plain build needs only a C compiler and zlib.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>3. How to install <tt>geneid</tt>
-</td>
-</table>
+  <h2>Get the source</h2>
+  <pre><code><span class="cmd">$</span> git clone https://github.com/guigolab/geneid.git
+<span class="cmd">$</span> cd geneid</code></pre>
+  <p>Or download a release tarball from the
+  <a href="https://github.com/guigolab/geneid/releases">releases page</a> and
+  unpack it.</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#extract">Extracting the distribution</a>
-<li> <a href="#list"><tt>geneid</tt> file listing</a>
-<li> <a href="#compilation">Compiling <tt>geneid</tt> code</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <h2>Build</h2>
+  <pre><code><span class="cmd">$</span> make</code></pre>
+  <p>This produces the executable at <code>bin/geneid</code>. Test it:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -h</code></pre>
+  <div class="callout tip">
+    <span class="label">Memory</span>
+    geneid's working arrays grow on demand, so there is nothing to size at build
+    time &mdash; just <code>make</code>. (The old <code>MEM=low|medium|high</code>
+    build profiles are gone.) Resident memory follows the input and stays modest,
+    a few&nbsp;GB even on a large, dense genome.
+  </div>
+
+  <h2>Dependencies</h2>
+  <h3>zlib &mdash; required</h3>
+  <p>Used by the indexed bigBed (<code>-R</code>) and bigWig (<code>-S</code>)
+  readers. It is preinstalled on virtually every system (package
+  <code>zlib1g-dev</code> / <code>zlib-devel</code>); the Makefile links it with
+  <code>-lz</code> automatically, so a plain <code>make</code> just works.</p>
+
+  <h3>htslib &mdash; optional (for BAM input)</h3>
+  <p>Reading indexed <strong>BAM</strong> evidence directly
+  (<code>-R</code>/<code>-S</code>/<code>-Y</code> with a <code>.bam</code>)
+  needs <a href="https://github.com/samtools/htslib">htslib</a>. Enable it:</p>
+  <pre><code><span class="cmd">$</span> make WITH_HTSLIB=1</code></pre>
+  <p>If htslib is not under <code>/usr/local</code>, point the build at its
+  prefix:</p>
+  <pre><code><span class="cmd">$</span> make WITH_HTSLIB=1 HTSLIB_PREFIX=/opt/homebrew        <span style="color:var(--muted)"># macOS / Homebrew</span>
+<span class="cmd">$</span> make WITH_HTSLIB=1 HTSLIB_PREFIX=/path/to/htslib</code></pre>
+  <p>The build bakes <code>HTSLIB_PREFIX/lib</code> into the binary's runtime
+  search path (<code>-Wl,-rpath</code>), so the resulting geneid finds
+  <code>libhts</code> on its own &mdash; no <code>module load</code> or
+  <code>LD_LIBRARY_PATH</code> at run time. Install htslib with
+  <code>brew install htslib</code>, <code>apt-get install libhts-dev</code>, a
+  cluster module, or from source.</p>
+  <div class="callout">
+    <span class="label">Note</span>
+    The default build (plain <code>make</code>) never references htslib; BAM input
+    simply is not available in that binary. bigWig / bigBed / GFF evidence still
+    work without it.
+  </div>
+
+  <h2>What's in the distribution</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Path</th><th>Contents</th></tr>
+    <tr><td><code>src/</code>, <code>include/</code></td><td>C source and the <code>geneid.h</code> header.</td></tr>
+    <tr><td><code>bin/</code>, <code>objects/</code></td><td>the built binary and object files.</td></tr>
+    <tr><td><code>param/</code></td><td>parameter files for several species (see <a href="../chapter8/index.html">chapter&nbsp;8</a>).</td></tr>
+    <tr><td><code>samples/</code></td><td>example FASTA sequences.</td></tr>
+    <tr><td><code>docs/</code></td><td>this manual.</td></tr>
+    <tr><td><code>Makefile</code>, <code>README</code></td><td>build rules and quick-start notes.</td></tr>
+  </table></div>
+
+  <div class="pagenav">
+    <a href="../chapter2/index.html"><span class="dir">&larr; Prev</span><span>Signals, exons and genes</span></a>
+    <a class="next" href="../chapter4/index.html"><span class="dir">Next &rarr;</span><span>Running geneid</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Extracting the distribution:</font>
-<a name ="extract"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> distribution contains several directories and files. Source
-code and documentation files are included in the distribution, as well as
-parameters file and other extra information.
-<br><p>
-The distribution os archived and compressed in a single file using the
-Linux command <tt><font color="red">tar -zcvf</font></tt>. The compressed
-filename is <tt>geneid.tar.gz</tt>. <tt>geneid</tt> files can be
-extracted following these instructions:
-<ol>
-<li>Type <tt><font color="red">gzip -d geneid.tar.gz</font></tt>
-<li>Type <tt><font color="red">tar -xvf geneid.tar</font></tt>
-</ol>
-Under Linux, try:
-<ol>
-<li>Type <tt><font color="red">tar -zxvf geneid.tar.gz</font></tt>
-</ol>
-After executing those commands, the directory <tt>geneid</tt> will have been
-created in your current working directory.
-</font>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3><tt>geneid</tt> file listing:</font>
-<a name ="list"></td>
-<tr>
-<td>
-<font face="arial black" size=2>
-<tt>geneid</tt> distribution contains the following things:
-<ul>
-<li> <b><tt>bin/</tt></b><br>
-binaries will be stored over there.
-<li> <b><tt>docs/</tt></b><br>
-HTML documentation. Open the <tt>index.html</tt> page.
-<li> <b><tt>include/</tt></b><br>
-<tt>geneid</tt> header file called <tt>geneid.h</tt>.
-<li> <b><tt>objects/</tt></b><br>
-object files will be stored over there.
-<li> <b><tt>params/</tt></b><br>
-Different parameters files are provided. Select the proper one according to
-the organism to which the input sequence belongs.
-<li> <b><tt>samples/</tt></b><br>
-Some FASTA sequences as examples 
-(E. Blanco, G. Parra and R. Guigó. <i>Using geneid to Identify Genes.</i>
-In A. D. Baxevanis and D. B. Davison, chief editors: Current Protocols in 
-Bioinformatics. Volume 1, Unit 4.3. John Wiley & Sons Inc., New York, 
-2002. ISBN: 0-471-25093-7.)
-<li> <b><tt>src/</tt></b><br>
-<tt>geneid</tt> source code.
-<li> <b><tt>GNULicense</tt></b><br>
-This software has been registered under this license. Copy of the license.
-<li> <b><tt>Makefile</tt></b><br>
-Makefile to build <tt>geneid</tt> binary.
-<li> <b><tt>README</tt></b><br>
-This file contains information about how to install and run the program,
-and other more recent information.
-</ul>
-</font>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Compiling <tt>geneid</tt> code:</font>
-<a name ="compilation"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Enter the <tt>geneid</tt> directory and then, to build the binary file
-use the make tool:
-<ol>
-<li>Type <tt><font color="red">cd geneid</font></tt>
-<li>Type <tt><font color="red">make</font></tt>
-</ol>
-
-The binary <tt>geneid</tt> will have been created into the <tt>bin</tt>
-directory. Type <tt><font color="red">bin/geneid -h</font></tt> to test
-the file has been properly built.
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter4/index.html
+++ b/docs/chapter4/index.html
@@ -1,380 +1,149 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>4. Running geneid &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a class="current" href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 4</p>
+  <h1>Running geneid</h1>
+  <p class="lead">Input format, the basic command, the full command-line
+  reference, and the output formats.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>4. Running <tt>geneid</tt>
-</td>
-</table>
+  <h2>Input sequence (FASTA)</h2>
+  <p>geneid reads one or more DNA sequences in FASTA format from a file named on
+  the command line. A record is a header line beginning with <code>&gt;</code>
+  followed by the sequence; line width is free.</p>
+  <pre><code>&gt;chr21
+CCTATCAGCTAGCATCGATCGCATCGATTGCACAGCTAGCTAGCTACGTACG
+TCGTACGATCGATCGTAGCATCACGATCAGCATCTAGCACATCACACAGCAT
+...</code></pre>
+  <p>A file may hold several records (multi-FASTA); each is predicted
+  independently. External evidence for a multi-FASTA run must name the matching
+  sequence in column&nbsp;1 and be sorted by start position within each.</p>
+  <div class="callout warn">
+    <span class="label">Soft-masking is ignored</span>
+    geneid treats lower-case bases as ordinary sequence; only <code>N</code> is
+    masked. To exclude repeats, <strong>hard-mask them to <code>N</code></strong>
+    in the FASTA rather than relying on lower-case soft-masking.
+  </div>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#fasta">FASTA format</a>
-<li> <a href="#main">General considerations</a>
-<li> <a href="#menu"><tt>geneid</tt> command line options</a>
-<li> <a href="#output"><tt>geneid</tt> output formats</a>
-<li> <a href="#samples">Samples</a>
-<li> <a href="#multi">Multi-fasta files</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <h2>Basic usage</h2>
+  <p>geneid needs the sequence and a species <em>parameter file</em> (see
+  <a href="../chapter8/index.html">chapter&nbsp;8</a>). Predictions go to standard
+  output:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -P param/human3iso.param samples/example1.fa</code></pre>
+  <p>The parameter file can be given three ways: with <code>-P&nbsp;&lt;file&gt;</code>;
+  through the <code>GENEID</code> environment variable holding its path; or, if
+  neither is set, from a file named <code>param.default</code> beside the binary.
+  Parameter files are broadly reusable within a phylogenetic group (the human file
+  works across vertebrates).</p>
+
+  <h2>Command-line reference</h2>
+  <p>Run <code>geneid -h</code> for the terse list. The options below are grouped
+  by purpose; flags marked <span class="flag">htslib</span> require a build with
+  BAM support (<a href="../chapter3/index.html">chapter&nbsp;3</a>).</p>
+
+  <h3>General</h3>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Meaning</th></tr>
+    <tr><td><code>-P &lt;file&gt;</code></td><td>Parameter file (else <code>GENEID</code> env var, else <code>param.default</code>).</td></tr>
+    <tr><td><code>-p &lt;prefix&gt;</code></td><td>Prefix added to predicted gene / protein / CDS names.</td></tr>
+    <tr><td><code>-j &lt;coord&gt;</code>, <code>-k &lt;coord&gt;</code></td><td>Restrict prediction to the window [begin, end] (1-based).</td></tr>
+    <tr><td><code>-v</code></td><td>Verbose: progress and diagnostic messages on stderr.</td></tr>
+    <tr><td><code>-B</code></td><td>Report the memory required for the given sequence, then exit.</td></tr>
+    <tr><td><code>-h</code></td><td>Show the option list and exit.</td></tr>
+  </table></div>
+
+  <h3>Prediction engine</h3>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Meaning</th></tr>
+    <tr><td><em>(default)</em></td><td>Predict on both strands and assemble genes.</td></tr>
+    <tr><td><code>-W</code> / <code>-C</code></td><td>Predict only the forward (Watson) / reverse (Crick) strand.</td></tr>
+    <tr><td><code>-o</code></td><td>Signal and exon prediction only &mdash; do not assemble genes.</td></tr>
+    <tr><td><code>-O &lt;file&gt;</code></td><td>Assemble genes <em>only</em>, from exons supplied in a file (<a href="../chapter5/index.html">chapter&nbsp;5</a>).</td></tr>
+    <tr><td><code>-F</code></td><td>Force the prediction of one complete gene structure.</td></tr>
+    <tr><td><code>-Z</code></td><td>Switch on open-reading-frame searching.</td></tr>
+    <tr><td><code>-U</code></td><td>Allow U12 (minor-spliceosome) introns (needs U12 profiles in the parameter file).</td></tr>
+    <tr><td><code>-r</code></td><td>Use recursive splicing.</td></tr>
+    <tr><td><code>-E &lt;n&gt;</code></td><td>Add <code>n</code> to the exon-weight parameter (raise/lower how readily exons are kept).</td></tr>
+  </table></div>
+
+  <h3>External evidence</h3>
+  <p>Summarised here; see chapters <a href="../chapter5/index.html">5</a>&ndash;<a href="../chapter7/index.html">7</a> for detail.</p>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Meaning</th></tr>
+    <tr><td><code>-R &lt;file&gt;</code></td><td>Annotations that guide/force predictions: GFF, bigBed, or <span class="flag">htslib</span> a BAM whose spliced-read junctions become intron evidence.</td></tr>
+    <tr><td><code>-S &lt;file&gt;</code></td><td>Signal that scores exons: protein-HSP GFF, bigWig coverage (<code>plus.bw,minus.bw</code> or <code>cov.bw</code>), or <span class="flag">htslib</span> a BAM (<code>reads.bam</code>).</td></tr>
+    <tr><td><code>-Y &lt;bam[,bam,&hellip;]&gt;</code></td><td><span class="flag">htslib</span> One or more indexed BAMs used as <em>both</em> <code>-R</code> junctions and <code>-S</code> coverage.</td></tr>
+    <tr><td><code>-y &lt;rf|fr|none&gt;</code></td><td>Library strandedness for BAM coverage (<code>rf</code> = dUTP/reverse; default <code>none</code>).</td></tr>
+    <tr><td><code>-u</code></td><td>Predict UTRs (uses the <code>-S</code>/<code>-Y</code> coverage to place UTR ends).</td></tr>
+    <tr><td><code>-L &lt;k&gt;</code> / <code>-Q &lt;w&gt;</code></td><td>Enable expression log-likelihood-ratio scoring and set its weight (<a href="../chapter7/index.html">chapter&nbsp;7</a>).</td></tr>
+    <tr><td><code>-K &lt;n&gt;</code> / <code>-I &lt;n&gt;</code></td><td>Multi-library agreement, and junction read-support floor (<a href="../chapter7/index.html">chapter&nbsp;7</a>).</td></tr>
+    <tr><td><code>-N &lt;M&gt;</code></td><td>Millions of reads mapped, for the rpkm report (auto-estimated from a BAM).</td></tr>
+    <tr><td><code>-V &lt;n&gt;</code></td><td>Add <code>n</code> to the score of evidence exons.</td></tr>
+    <tr><td><code>-J</code></td><td>Annotation-scoring mode: score and U2/U12-type the splice sites of forced exons (report only).</td></tr>
+  </table></div>
+
+  <h3>Choosing what to output</h3>
+  <p>By default geneid prints assembled genes. These flags add or restrict the
+  reported elements and sequences.</p>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Outputs</th></tr>
+    <tr><td><code>-b</code> <code>-d</code> <code>-a</code> <code>-e</code></td><td>Best start codons / donor sites / acceptor sites / stop codons.</td></tr>
+    <tr><td><code>-f</code> <code>-i</code> <code>-t</code> <code>-s</code></td><td>Best first / internal / terminal exons, and single-gene exons.</td></tr>
+    <tr><td><code>-x</code> <code>-n</code> <code>-z</code></td><td>All predicted exons / introns / open reading frames.</td></tr>
+    <tr><td><code>-T</code> <code>-D</code> <code>-A</code></td><td>Genomic sequence of exons / of CDS / translated protein, for predicted genes.</td></tr>
+  </table></div>
+
+  <h2>Output formats</h2>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Format</th></tr>
+    <tr><td><em>(default)</em></td><td>geneid native tabular format.</td></tr>
+    <tr><td><code>-G</code></td><td>GFF2.</td></tr>
+    <tr><td><code>-3</code></td><td>GFF3 (recommended for downstream tools).</td></tr>
+    <tr><td><code>-X</code></td><td>Extended format (adds per-signal detail).</td></tr>
+    <tr><td><code>-M</code> / <code>-m</code></td><td>XML output / print its DTD.</td></tr>
+  </table></div>
+
+  <h2>Examples</h2>
+  <p>Ab&nbsp;initio prediction, GFF3, on the bundled example:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -3 -P param/human3iso.param samples/example1.fa</code></pre>
+  <p>Ab&nbsp;initio with translated proteins, on one strand and one window:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -3 -A -W -j 1 -k 200000 -P param/human3iso.param genome.fa</code></pre>
+  <p>RNA&#8209;seq-guided, from an indexed BAM, with UTRs and expression scoring
+  (<span class="flag">htslib</span> build; see
+  <a href="../chapter7/index.html">chapter&nbsp;7</a>):</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -3U -u -y rf -L 50 -Q 0.0007 -Y aligned.bam \
+             -P param/human.rnaseq.param genome.fa</code></pre>
+
+  <div class="pagenav">
+    <a href="../chapter3/index.html"><span class="dir">&larr; Prev</span><span>Installing geneid</span></a>
+    <a class="next" href="../chapter5/index.html"><span class="dir">Next &rarr;</span><span>Assembling exons (-O)</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>FASTA format:</font>
-<a name ="fasta"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> input sequences must be in FASTA format:
-<br><p>
-FASTA sequence files show this structure:
-<br><p>
-<center>
-<table border=2 cellpadding=10>
-<tr><td bgcolor="skyblue">
-<pre>
->NAME OR IDENTIFIER OF SEQUENCE
-ATCGTACAGCTAGCTAGCTACGTACG
-TCGTACGATCGATCGTAGCATCACGA
-GGTCAGCATCTAGCACATCACACAGC
-CTATCAGCTAGCATCGATCGCATCGA
-...
-</pre>
-</td>
-</table>
-</center>
-<br><p>
-Usually Fasta lines are 60 chars long but this is not mandatory.
-</font>
 </div>
-</td>
-</table>
-
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>General considerations:</font>
-<a name ="main"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-To run <tt>geneid</tt>,
-type <tt><font color="red">geneid [options] sequence_file</font></tt> where
-sequence_file is a FASTA formatted DNA sequence. Predictions are sent to
-the standard output. In addition, the program requires an organism specific
-parameters file (which can be broadly used within the phylogenetic group to which
-organism belongs. For instance, the human file may be used as well to
-predict genes in genomic sequences from vertebrates).The directory
-<tt>params</tt> contains several files for different organisms.
-<br><p>
-The parameters file may be speficied in three different ways:
-<ol>
-<li> By default, <tt>geneid</tt> will try to find a default file called
-<tt>param.default</tt> which must be in the same directory that the binary.
-<li> Through the enviromental var GENEID, defining the path.
-<li> Using the command line option <tt><font color="red">geneid -P file</font></tt>.
-</ol>
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3><tt>geneid</tt> command line options:</font>
-<a name ="menu">
-</td>
-<tr>
-<td align=center>
-<table border=0 width=600 cellpadding=10>
-<tr>
-<td></td>
-<tr>
-<td bgcolor="lightblue">
-<table border=0 width=600>
-<tr>
-<td width=700 align=right colspan=2><font face="arial" size=4>Selection of genomic
-elements to display</td>
-<tr>
-<td width=50 bgcolor="yellow"><font face="arial" size=4>Flag</td>
-<td width=650 bgcolor="yellow"><font face="arial" size=4>Action</td>
-<tr>
-<td width=50><font face="arial" size=3>b</td>
-<td width=650><font face="arial" size=3>Display best Start codons
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>d</td>
-<td width=650><font face="arial" size=3>Display best Donor sites
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>a</td>
-<td width=650><font face="arial" size=3>Display best Acceptor sites
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>e</td>
-<td width=650><font face="arial" size=3>Display best Stop codons
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>f</td>
-<td width=650><font face="arial" size=3>Display best First exons
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>i</td>
-<td width=650><font face="arial" size=3>Display best Internal exons
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>t</td>
-<td width=650><font face="arial" size=3>Display best Terminal exons
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>s</td>
-<td width=650><font face="arial" size=3>Display best Single genes
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>x</td>
-<td width=650><font face="arial" size=3>Display best exons (all)
-found on sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>z</td>
-<td width=650><font face="arial" size=3>Display Open Reading Frames
-found on sequence [see -Z]</td>
-<tr>
-<td width=50><font face="arial" size=3>D</td>
-<td width=650><font face="arial" size=3>Display genomic sequence in
-predicted genes</td>
-<tr>
-<td><br><p></td>
-<tr>
-<td width=700 align=right colspan=2><font face="arial" size=4>Selection of
-output format</td>
-<tr>
-<td width=50 bgcolor="yellow"><font face="arial" size=4>Flag</td>
-<td width=650 bgcolor="yellow"><font face="arial" size=4>Action</td>
-<tr>
-<td width=50><font face="arial" size=3>-</td>
-<td width=650><font face="arial" size=3>geneid format</td>
-<tr>
-<td width=50><font face="arial" size=3>G</td>
-<td width=650><font face="arial" size=3>gff format</td>
-<tr>
-<td width=50><font face="arial" size=3>X</td>
-<td width=650><font face="arial" size=3>Extended format (gff or geneid)</td>
-<tr>
-<td width=50><font face="arial" size=3>M</td>
-<td width=650><font face="arial" size=3>XML output (see -m)</td>
-<tr>
-<td width=50><font face="arial" size=3>m</td>
-<td width=650><font face="arial" size=3>See DTD for XML output</td>
-<tr>
-<td><br><p></td>
-<tr>
-<td width=700 align=right colspan=2><font face="arial" size=4>
-Control prediction engine</td>
-<tr>
-<td width=50 bgcolor="yellow"><font face="arial" size=4>Flag</td>
-<td width=650 bgcolor="yellow"><font face="arial" size=4>Action</td>
-<tr>
-<td width=50><font face="arial" size=3>-</td>
-<td width=650><font face="arial" size=3>Predictions in both strands
-of sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>W</td>
-<td width=650><font face="arial" size=3>Predictions only in forward strand
-of sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>C</td>
-<td width=650><font face="arial" size=3>Predictions only in reverse strand
-of sequence</td>
-<tr>
-<td width=50><font face="arial" size=3>o</td>
-<td width=650><font face="arial" size=3>Only signal and exon prediction (gene
-assembling disabled)</td>
-<tr>
-<td width=50><font face="arial" size=3>F</td>
-<td width=650><font face="arial" size=3>Force prediction of a complete gene</td>
-<tr>
-<td width=50><font face="arial" size=3>O</td>
-<td width=650><font face="arial" size=3>Only gene assembling (exons provided
-from file)</td>
-<tr>
-<td width=50><font face="arial" size=3>Z</td>
-<td width=650><font face="arial" size=3>Switch ORF searching on</td>
-<tr>
-<td><br><p></td>
-<tr>
-<td width=700 align=right colspan=2><font face="arial" size=4>
-Re-annotation of sequences
-</td>
-<tr>
-<td width=50 bgcolor="yellow"><font face="arial" size=4>Flag</td>
-<td width=650 bgcolor="yellow"><font face="arial" size=4>Action</td>
-<tr>
-<td width=50><font face="arial" size=3>R</td>
-<td width=650><font face="arial" size=3>Include annotations (evidences) provided
-from file</td>
-<tr>
-<td width=50><font face="arial" size=3>S</td>
-<td width=650><font face="arial" size=3>Use homology to protein information
- (SR) provided from file</td>
-<tr>
-<td><br><p></td>
-<tr>
-<td width=700 align=right colspan=2><font face="arial" size=4>
-Statistical model
-</td>
-<tr>
-<td width=50 bgcolor="yellow"><font face="arial" size=4>Flag</td>
-<td width=650 bgcolor="yellow"><font face="arial" size=4>Action</td>
-<tr>
-<td width=50><font face="arial" size=3>P</td>
-<td width=650><font face="arial" size=3>Provide a new parameter file</td>
-<tr>
-<td width=50><font face="arial" size=3>E</td>
-<td width=650><font face="arial" size=3>Increase/decrease exon weight
-value</td>
-<tr>
-<td><br><p></td>
-<tr>
-<td width=700 align=right colspan=2><font face="arial" size=4>
-Miscellanea
-</td>
-<tr>
-<td width=50 bgcolor="yellow"><font face="arial" size=4>Flag</td>
-<td width=650 bgcolor="yellow"><font face="arial" size=4>Action</td>
-<tr>
-<td width=50><font face="arial" size=3>v</td>
-<td width=650><font face="arial" size=3>Display information during geneid
-running</td>
-<tr>
-<td width=50><font face="arial" size=3>B</td>
-<td width=650><font face="arial" size=3>Show memory requirements</td>
-<tr>
-<td width=50><font face="arial" size=3>h</td>
-<td width=650><font face="arial" size=3>Show list of available options</td>
-</table>
-</table>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3><tt>geneid</tt> output formats:</font>
-<a name ="output"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Click over every available format to see a detailed description:
-<ul>
-<li><a href="./formats_html/geneid.html">geneid format</a> (default)
-<li><a href="./formats_html/gff.html">gff format</a>
-<li><a href="./formats_html/xml.html">xml format</a>
-<li><a href="./formats_html/extended.html">extended format (geneid and gff formats)</a>
-</ul>
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Samples:</font>
-<a name ="samples"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Click over every example to see the corresponding output:
-<ul>
-<li> <a href="./samples_html/acceptors.html">Prediction of acceptor splice sites</a>
-<li> <a href="./samples_html/exons.html">Prediction of exons</a>
-<li> <a href="./samples_html/genes.html">Gene prediction</a>
-<li> <a href="./samples_html/evidences.html">External information 1: annotations</a>
-<li> <a href="./samples_html/sr.html">External information 2: sequence homology</a>
-</ul>
-<font color="red">This the sequence used to generate these outputs: <a href="./sequence/test.fa">test.fa</a></font>
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Multi-fasta files:</font>
-<a name ="multi"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> can process files containing more than one FASTA sequence. 
-Moreover, external information as annotations and HSPs can be provided for 
-every sequence. <b>Requirement</b>: records belonging to the same Locus must be sorted 
-by first position.<br><p>
-
-Click over every example to see the corresponding output:
-<ul>
-<li> <a href="./sequence/5seqs.fa">Multi-fasta file</a>
-<li> <a href="./sequence/tmp.evi">Multi-fasta annotations</a>
-<li> <a href="./sequence/tmp.hsp">Multi-fasta homology information</a>
-</ul>
-</font>
-</div>
-</td>
-</table>
-
-
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter5/index.html
+++ b/docs/chapter5/index.html
@@ -1,124 +1,83 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>5. Assembling exons (-O) &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a class="current" href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 5</p>
+  <h1>Assembling exons into gene structures</h1>
+  <p class="lead">With <code>-O</code>, geneid skips ab&nbsp;initio prediction and
+  assembles a gene structure from exons you supply.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>5. Assembling predicted exons into gene structures</font>
-</td>
-</table>
+  <p>geneid's assembly stage is useful on its own: given a set of scored, predicted
+  exons from any source, it finds the gene structure that maximises the summed
+  exon score under the gene model. Supply the exons in a GFF file and select this
+  mode with <code>-O&nbsp;&lt;file&gt;</code>:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -O exons.gff -P param/human3iso.param genome.fa</code></pre>
+  <p>The file must be <strong>sorted by start coordinate</strong> (GFF column 4).
+  The scores you provide are what gets maximised, so they should be a meaningful,
+  comparable scale &mdash; assembling arbitrary or inconsistent scores is not
+  meaningful.</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#exons">Assembling exons</a>
-<li> <a href="#others">Working with promoters, polyA tails, CpG islands,...</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <div class="callout">
+    <span class="label">-O vs -R</span>
+    <code>-O</code> assembles <em>only</em> the supplied elements (no
+    ab&nbsp;initio prediction). <code>-R</code>
+    (<a href="../chapter6/index.html">chapter&nbsp;6</a>) instead <em>adds</em>
+    external evidence to geneid's own predictions.
+  </div>
+
+  <h2>Beyond exons: promoters, poly-A, CpG islands</h2>
+  <p>The input may contain predicted elements of any type, not just coding exons
+  &mdash; promoters, repeats, poly-A sites, and so on. Element types are matched
+  by the feature name in GFF column 3, and the same names are used in the gene
+  model to say how they may be chained and at what distances
+  (<a href="../chapter8/index.html">chapter&nbsp;8</a>). Elements whose type
+  appears in no gene-model rule are ignored.</p>
+
+  <div class="callout">
+    <span class="label">Frame for non-coding elements</span>
+    Assigning a reading frame to an intergenic element (a promoter, a CpG island)
+    is meaningless. Give such records a frame of <code>.</code> in GFF column 8:
+    geneid expands each into three (one per frame) and computes remainder
+    consistently, so the frame/remainder machinery is bypassed for them.
+  </div>
+
+  <h2>Scoring or typing a provided structure (-J)</h2>
+  <p>Add <code>-J</code> to run in annotation-scoring mode: geneid scores the
+  splice sites of the forced exons under the parameter's profiles and classifies
+  each intron as U2 or U12, without changing the assembly. It is a report-only
+  companion to <code>-O</code>:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -J -3nU -O annotation.gff -P param/human3isoU12.param genome.fa</code></pre>
+
+  <div class="pagenav">
+    <a href="../chapter4/index.html"><span class="dir">&larr; Prev</span><span>Running geneid</span></a>
+    <a class="next" href="../chapter6/index.html"><span class="dir">Next &rarr;</span><span>External annotations (-R)</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Assembling exons:</font>
-<a name ="exons"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> can be used to chain predicted exons, obtained through
-sources other than <tt>geneid</tt>, into coherent structures. The score
-associated to the input predicted exons will be used to predict the gene
-structure that maximizes the sum of scores of assembled exons. There is no
-point in using <tt>geneid</tt> in this context when the sum of these scores
-is not a meaningful score.
-<br><p>
-The set of predicted exons must be given in an additional file formatted in
-<tt>gff</tt> style. <tt>geneid</tt> is instructed to read this file with
-the command line option <tt>-O filename</tt>. This file must be sorted
-by the starting position of the exons (column 4 in <tt>gff</tt> format).
-</font>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Working with promoters, polyA tails, CpG islands,...:</font>
-<a name ="others"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Actually, the input file may include predicted genic elements of any type, such
-as promoters, repeats, etc... and not only, exons. The gene model lists
-the rules according to which the predicted elements must be chained.
-Elements types are identified through the feature name in the
-<tt>gff</tt> file. Therefore, this name must be employed in the gene model
-to refer to the element. The rules specify essentially which elements might
-be chained together and within which distances,
-<br><p>
-<tt>geneid</tt> implementation of this problem is not completely satisfactory
-due to the frame/remainder requirement. The remainder is automatically computed
-from the frame and length of the element. But assigning a frame to intergenic
-elements such as <i>promoters, CpG islands</i>,... is pointless, so the frame
-column for these elements is recommended to be specified with a point: '.'.
-<tt>geneid</tt> internally will expand every record into three (one per frame),
-and frame/remainder problem will be skipped.
-<br><p>
-Another solution to avoid this <tt>geneid</tt> limitation would be
-introducing elements with length multiple of three and frame 0 to
-skip the frame/remainder problem. Both solutions are temporary and not
-satisfactory so this problem will be solved in next releases.
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter6/index.html
+++ b/docs/chapter6/index.html
@@ -1,185 +1,93 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>6. External annotations (-R) &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a class="current" href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 6</p>
+  <h1>External annotations (-R)</h1>
+  <p class="lead"><code>-R</code> folds external evidence into geneid's own
+  predictions &mdash; guiding them, or forcing specific elements into the result.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>6. Introducing external information: annotations</font>
-</td>
-</table>
+  <p>With <code>-R&nbsp;&lt;file&gt;</code>, the final gene structure is built from
+  <em>both</em> the external records and geneid's ab&nbsp;initio predictions.
+  (Contrast <code>-O</code>, which assembles only the supplied elements.)</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#description">Description</a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <h2>Input formats</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Format</th><th>Notes</th></tr>
+    <tr><td>GFF</td><td>text records; must be sorted by acceptor (start) position.</td></tr>
+    <tr><td>bigBed</td><td>the same records, indexed; queried per genomic fragment.</td></tr>
+    <tr><td>BAM <span class="flag">htslib</span></td><td>spliced-read (CIGAR&nbsp;<code>N</code>) junctions become <strong>intron</strong> evidence; sorted internally.</td></tr>
+  </table></div>
+  <p>bigBed and BAM are read with per-fragment range queries, so large evidence
+  sets stream rather than load whole. For BAM junctions, strand comes from the
+  read's <code>XS</code> tag, else the minimap2 <code>ts</code> tag, else the
+  <code>GT&ndash;AG</code>/<code>CT&ndash;AC</code> splice motif.</p>
+
+  <h2>Competing vs. forced elements</h2>
+  <p>Whether an element is a hint or a requirement depends on its score
+  (GFF column 6):</p>
+  <p><strong>Scored</strong> elements <em>compete</em> with ab&nbsp;initio
+  predictions to enter the final structure:</p>
+  <pre><code>chr21   lab_XX   Internal   66255   66323   3.27   +   1</code></pre>
+  <p>An element with a score of <code>.</code> is <strong>forced</strong> &mdash;
+  it must appear in the output (unless a conflicting forced element is also
+  given):</p>
+  <pre><code>chr21   lab_XX   Internal   66255   66323   .   +   1</code></pre>
+
+  <h2>Unknown frame</h2>
+  <p>Set the frame in GFF column 8, or use <code>.</code> when it is unknown.
+  geneid then expands the record into the three possible frames, computing each
+  remainder, and keeps frame/remainder consistency during assembly:</p>
+  <pre><code>chr21   lab_XX   Internal   66255   66323   3.27   +   .
+   &rarr; internally becomes the frame-0, frame-1 and frame-2 candidates</code></pre>
+
+  <h2>Preserving whole genes (the group field)</h2>
+  <p>Use the group field (GFF column 9) to tie the exons of one annotated gene
+  together so they are kept as a block, rather than mixed with ab&nbsp;initio
+  exons. Given this annotation, the gene is preserved intact:</p>
+  <pre><code>chr21   external   Terminal   21839   22922   18.37   -   1   gene_2
+chr21   external   Internal   23679   24029    7.99   -   1   gene_2
+chr21   external   First      30732   30775   -1.11   -   0   gene_2</code></pre>
+  <p>Without a shared group id, geneid may interleave its own predictions between
+  the supplied exons.</p>
+
+  <div class="callout tip">
+    <span class="label">One BAM for both roles</span>
+    A single indexed BAM can serve as both <code>-R</code> junctions and
+    <code>-S</code> coverage via <code>-Y</code> &mdash; see
+    <a href="../chapter7/index.html">chapter&nbsp;7</a>.
+  </div>
+
+  <div class="pagenav">
+    <a href="../chapter5/index.html"><span class="dir">&larr; Prev</span><span>Assembling exons (-O)</span></a>
+    <a class="next" href="../chapter7/index.html"><span class="dir">Next &rarr;</span><span>RNA-seq &amp; homology (-S / -Y)</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Description:</font>
-<a name ="description"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> allows to integrate ab initio predictions with external
-evidence (annotations), such as annotated genes. The external
-evidence is read from an additional file in <tt>gff</tt> format. <tt>geneid</tt>
-is instructed to read this file with the command line option <tt>-R filename</tt>.
-This input file must sorted by the starting position (column 4 in <tt>gff</tt>).
-<br><p>
-There is a difference between using options <tt>-O filename</tt> and
-<tt>-R filename</tt>. In the first case, only elements extracted from file
-will be assembled while, in the second one, gene predictions are built from
-both file records and from <tt>geneid</tt> predictions.
-<br><p>
-If the elements in the input file are assigned an score, then they will
-"compete" with <tt>geneid</tt> original predictions (if any) to be in the final gene
-structure. For instance, this record will fight against ab initio predictions:
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=700>
-<tr>
-<td align=center bgcolor="skyblue">
-<pre>
-AE002566   lab_XX  Internal    66255    66323    3.27  +  1
-</pre>
-</td>
-</table>
-</center>
-<br><p>
-If no score is given for the element (a dot "."), then this element is
-supposed to be mandatory (forced) in the final gene prediction (unless a conflicting
-element with no score is also given in the input file). For instance, this record
-will be in the final prediction.
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=700>
-<tr>
-<td align=center bgcolor="skyblue">
-<pre>
-AE002566   lab_XX  Internal    66255    66323    .  +  1
-</pre>
-</td>
-</table>
-</center>
-<br><p>
-The frame can be either set in the column 8 of <tt>gff</tt> format or
-skipped by using the wildcar "." when is unknown. In the last case,
-<tt>geneid</tt> generates 3 equivalent elements (one per possible frame),
-computing the corresponding remainder in each case, keeping the frame/remainder
-consistency anyway when assembling is done. For instance, this record is
-internally expanded to these 3 exons, being incorporated to the set of
-candidate exons to be part of final gene prediction:
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=700>
-<tr>
-<td align=center bgcolor="skyblue">
-<pre>
-AE002566   lab_XX  Internal    66255    66323    3.27  +  .
-<hr>
-AE002566   lab_XX  Internal    66255    66323    3.27  +  0
-AE002566   lab_XX  Internal    66255    66323    3.27  +  1
-AE002566   lab_XX  Internal    66255    66323    3.27  +  2
-</pre>
-</td>
-</table>
-</center>
-<br><p>
-By using the optional group field (column 9 in <tt>gff</tt> format), user
-is able to specificy whether one annotated gene (annotation) introduced
-in the input file has to be preserved if it is incorporated in the final results
-or <tt>geneid</tt> predictions can be mixed within that annotation.
-For instance, given this annotation (1), this gene will be preserved
-in the final output. But, given this other annotation (2) for the same gene
-but without setting a group identifier, we can obtain predictions such as
-the following (3):
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=700>
-<tr>
-<td align=left bgcolor="skyblue">
-<pre>
-(1)
-AE002566  external Terminal  21839    22922   18.37 -  1  gene_2
-AE002566  external Internal  23679    24029    7.99 -  1  gene_2
-AE002566  external First     30732    30775   -1.11 -  0  gene_2
-<hr>
-(2)
-AE002566  external Terminal  21839    22922   18.37 -  1  
-AE002566  external Internal  23679    24029    7.99 -  1  
-AE002566  external First     30732    30775   -1.11 -  0  
-<hr>
-(3)
-AE002566     external  Terminal  21839    22922   18.37 -  1  
-AE002566     external  Internal  23679    24029    7.99 -  1  
-<font color="red">AE002566  geneid_v1.2  Internal  28002    28007    1.14 -  1 </font>
-AE002566     external  First     30732    30775   -1.11 -  0
-</pre>
-</td>
-</table>
-</center>
-
-
-
-
-
-
-
-</font>
 </div>
-</td>
-</table>
-
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter7/index.html
+++ b/docs/chapter7/index.html
@@ -1,202 +1,138 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>7. RNA-seq &amp; homology (-S / -Y) &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a class="current" href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 7</p>
+  <h1>RNA-seq &amp; homology evidence</h1>
+  <p class="lead"><code>-S</code> feeds geneid a per-base signal that scores exons
+  &mdash; either protein-homology alignments or RNA&#8209;seq coverage.
+  <code>-Y</code> uses a BAM as both coverage and junctions.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>7. Using sequence homology information</font>
-</td>
-</table>
+  <p>The <code>-S</code> option supplies a signal that raises the score of exons
+  it overlaps. It accepts two kinds of evidence: <strong>protein homology</strong>
+  as HSP alignments, and <strong>RNA&#8209;seq coverage</strong> as bigWig or BAM.
+  The rest of this chapter covers each.</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#description">Description</a>
-<li> <a href="#srs">HSPs</a>
-<li> <a href="#frame">Frame definition in <tt>blast</tt> and <tt>geneid</tt></a>
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
+  <h2>Protein homology (HSPs)</h2>
+  <p>Given alignments between the input and well-annotated sequences, the
+  High-scoring Segment Pairs (HSPs) can raise the score of overlapping predicted
+  exons. Supply them as a GFF list with <code>-S</code>; order does not matter.
+  To combine several alignments, geneid projects the HSPs onto the sequence,
+  taking the highest score at each position. Positions with no homology get the
+  parameter file's <code>NO_SCORE</code> value
+  (<a href="../chapter8/index.html">chapter&nbsp;8</a>).</p>
+  <div class="callout">
+    <span class="label">Frame in BLAST vs geneid</span>
+    BLAST frames are <code>1,2,3</code> (from <code>start&nbsp;mod&nbsp;3</code>,
+    with 0&nbsp;&rarr;&nbsp;3); geneid frames are <code>0,1,2</code> (nucleotides
+    to the first complete codon). geneid converts between them internally as
+    <code>blastFrame = (start(exon) + geneidFrame) mod 3</code>. Give a frame of
+    <code>.</code> for DNA&ndash;DNA alignments, which have none.
+  </div>
+
+  <h2>RNA-seq coverage</h2>
+  <p>RNA&#8209;seq read depth scores exons by expression. Supply it as stranded
+  or unstranded bigWig, or &mdash; in an <span class="flag">htslib</span> build
+  &mdash; directly as an indexed BAM:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -3U -u -y rf -S plus.bw,minus.bw  -P param/human.rnaseq.param genome.fa
+<span class="cmd">$</span> bin/geneid -3U -u -y rf -S reads.bam         -P param/human.rnaseq.param genome.fa</code></pre>
+  <p>Coverage scores exons with or without <code>-u</code>; adding
+  <code>-u</code> also predicts <strong>UTRs</strong> from where coverage extends
+  beyond the coding exons. <code>-y</code> sets library strandedness
+  (<code>rf</code> = dUTP/reverse, the common Illumina protocol; <code>fr</code>;
+  or <code>none</code>). BAMs must be coordinate-sorted and indexed.</p>
+
+  <h3>Expression scoring (-L / -Q)</h3>
+  <p>By default the coverage term is additive and has no null model, so
+  background transcription is rewarded and the score grows with sequencing depth
+  &mdash; deep libraries over-predict. <code>-L</code> replaces it with a
+  two-state <strong>log-likelihood ratio</strong> against the sequence's own
+  background coverage: a base scores positive only where it is genuinely enriched
+  over that background, and only its <em>fold</em>-enrichment matters, so the
+  score does not drift with library size.</p>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Meaning</th></tr>
+    <tr><td><code>-L &lt;k&gt;</code></td><td>Enable expression LLR scoring. <code>k</code> is the enrichment of an expressed exon over the genome-wide mean coverage (tens, not units, because most of a genome is untranscribed). Off by default.</td></tr>
+    <tr><td><code>-Q &lt;w&gt;</code></td><td>Weight of the <code>-L</code> term against the coding/site scores (default <code>0.0007</code>). It transfers across library depths but depends on the parameter file's factors, so re-tune it if you change parameter files.</td></tr>
+  </table></div>
+  <div class="callout tip">
+    <span class="label">Recommended start</span>
+    For human RNA&#8209;seq: <code>-L 50 -Q 0.0007</code> together with
+    <code>-u</code>.
+  </div>
+
+  <h3>Multiple libraries (-Y a.bam,b.bam,&hellip; and -K)</h3>
+  <p><code>-Y</code> takes a comma-separated list of BAMs to combine several
+  libraries in one run &mdash; each also contributes its junctions. They are
+  <strong>not merged</strong>: each library keeps its own background estimate
+  (which reflects tissue biology, not just depth, and varies several-fold per
+  read across tissues), and their per-base scores are combined by an order
+  statistic. Junctions are unioned across libraries with read support summed.</p>
+  <div class="tablewrap"><table class="flags">
+    <tr><th>Flag</th><th>Meaning</th></tr>
+    <tr><td><code>-K &lt;n&gt;</code></td><td>How many libraries must support a base for it to count as expressed (default <code>2</code>; <code>1</code> = the plain maximum / union). Requiring two suppresses single-library noise, whose false positives would otherwise grow with the number of libraries. A single BAM ignores <code>-K</code>.</td></tr>
+    <tr><td><code>-I &lt;n&gt;</code></td><td>Minimum reads (summed across all libraries) supporting a BAM junction before it becomes intron evidence (default <code>1</code>). <code>-I 2</code> helps a little for a single library; it is redundant once <code>-K &ge; 2</code>.</td></tr>
+    <tr><td><code>-N &lt;M&gt;</code></td><td>Millions of reads mapped, used only for the <code>rpkm=</code> report attribute; estimated from a BAM index when omitted.</td></tr>
+  </table></div>
+  <div class="callout">
+    <span class="label">How many tissues?</span>
+    Diminishing returns set in around <strong>four diverse tissues</strong>: on a
+    human benchmark, most protein-coding genes reachable from RNA&#8209;seq are
+    covered by the fourth complementary library, and adding more (or a second
+    sample of the same organ) helps little. Prefer complementary tissues over
+    many similar ones.
+  </div>
+
+  <h2>One BAM, both roles (-Y)</h2>
+  <p>A single <code>-Y&nbsp;reads.bam</code> uses that BAM as both the
+  <code>-R</code> junction source and the <code>-S</code> coverage source, instead
+  of passing it to each separately. A full example &mdash; GFF3 output, U12
+  introns allowed, UTRs, expression scoring, from one STAR/minimap2 BAM:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -3U -u -y rf -L 50 -Q 0.0007 -Y aligned.bam \
+             -P param/human.rnaseq.param genome.fa</code></pre>
+  <p>And several tissue BAMs, each keeping its own background, two required to
+  agree:</p>
+  <pre><code><span class="cmd">$</span> bin/geneid -3U -u -y rf -L 50 -Q 0.0007 -K 2 \
+             -Y brain.bam,liver.bam,heart.bam,testis.bam \
+             -P param/human.rnaseq.param genome.fa</code></pre>
+
+  <div class="callout warn">
+    <span class="label">Hard-mask repeats</span>
+    geneid ignores soft-masking. Hard-mask repeats to <code>N</code> in the FASTA;
+    otherwise repeat-region coverage inflates false predictions
+    (<a href="../chapter4/index.html">chapter&nbsp;4</a>).
+  </div>
+
+  <div class="pagenav">
+    <a href="../chapter6/index.html"><span class="dir">&larr; Prev</span><span>External annotations (-R)</span></a>
+    <a class="next" href="../chapter8/index.html"><span class="dir">Next &rarr;</span><span>The parameter file</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Description:</font>
-<a name ="description"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> provides a simple support to the usage of homology
-information, either genomic homology (DNA - DNA) or protein homology
-(Protein - DNA translated). Homology information extracted from the aligment
-between input sequence and others (well-annotated) can be used to improve
-the degree of accuracy obtained ab initio, increasing the final score on the
-set of predicted exons overlapping the shared regions in such alignment
-(High-scoring Segment Pairs).
-<br><p>
-The information from aligments is read from an additional file in
-<tt>gff</tt> format as a list of HSPs. <tt>geneid</tt>
-is instructed to read this file with the command line option 
-<tt>-S filename</tt>. It is NOT necessary to provide the HSPs ordered 
-by any position in the sequence.
-<br><p>
-The frame can be either set in the column 8 of <tt>gff</tt> format or
-skipped by using the wildcar "." when is unknown. In the last case,
-<tt>geneid</tt> generates 3 equivalent elements (one per possible frame).
-This is necessary when aligments have been produced between 2 genomic
-sequences (DNA to DNA) and therefore there is no frame associated to.
-<br><p>
-The group field (column 9 in <tt>gff</tt> format) can be present but will be
-omitted when storing this information.
-</font>
 </div>
-</td>
-</table>
-
-<br><p>
-
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>HSPs:</font>
-<a name ="srs"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-Given an <tt>blast</tt> aligment, a set of High-score Segment Pairs (HSPs)
-are produced to represent parts common in both sequences. Given the
-interesting sequence (input to <tt>geneid</tt>), numerous pairwise
-alignments can be done by using sequences related to the original by
-many causes such as containing an homologous gene (syntenic gene prediction).
-<br><p>
-<tt>geneid</tt> will increase proportionally the score of predicted exons
-which overlap the HSPs obtained by previous pairwise aligments. To sum up
-the information coming from several aligments, a projection of HSPs over the
-sequence is performed, taking always the highest score among the HSPs 
-being in every position of the input sequence. Exon positions overlapping
-regions without homology support will be given a value <tt>NO_SCORE</tt> 
-(see <a href="../chapter8/index.html">chapter 8. <tt>geneid</tt> 
-parameter file</a>)
-<br><p>
-<center>
-<IMG SRC="../images/SR.jpg">
-</center>
-
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>
-Frame definition in <tt>blast</tt> and <tt>geneid</tt>
-</font>
-<a name ="frame"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<font color="red">
-It is important to understand that frame definition in <tt>blast</tt> and
-<tt>geneid</tt> is different and therefore a simple translation from one into
-another format is needed. Altough this conversion is implemented inside
-<tt>geneid</tt>, it might be necessary to keep it in mind to analyze and
-understand the new results.
-</font>
-<br><p>
-<hr>
-<br><p>
-In <tt>blast</tt>, there are 3 frames (1,2 or 3)
-corresponding to the mathematical modulus operation computed following this
-formula:
-<br><p>
-<center>
-frame = HSP starting position modulus 3 (0 corresponds to frame 3).
-</center>
-<br><p>
-i.e. Given a sequence which its first position is called 1, one HSP which starts
-at the position 7 is said to be in frame 1 (7 modulus 3 = 1), while a HSP
-which starts at the position 9 is said to be in frame 3 (9 modulus 3 = 0
-and 0 is coded by 3).
-<br><p>
-<font color="green">
-IMPORTANT: HSPs might appear in the negative (reverse) strand of the
-input sequence. In that case, the HSPs coordinates must be translated into
-coordinates regarding to the reverse reading direction before computing the
-frame.
-</font>
-<br><p>
-<hr>
-<br><p>
-In <tt>geneid</tt>, the frame is defined as the number of nucleotides (0,1,2)
-from the first nucleotide in the exon sequence to the the first nucleotide
-in the first COMPLETE codon translated from the genomic sequence
-(<a href="../chapter2/index.html#frames">see section Frame and Remainder (chapter 2)</a>).
-<br><p>
-<hr>
-<br><p>
-Obviously, it is necessary a method to convert <tt>geneid</tt> frames (exons)
-into <tt>blast</tt> frames (HSPs) to use this information properly. The
-following formula makes both types of frame definitions compatible
-<br><p>
-  Given an exon and a HSP (both in the same strand):
-<center>
-<br><p>
-  blastFrame(HSP) = (starting(exon) + geneidFrame(exon)) % 3;<br>
-  (result 0 corresponding to blastFrame 3)
-</center>
-<br><p>
-  notice: blastFrame = [1,2,3] and geneidFrame = [0,1,2].
-</font>
-</div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter8/index.html
+++ b/docs/chapter8/index.html
@@ -1,652 +1,172 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>8. The parameter file &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a class="current" href="../chapter8/index.html">The parameter file</a></li>
+    <li><a href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 8</p>
+  <h1>The parameter file</h1>
+  <p class="lead">Everything species-specific lives here: the statistical model
+  that scores signals and exons, and the gene model that chains them.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>8. <tt>geneid</tt> parameter file</font>
-</td>
-</table>
+  <p>geneid is data-driven. A parameter file describes the probabilistic model
+  the predictions are based on, plus the gene model at the end. The
+  <code>param/</code> directory ships files for several species (human, Drosophila,
+  plasmodium, dictyostelium, wheat, and more); one file is broadly reusable within
+  a phylogenetic group.</p>
+  <div class="callout tip">
+    <span class="label">Don't hand-write these</span>
+    Parameter files are trained from annotated sequence, not edited by hand. Use
+    the <strong>geneid-train</strong> workflow (see the
+    <a href="https://github.com/guigolab/geneid/wiki">Wiki</a>) to fit and emit a
+    new one. This chapter describes the file so you can read and lightly tune it.
+  </div>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="#description">Description</a>
-<li> <a href="#gm">The GENE MODEL</a>
-<li> <a href="#acc">Acceptor splice sites: 
-Branch Points and  Poly Pyrimidine Tracts</a>
-<li> <a href="#full">Full description</a>
+  <h2>Overall structure</h2>
+  <p>A parameter file has three top-level parts:</p>
+  <ol>
+    <li><strong><code>NO_SCORE</code></strong> &mdash; the value given to exon
+    positions with no homology support (<a href="../chapter7/index.html">chapter&nbsp;7</a>).
+    Zero by default; raise it to favour homology-supported predictions.</li>
+    <li><strong>Isochores</strong> &mdash; one model per G+C band, so scoring
+    adapts to local base composition.</li>
+    <li><strong>The gene model</strong> &mdash; the rules for chaining elements.</li>
+  </ol>
+  <pre><code># 0. Non-homology penalty
+NO_SCORE  0
 
-<li> <a href="./../index.html">INDEX</a>
-</ol>
-</font>
-</div>
-</td>
-</table>
+# 1. Isochore-dependent models (by G+C %)
+number_of_isochores 3
+boundaries_of_isochore  0 40      # isochore 1
+  ...
+boundaries_of_isochore 40 70      # isochore 2
+  ...
+boundaries_of_isochore 70 100     # isochore 3
+  ...
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Description:</font>
-<a name ="description"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> relies on a parameter file to build the predictions. 
-The parameter file contains
-mostly the description of the probabilistic model on which the predictions
-are based. It also contains the so-called gene model at the end, the set of 
-rules describing how to chain gene elements (such as exons) into gene 
-predictions. Through the usage of the gene model
-and the options <tt>O/R</tt>, <tt>geneid</tt> offers support for the
-integration of predictions from multiple sources.
-</font>
-</div>
-</td>
-</table>
+# 2. Gene-assembling rules (the gene model)
+  ...</code></pre>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>The GENE MODEL</font>
-<a name ="gm"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-The gene model is the list of rules describing the constrains under which,
-predicted gene elements must be joined together in the final output. This
-constrains refer to the succession of elements in the gene structure and
-to the range of allowed distances among them.
+  <h2>Inside one isochore</h2>
+  <p>Each isochore block holds four things:</p>
+  <ol>
+    <li>exon-filtering cutoffs and scoring factors;</li>
+    <li>signal profiles (position weight arrays);</li>
+    <li>the Markov coding-potential model;</li>
+    <li>the maximum number of donors kept per acceptor.</li>
+  </ol>
 
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=600>
-<tr>
-<td align=center bgcolor="skyblue">
-<font size=2>
-<pre>
-#Intragenic connections
-First+:Internal+     Internal+:Terminal+     40:11000
-</pre>
-</font>
-</td>
-</table>
-</center>
-<br><p>
-For instance, the rule above indicates that elements (exons) of type
-<tt>Internal</tt> or <tt>Terminal</tt>, must be chained immediately after
-elements of type <tt>First</tt> or <tt>Internal</tt> in the forward strand.
-The third column indicates the range at which they can be chained. In this
-rule, the predicted elements must be at least 40 bp and at most 11000, apart.
-The equivalent rule for the reverse sense is:
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=600>
-<tr>
-<td align=center bgcolor="skyblue">
-<font size=2>
-<pre>
-#Intragenic connections (reverse)
-Terminal-:Internal-     Internal-:First-    40:11000
-</pre>
-</font>
-</td>
-</table>
-</center>
-<br><p>
-The following rule specifies the constrains governing connections between
-genes:
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=600>
-<tr>
-<td align=left bgcolor="skyblue">
-<font size=2>
-<pre>
-#Intergenic connections
-Terminal+       First+:Terminal-        500:Infinity
-First-          First+:Terminal-        500:Infinity
-</pre>
-</font>
-</td>
-</table>
-</center>
-<br><p>
-First line describes the relationship between the end of a gene
-in the forward strand  and the beginning of another one in the positive
-strand or the end of a gene in the reverse strand.
-Second rule defines the connections between the beginning of a gene
-in the reverse strand and the beginning of a gene in the forward strand
-or the end of another gene in reverse strand. To specify no maximum 
-distance constrains, the keyword Infinity must be used.
-<br><p>
-The present version of <tt>geneid</tt> predicts elements with types
-<tt>First, Internal, Terminal and Single</tt>. Gene termination is 
-coded within the program with the features <tt>First+/Terminal-</tt> 
-(start) and <tt>First-/Terminal+</tt> (end) while <tt>Single+/Single-</tt> 
-are both start and end from genes. Other elements in the additional 
-files provided externally (O/R options) are ignored when they are not 
-defined in any rule of the gene model.
-<br><p>
-<center>
-<table border=1 cellpadding=10 width=600>
-<tr>
-<td align=left bgcolor="skyblue">
-<font size=2>
-<pre>
-# BEGINNING and END of prediction
-Begin+        First+:Internal+:Terminal+:Single+  0:Infinity
-Begin-        First-:Internal-:Terminal-:Single-  0:Infinity
-First+:Internal+:Terminal+:Single+   End+         0:Infinity
-First-:Internal-:Terminal-:Single-   End-         0:Infinity
-</pre>
-</font>
-</td>
-</table>
-</center>
-<br><p>
-Rules above are defining which elements are allowed to start and
-finish the prediction output. Option -F forces <tt>geneid</tt> to 
-predict a complete gene structure in the input sequence. That is, 
-either First-(Internal)*-Terminal, Terminal-(Internal)*-First or a 
-single-exon gene.
-</font>
-</div>
-</td>
-</table>
+  <h3>Exon cutoffs and factors</h3>
+  <p>Four values per line, one for each exon type (First, Internal, Terminal,
+  Single). The factors set how the final exon score combines its parts:</p>
+  <pre><code>Total_score_cutoff          -15 -15 -15 -15   # drop exons below this
+Coding_potential_score_cutoff -10 -15 -15 -15   # drop weak coding potential
+Site_factor                 0.6 0.6 0.6 0.6    # weight of the splice/site scores
+Exon_factor                 0.1 0.1 0.1 0.1    # weight of the coding-potential score
+HSP_factor                  0.04 0.04 0.04 0.04 # weight of the homology / coverage score
+Exon_weights               -5.5 -5.5 -5.5 -5.4 # constant added to surviving exons</code></pre>
+  <p>The final exon score is
+  <code>Site_factor&middot;sites + Exon_factor&middot;coding + HSP_factor&middot;evidence</code>,
+  plus <code>Exon_weights</code> (a negative bias that discourages spuriously long,
+  many-exon genes under the additive assembly).</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Acceptor Splice sites:</font>
-<a name ="acc"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<tt>geneid</tt> can predict both the putative branch point and 
-the putative Poly Pyrimidine Tract for each predicted acceptor. In order
-to obtain such predictions, separate optional profiles for one of them or 
-both additional signals must be provided in the parameter file. It is always 
-mandatory to have a very basic acceptor profile to detect the core of the 
-signal: <tt>AG</tt>.
-<br><p>
-Then, the structure
-of the parameter file in that section would be:
-<br><p>
-<center>
-<table border=1>
-<tr>
-<td bgcolor=lightblue>
-<pre>
-<b>
-Branch_point_profile
-20 0 0 1
-# Transition probabilities at every position
-1 AA -0.128982
-1 AC 0.401934
-1 AG -0.580466
-1 AT 0.293935
-1 CA -0.41815
-1 CC 0.0892966
-1 CG -0.350502
-1 CT 0.294759
-1 GA -0.103346
-1 GC 0.110032
-1 GG -0.345638
-1 GT 0.358765
-1 TA -0.111567
-...
-
-Poly_Pyrimidine_Tract_profile
-20 0 0 1
-# Transition probabilities at every position
-1 AA -0.128982
-1 AC 0.401934
-1 AG -0.580466
-1 AT 0.293935
-1 CA -0.41815
-1 CC 0.0892966
-1 CG -0.350502
-1 CT 0.294759
-1 GA -0.103346
-1 GC 0.110032
-1 GG -0.345638
-1 GT 0.358765
-1 TA -0.111567
-1 TC 0.0519978
-1 TG -0.300144
-1 TT 0.273584
-2 AA -0.082934
-2 AC 0.399051
-2 AG -0.606083
-2 AT 0.221358
-2 CA -0.320746
-2 CC 0.0964467
-2 CG 0.0141593
-2 CT 0.15082
-2 GA -0.00298645
-...
-
-Acceptor_profile
-7 4 -7 1
-# Transition probabilities at every position
-
+  <h3>Signal profiles (position weight arrays)</h3>
+  <p>Each signal &mdash; start, stop, acceptor, donor &mdash; is a PWA: a matrix
+  indexed by (oligonucleotide, position) of log-likelihood ratios between a model
+  of true sites and one of false sites. Four header numbers define it:</p>
+  <div class="tablewrap"><table>
+    <tr><th>Header</th><th>Meaning</th></tr>
+    <tr><td>length</td><td>size of the scanned window</td></tr>
+    <tr><td>offset</td><td>distance to the core element (e.g. the <code>AG</code> / <code>ATG</code>)</td></tr>
+    <tr><td>cutoff</td><td>score below which candidate sites are discarded</td></tr>
+    <tr><td>order</td><td>Markov order (oligonucleotide length used to score each position)</td></tr>
+  </table></div>
+  <pre><code>Acceptor_profile  7 4 -7 1
+# order-1 transition scores, per position and dinucleotide
 1 AA 0.489398
 1 AC 0.559547
 1 AG -1.62606
-1 AT -0.114812
-1 CA -0.0513558
-1 CC 0.240873
-1 CG 0.463496
-1 CT -0.413189
-1 GA -0.287557
-1 GC 0.250994
-1 GG 0.152369
-1 GT -0.255893
-1 TA -0.353906
-1 TC 0.166021
-1 TG -0.0541454
-1 TT 0.150306
-2 AA -1.45683
-2 AC 0.970558
-2 AG -4.94779
-2 AT 0.397884
-2 CA -1.93025
-2 CC 0.36421
-2 CG -3.01555
-2 CT 0.565917
-2 GA -1.98417
-2 GC 0.970977
-2 GG -4.5318
-2 GT 0.383942
-2 TA -1.24867
-2 TC 0.614448
-2 TG -5.14748
-2 TT 0.758865
-3 AA 0.000
-3 AC -9999
-3 AG -9999
-3 AT -9999
-3 CA 0.000
-3 CC -9999
-3 CG -9999
-3 CT -9999
-3 GA 0.000
-3 GC -9999
-3 GG -9999
-3 GT -9999
-3 TA 0.000
-3 TC -9999
-3 TG -9999
-3 TT -9999
-4 AA -9999
-4 AC -9999
-4 AG 0.000
-4 AT -9999
-4 CA -9999
-4 CC -9999
-4 CG -9999
-4 CT -9999
-4 GA -9999
-4 GC -9999
-4 GG -9999
-4 GT -9999
-4 TA -9999
-4 TC -9999
-4 TG -9999
-4 TT -9999
-5 AA -9999
-5 AC -9999
-5 AG -9999
-5 AT -9999
-5 CA -9999
-5 CC -9999
-5 CG -9999
-5 CT -9999
-5 GA -0.17512
-5 GC -0.456677
-5 GG 0.573456
-5 GT -0.627791
-5 TA -9999
-5 TC -9999
-5 TG -9999
-5 TT -9999
-6 AA -0.213185
-6 AC -0.085246
-6 AG -0.346927
-6 AT 0.573534
-6 CA -0.33339
-6 CC -0.154707
-6 CG 0.349989
-6 CT 0.305452
-6 GA -0.120601
-6 GC -0.354317
-6 GG -0.061412
-6 GT 0.491861
-6 TA -0.316615
-6 TC -0.244502
-6 TG 0.049206
-6 TT 0.276332
-7 AA 0.0223094
-7 AC 0.25836
-7 AG -0.361517
-7 AT 0.168915
-7 CA -0.238056
-7 CC 0.195423
-7 CG 0.184102
-7 CT -0.00295397
-7 GA -0.22978
-7 GC 0.203999
-7 GG -0.0720478
-7 GT 0.162323
-7 TA -0.111801
-7 TC 0.00204436
-7 TG 0.108514
-7 TT -0.0726444
-</b></pre>
-</td>
-</table>
-</center>
-</font>
+  ...</code></pre>
+  <p><strong>Optional profiles</strong> refine acceptors and enable minor-class
+  splicing: <code>Branch_point_profile</code> and
+  <code>Poly_Pyrimidine_Tract_profile</code>, and the <strong>U12</strong> donor
+  and acceptor profiles that <code>-U</code> activates (for the
+  <code>GT&ndash;AG</code> and <code>AT&ndash;AC</code> subtypes). A
+  <code>Branch_point_score_weight</code> scales how much the branch score
+  contributes.</p>
+
+  <h3>Coding-potential (Markov) model</h3>
+  <p>Protein-coding potential is measured with a Markov model, usually order 5.
+  Two matrices: <em>initial</em> scores the first oligonucleotide of an exon;
+  <em>transition</em> scores each subsequent position, per codon position, as the
+  log-ratio of the oligonucleotide's probability in real vs. intronic sequence.</p>
+  <pre><code>Markov_oligo_logs_file
+Markov_model_order 5
+Markov_initial_probability_matrix
+  AAAAA 0 0 -0.85727
+  ...
+Markov_transition_probability_matrix
+  AAAAAA 0 0 -1.10797
+  ...</code></pre>
+
+  <h2>The gene model</h2>
+  <p>The gene model lists the rules for chaining predicted elements. Each rule
+  gives the element types that may connect, in order, and the allowed distance
+  range. <code>Infinity</code> removes an upper bound; <code>block</code>
+  preserves grouped exons (an annotated gene) without interleaving ab&nbsp;initio
+  predictions.</p>
+  <pre><code># Intragenic connections (forward and reverse)
+First+:Internal+   Internal+:Terminal+   40:25000
+Terminal-:Internal- Internal-:First-     40:25000
+
+# Intergenic connections
+Terminal+   First+:Terminal-   500:Infinity
+First-      First+:Terminal-   500:Infinity
+
+# What may begin / end a prediction
+Begin+  First+:Internal+:Terminal+:Single+   0:Infinity
+        First+:Internal+:Terminal+:Single+  End+  0:Infinity</code></pre>
+  <p>Connections between exon types are sometimes real gene junctions &mdash; a
+  Terminal followed by a First joins the end of one gene to the start of the next.
+  <code>-F</code> forces geneid to emit a single complete gene structure. Element
+  types not named in any rule (arriving via <code>-O</code>/<code>-R</code>) are
+  ignored during assembly.</p>
+
+  <h3>Optional: soft intron-length model</h3>
+  <p>Modern parameter files may include a trained intron-length distribution and a
+  weight, turning the hard maximum-intron distance into a smooth,
+  length-dependent penalty on intron-spanning joins. It is inert unless the
+  weight is set, and is waived for junction-supported introns
+  (<a href="../chapter7/index.html">chapter&nbsp;7</a>).</p>
+
+  <div class="pagenav">
+    <a href="../chapter7/index.html"><span class="dir">&larr; Prev</span><span>RNA-seq &amp; homology (-S / -Y)</span></a>
+    <a class="next" href="../chapter9/index.html"><span class="dir">Next &rarr;</span><span>Source code &amp; architecture</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Full description:</font>
-<a name ="full"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-
-<br><p>
-<table border=0 width=600 cellpadding=10>
-<tr>
-<td bgcolor="white">
-<b>(1)</b>
-This the general structure in geneid parameter files:
-<tt>NO_SCORE</tt> parameter, information model to predict genomic elements 
-according to the G+C content
-of every sequence fragment, and gene model to assemble the predictions
-following series of rules.</td>
-
-<tr>
-<td>
-<font size=1>
-<tt>NO_SCORE</tt> is the value that will be used to score exon positions that
-do not overlap with any input HSP. By default, its value is zero, but it can be
-modified to enhance the appearance of predictions supported by homology 
-information (option -S).
-</font>
-</td>
-
-<tr>
-<td bgcolor="lightblue">
-<font size=2 color="black">
-<b>
-<pre>
-<font color=red>
-# 0. Non-homology penalty</font>
-NO_SCORE
-0
-
-<font color=red>
-#1. ISOCHORE DEPENDENT INFORMATION</font>
-number_of_isochores
-3
-
-# SET OF PARAMETERS FOR ISOCHORE 1
-boundaries_of_isochore
-0  40
-<font color="white">...</font>
-# SET OF PARAMETERS FOR ISOCHORE 2
-boundaries_of_isochore
-40  70
-<font color="white">...</font>
-# SET OF PARAMETERS FOR ISOCHORE 3
-boundaries_of_isochore
-70  100
-<font color="white">...</font>
-
-<font color=red>#2. GENE ASSEMBLING RULES (gene model)</font>
-<font color="white">...</font>
-</pre></b></font>
-</td>
-<tr>
-<td bgcolor="white">
-<b>(2)</b>
-This the general structure for every isochore model: cutoff values to filter
-exons after scoring, profiles to discover genomic signals, Markov
-model matrices to measure coding potential property and maximum number
-of exons starting with the same starting signal.
-</td>
-<tr>
-<td bgcolor="lightblue">
-<font size=2 color="black">
-<b>
-<pre>
-# SET OF PARAMETERS FOR ISOCHORE 1
-boundaries_of_isochore
-0  40
-
-<font color=red>#1. SET OF PARAMETERS to filter exons</font>
-<font color="white">...</font>
-
-<font color=red>#2. PROFILES TO PREDICT SIGNALS</font>
-<font color="white">...</font>
-
-<font color=red>#3. MARKOV MODEL TO ESTIMATE CODING POTENTIAL</font>
-<font color="white">...</font>
-
-<font color=red>#4. Maximum amount of exons with every left signal</font>
-maximum_number_of_donors_per_acceptor_site
-5
-</pre></b></font>
-</td>
-<tr>
-<td bgcolor="white">
-<b>(3)</b>
-Parameters for filtering exons depending on their coding potential score:
-cutoff on the final exon score, cutoff on the protein coding potential
-score, factors for weighting site score, coding potential score and 
-homology score and finally exon weight parameter (value added to exons 
-which have overcome all of the previous filters: penalty to avoid predicting 
-long genes with too many exons due to the additive schema under gene 
-assembling model). There are always 4 values for each of exon types: First, 
-Internal, Terminal and Single.
-</td>
-<tr>
-<td bgcolor="lightblue">
-<font size=2 color="black">
-<b>
-<pre>
-# SET OF PARAMETERS to filter exons
-
-<font color="red">Total_score_cutoff</font>
--15 -15 -15 -15
-
-<font color="red">Coding_potential_score_cutoff</font>
--10 -15 -15 -15
-
-<font color="red">Site_factor</font>
-0.6 0.6 0.6 0.6
-
-<font color="red">Exon_factor</font>
-0.4 0.4 0.4 0.4
-
-<font color="red">HSP_factor</font>
-1.0 1.0 1.0 1.0
-
-<font color="red">Exon_weight_values</font>
--7 -7 -7 -7
-</pre></b></font>
-</td>
-<tr>
-<td bgcolor="white">
-<b>(4)</b> This a generic profile to predict genomic signals: start / stop
-codons or acceptor / donor splice sites. This type of profile is called
-Position Weight Array: a matrix addressed by (nucleotide,position) in which
-every cell contains a loglikelihood ratio between a Markov model (order k)
-recognizing true sites and another one, matching false ones. Therefore,
-for every nucleotide in a candidate region, is scored the probability to
-find the oligonucleotide (length k) before that nucleotide whether the region
-contains a true site or not. PWA are well characterized by defining 4 parameters:
-<ul>
-<li>length of profile (region to be scanned)
-<li>offset: distance from the beginning of the profile to the characteristic
-or core element for that signal (i.e. ATG in start codons)
-<li>cutoff: score to filter false signals
-<li>order (Markov chains): length of oligonucleotides used to score every
-element in the candidate region
-</ul>
-</td>
-<tr>
-<td bgcolor="lightblue">
-<font size=2 color="black">
-<b>
-<pre>
-<font color="red">Start profile</font>
-20 14 -6 2
-
-<font color="red"># Position Weight Array</font>
-
-1 AAA -0.230297
-1 AAC 0.519562
-1 AAG 0.301505
-1 AAT -0.519705
-1 ACA -0.688891
-1 ACC 0.483538
-<font color="white">...</font>
-20 TGT -0.483268
-20 TTA -0.545436
-20 TTC 0.557414
-20 TTG -0.0335678
-20 TTT -0.172498
-
-<font size=1>
-# e.g. Given S=ATGAGC then
-# score(GAGC) = score(1,ATG) + score(2,TGA) + score(3,GAG) + score(4,AGC)
-</font></pre></b></font>
-</td>
-<tr>
-<td bgcolor="white">
-<b>(5)</b> Model to measure the protein coding potential of genomic regions.
-A Markov model (chains of order 5) are usually used, having 2 types of
-matrices: initial (for scoring the first pentanucleotide of an exon) and
-transition (for scoring the exon by taking 5+1 nucleotides until reaching
-the end of the exon). Initial matrix has been computed by measuring the
-ratio between frequency of pentanucleotides found in real exons and
-contained in intronic regions. Transition matrix has been computed by
-measuring the ratio between the probability to find a pentanucleotide X in
-codon position CP (translation) before a given nucleotide, in a real exon or
-in a false one (intronic region).
-</td>
-<tr>
-<td bgcolor="lightblue">
-<font size=2 color="black">
-<b>
-<pre>
-<font color="red"># Markov model (log likelihood ratio)</font>
-<font color="red">Markov_model_order</font>
-5
-
-<font color="red">Markov_initial_probability_matrix</font>
-AAAAA 0 0 -0.85727
-AAAAA 0 1 -1.48328
-AAAAA 0 2 -1.72858
-AAAAC 1 0 -0.377093
-AAAAC 1 1 -0.202228
-AAAAC 1 2 -0.961698
-<font color="white">...</font>
-
-<font color="red">Markov_transition_probability_matrix</font>
-AAAAAA 0 0 -1.10797
-AAAAAA 0 1 -0.736771
-AAAAAA 0 2 -0.570196
-AAAAAC 1 0 0.961644
-AAAAAC 1 1 0.516564
-AAAAAC 1 2 0.646909
-</pre></b></font>
-</td>
-<tr>
-<td bgcolor="white">
-<b>(6)</b> Gene model rules. Rules defining which exon types are allowed
-to join to others, respecting minimum and maximum distance requirement.
-First column of rule are features which will be assembled before features
-in the second one, respecting the distances (third column). The word
-"block" is used to preserve connections between exons sharing the same
-identifier (group), as annotated genes (evidences) without mixing them
-with ab initio predictions. Minimum distance is the smallest allowed
-distance between the end and start of both connected exons while maximum
-distance is the highest allowed distance to connect two exons (the reserved
-word "Infinity" is used to disable the maximum restriction to save time
-consuming). Connection between exons, depending on their type, are sometimes
-actual gene connections (i.e. a Terminal exon with a First exon means joining
-the end of a gene with the beginning of another one).
-</td>
-<tr>
-<td bgcolor="lightblue">
-<font size=2 color="black">
-<b>
-<pre>
-<font color="red">#Intronic connections</font>
-First+:Internal+       Internal+:Terminal+      20:25000 block
-Terminal-:Internal-    First-:Internal-         20:25000 block
-</pre></b></font>
-</td>
-</table>
-
-</font>
 </div>
-</td>
-</table>
-
-
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/chapter9/index.html
+++ b/docs/chapter9/index.html
@@ -1,239 +1,97 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
-</style>
-<title>
-geneid docs
-</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>9. Source code &amp; architecture &mdash; geneid manual</title>
+<link rel="stylesheet" href="../style.css">
 </head>
+<body>
+<div class="layout">
+<nav class="sidebar">
+  <a class="brand" href="../index.html">geneid <span class="ver">v1.6 manual</span></a>
+  <ol>
+    <li><a href="../chapter1/index.html">What is geneid?</a></li>
+    <li><a href="../chapter2/index.html">Signals, exons and genes</a></li>
+    <li><a href="../chapter3/index.html">Installing geneid</a></li>
+    <li><a href="../chapter4/index.html">Running geneid</a></li>
+    <li><a href="../chapter5/index.html">Assembling exons (-O)</a></li>
+    <li><a href="../chapter6/index.html">External annotations (-R)</a></li>
+    <li><a href="../chapter7/index.html">RNA-seq &amp; homology (-S / -Y)</a></li>
+    <li><a href="../chapter8/index.html">The parameter file</a></li>
+    <li><a class="current" href="../chapter9/index.html">Source code &amp; architecture</a></li>
+    <li><a href="../chapter10/index.html">History &amp; references</a></li>
+  </ol>
+</nav>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
+<div class="content">
+<main>
+  <p class="eyebrow">Chapter 9</p>
+  <h1>Source code &amp; architecture</h1>
+  <p class="lead">geneid is ANSI C in <code>src/</code>, with one header
+  <code>include/geneid.h</code>. This chapter maps the code to the prediction
+  pipeline.</p>
 
-<center>
-<table border=0 width=700>
-<tr>
-<td align=left>
-<font face=courier size=5 color=red><b>geneid documentation:</b></font>
-</td>
-<td align=right>
-<font face="arial black" size=3>9. Source code documentation
-</td>
-</table>
+  <p>The authoritative source is on
+  <a href="https://github.com/guigolab/geneid">GitHub</a>; browse
+  <a href="https://github.com/guigolab/geneid/tree/master/src"><code>src/</code></a>
+  for the current files. The modules below are grouped by the stage they serve,
+  following the flow of a run.</p>
 
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor=orange><font face="arial black" size=3>Source code documentation:</font>
-<a name ="code"></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<img src="./images/V_orange.gif" border=0>: Description
-<br>
-<img src="./images/V_silver.gif" border=0>: Code
-<br><p>
+  <h2>The pipeline</h2>
+  <p>A run moves through these stages, per genomic fragment for large sequences:</p>
+  <ol>
+    <li><strong>Set-up</strong> &mdash; parse arguments and the parameter file,
+      read the sequence.</li>
+    <li><strong>Signals</strong> &mdash; score sites with the profiles.</li>
+    <li><strong>Exons</strong> &mdash; build and score candidate exons.</li>
+    <li><strong>Evidence</strong> &mdash; fold in annotations, homology and
+      RNA&#8209;seq.</li>
+    <li><strong>Assembly</strong> &mdash; chain exons into the optimal gene
+      structure by dynamic programming.</li>
+    <li><strong>Output</strong> &mdash; translate and print.</li>
+  </ol>
 
-<table border=0>
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>account.c</tt></td>
-<td><a href="./code_html/account.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/account.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>Output.c</tt></td>
-<td><a href="./code_html/Output.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/Output.c"><img src="./images/V_silver.gif" border=0></a></td>
+  <h2>Module map</h2>
+  <div class="tablewrap"><table>
+    <tr><th>Stage</th><th>Key modules</th></tr>
+    <tr><td>Entry &amp; orchestration</td>
+        <td><code>geneid.c</code>, <code>manager.c</code>, <code>readargv.c</code>, <code>readparam.c</code>, <code>ReadGeneModel.c</code>, <code>SetRatios.c</code>, <code>RequestMemory.c</code></td></tr>
+    <tr><td>Sequence I/O</td>
+        <td><code>ReadSequence.c</code>, <code>FetchSequence.c</code>, <code>Dictionary.c</code></td></tr>
+    <tr><td>Signals</td>
+        <td><code>GetSitesWithProfile.c</code>, <code>ScoreProfile.c</code>, <code>BuildAcceptors.c</code>, <code>BuildU12Acceptors.c</code>, <code>BuildDonors.c</code>, <code>GetStopCodons.c</code>, <code>ComputeStopInfo.c</code></td></tr>
+    <tr><td>Exons &amp; coding potential</td>
+        <td><code>BuildInitialExons.c</code>, <code>BuildInternalExons.c</code>, <code>BuildTerminalExons.c</code>, <code>BuildSingles.c</code>, <code>BuildORFs.c</code>, <code>BuildUTRExons.c</code>, <code>BuildZeroLengthExons.c</code>, <code>ScoreExons.c</code>, <code>CorrectExon.c</code></td></tr>
+    <tr><td>Evidence (annotations, homology, RNA-seq)</td>
+        <td><code>ReadExonsGFF.c</code>, <code>ReadExonsBigBed.c</code>, <code>ReadHSP.c</code>, <code>ReadIntronsBam.c</code>, <code>ProcessHSPs.c</code>, <code>SearchEvidenceExons.c</code>, <code>PeakEdgeScore.c</code>, <code>GetTranscriptTermini-usingslopes.c</code>, <code>bamcov.c</code>, <code>bigwig.c</code>, <code>bigbed.c</code></td></tr>
+    <tr><td>Gene assembly (dynamic programming)</td>
+        <td><code>genamic.c</code>, <code>CookingGenes.c</code>, <code>BackupGenes.c</code>, <code>beggar.c</code></td></tr>
+    <tr><td>Sorting &amp; coordinate utilities</td>
+        <td><code>SortExons.c</code>, <code>SortSites.c</code>, <code>SortHSPs.c</code>, <code>BuildSort.c</code>, <code>SwitchFrames.c</code>, <code>SwitchPositions.c</code>, <code>RecomputePositions.c</code>, <code>DumpHash.c</code></td></tr>
+    <tr><td>Translation &amp; output</td>
+        <td><code>Translate.c</code>, <code>PrintExons.c</code>, <code>PrintSites.c</code>, <code>Output.c</code>, <code>account.c</code></td></tr>
+  </table></div>
 
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BackupGenes.c</tt></td>
-<td><a href="./code_html/BackupGenes.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BackupGenes.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>PrintExons.c</tt></td>
-<td><a href="./code_html/PrintExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/PrintExons.c"><img src="./images/V_silver.gif" border=0></a></td>
+  <div class="callout">
+    <span class="label">htslib modules</span>
+    <code>bamcov.c</code> and <code>ReadIntronsBam.c</code> are compiled only in a
+    <code>WITH_HTSLIB</code> build. <code>bigwig.c</code> and <code>bigbed.c</code>
+    depend only on zlib and are always built.
+  </div>
 
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>beggar.c</tt></td>
-<td><a href="./code_html/beggar.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/beggar.c"><img src="./images/V_silver.gif" border=0></a></td>
+  <div class="callout tip">
+    <span class="label">Memory model</span>
+    geneid's working arrays grow on demand; there are no compile-time capacity
+    ceilings. See the constants and comments in <code>include/geneid.h</code>.
+  </div>
 
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildAcceptors.c</tt></td>
-<td><a href="./code_html/BuildAcceptors.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildAcceptors.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildInitialExons.c</tt></td>
-<td><a href="./code_html/BuildInitialExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildInitialExons.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>PrintSites.c</tt></td>
-<td><a href="./code_html/PrintSites.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/PrintSites.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildInternalExons.c</tt></td>
-<td><a href="./code_html/BuildInternalExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildInternalExons.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>readargv.c</tt></td>
-<td><a href="./code_html/readargv.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/readargv.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildORFs.c</tt></td>
-<td><a href="./code_html/BuildORFs.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildORFs.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>ReadExonsGFF.c</tt></td>
-<td><a href="./code_html/ReadExonsGFF.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/ReadExonsGFF.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildSingles.c</tt></td>
-<td><a href="./code_html/BuildSingles.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildSingles.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>ReadGeneModel.c</tt></td>
-<td><a href="./code_html/ReadGeneModel.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/ReadGeneModel.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildSort.c</tt></td>
-<td><a href="./code_html/BuildSort.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildSort.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>readparam.c</tt></td>
-<td><a href="./code_html/readparam.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/readparam.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>BuildTerminalExons.c</tt></td>
-<td><a href="./code_html/BuildTerminalExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/BuildTerminalExons.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>ReadSequence.c</tt></td>
-<td><a href="./code_html/ReadSequence.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/ReadSequence.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>CookingGenes.c</tt></td>
-<td><a href="./code_html/CookingGenes.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/CookingGenes.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>ReadHSP.c</tt></td>
-<td><a href="./code_html/ReadHSP.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/ReadHSP.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>ComputeStopInfo.c</tt></td>
-<td><a href="./code_html/ComputeStopInfo.html"><img src="./images/V_orange.gif" border=0></a></td><td><a href="../../src/ComputeStopInfo.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>RecomputePositions.c</tt></td>
-<td><a href="./code_html/RecomputePositions.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/RecomputePositions.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>CorrectExon.c</tt></td>
-<td><a href="./code_html/CorrectExon.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/CorrectExon.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>RequestMemory.c</tt></td>
-<td><a href="./code_html/RequestMemory.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/RequestMemory.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>Dictionary.c</tt></td>
-<td><a href="./code_html/Dictionary.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/Dictionary.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>ScoreExons.c</tt></td>
-<td><a href="./code_html/ScoreExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/ScoreExons.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>DumpHash.c</tt></td>
-<td><a href="./code_html/DumpHash.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/DumpHash.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>SearchEvidenceExons.c</tt></td>
-<td><a href="./code_html/SearchEvidenceExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/SearchEvidenceExons.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>FetchSequence.c</tt></td>
-<td><a href="./code_html/FetchSequence.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/FetchSequence.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>SetRatios.c</tt></td>
-<td><a href="./code_html/SetRatios.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/SetRatios.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="red"><tt>genamic.c</tt></td>
-<td><a href="./code_html/genamic.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/genamic.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>SortExons.c</tt></td>
-<td><a href="./code_html/SortExons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/SortExons.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="red"><tt>geneid.c</tt></td>
-<td><a href="./code_html/geneid.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/geneid.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>SortHSPs.c</tt></td>
-<td><a href="./code_html/SortHSPs.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/SortHSPs.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>GetSitesWithProfile.c</tt></td>
-<td><a href="./code_html/GetSitesWithProfile.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/GetSitesWithProfile.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>SwitchFrames.c</tt></td>
-<td><a href="./code_html/SwitchFrames.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/SwitchFrames.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>GetStopCodons.c</tt></td>
-<td><a href="./code_html/GetStopCodons.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/GetStopCodons.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>SwitchPositions.c</tt></td>
-<td><a href="./code_html/SwitchPositions.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/SwitchPositions.c"><img src="./images/V_silver.gif" border=0></a></td>
-
-<tr>
-<td width=250 bgcolor="lightgreen"><tt>manager.c</tt></td>
-<td><a href="./code_html/manager.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/manager.c"><img src="./images/V_silver.gif" border=0></a></td>
-<td width=250 bgcolor="lightgreen"><tt>Translate.c</tt></td>
-<td><a href="./code_html/Translate.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../src/Translate.c"><img src="./images/V_silver.gif" border=0></a></td>
-</table>
-<br><p><br><p>
-<center>
-<table border=0 width=250 cellpadding=10>
-<tr>
-<td width=250 bgcolor="yellow"><tt>geneid.h</tt></td>
-<td><a href="./code_html/geneid.h.html"><img src="./images/V_orange.gif" border=0></a></td>
-<td><a href="../../include/geneid.h"><img src="./images/V_silver.gif" border=0></a></td>
-</table>
-</center>
-</font>
+  <div class="pagenav">
+    <a href="../chapter8/index.html"><span class="dir">&larr; Prev</span><span>The parameter file</span></a>
+    <a class="next" href="../chapter10/index.html"><span class="dir">Next &rarr;</span><span>History &amp; references</span></a>
+  </div>
+</main>
 </div>
-</td>
-</table>
-
-<br><p><br><p><br><p>
-
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
-
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
+</div>
 </body>
 </html>
-
-
-
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,83 +1,63 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<style type="text/css">
-div.bulk { text-align: justify }
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>geneid manual</title>
+<link rel="stylesheet" href="style.css">
+<style>
+  .hero { max-width: 900px; margin: 0 auto; padding: 3.5rem clamp(1.2rem,5vw,2rem) 1rem; }
+  .hero h1 { font-size: 2.8rem; margin: 0; letter-spacing: -0.03em; }
+  .hero .ver { color: var(--muted); font-weight: 400; font-size: 1.3rem; }
+  .hero .lead { font-size: 1.25rem; max-width: 60ch; }
+  .hero .links a { margin-right: 1.2rem; font-weight: 600; }
+  .toc { max-width: 900px; margin: 1rem auto 4rem; padding: 0 clamp(1.2rem,5vw,2rem); }
+  .toc h2 { border: 0; padding: 0; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 0.9rem; margin-top: 1rem; }
+  .card { display: block; padding: 1rem 1.1rem; border: 1px solid var(--border); border-radius: 11px; text-decoration: none; color: var(--fg); background: var(--sidebar-bg); }
+  .card:hover { border-color: var(--accent); text-decoration: none; }
+  .card .n { color: var(--accent); font-weight: 700; font-size: 0.8rem; }
+  .card .t { display: block; font-weight: 650; margin: 0.15rem 0 0.2rem; }
+  .card .d { color: var(--muted); font-size: 0.9rem; line-height: 1.45; }
+  footer.site { max-width: 900px; margin: 0 auto; padding: 0 clamp(1.2rem,5vw,2rem) 3rem; }
 </style>
-<title>
-geneid docs
-</title>
 </head>
+<body>
 
-<BODY 
-TEXT color ="blue"
-BGCOLOR="white"
-LINK="blue"
-VLINK="blue"
-ALINK="blue">
-
-
-<center>
-<table border=0 width=700>
-<tr>
-<td align=center>
-<img src="./images/geneid.jpg">
-</td>
-<td align=center>
-<font face=courier size=5 color=red><b>geneid v 1.2 documentation:</b></font>
-<br><p><br><p>
-<font face=arial black size=4>
-Enrique Blanco García
-<br><p>Genís Parra
-<br><p>and<br><p>
-Roderic Guigó Serra
-</font>
-</td>
-</td>
-</table>
-
-<br><p><br><p>
-<table border=0 width=700 cellpadding=10>
-<tr>
-<td bgcolor="red"><font face="arial black" size=3>Table of contents:</font></td>
-<tr>
-<td>
-<div class="bulk"><font face="arial black" size=2>
-<ol>
-<li> <a href="./chapter1/index.html">What is <tt>geneid</tt> ?</a>
-<li> <a href="./chapter2/index.html">Signals, exons and genes</a>
-<li> <a href="./chapter3/index.html">How to install <tt>geneid</tt></a>
-<li> <a href="./chapter4/index.html">Running <tt>geneid</tt></a>
-<li> <a href="./chapter5/index.html">Assembling predicted exons into gene structures</a>
-<li> <a href="./chapter6/index.html">Introducing external evidence: re-annotation</a>
-<li> <a href="./chapter7/index.html">Using sequence homology information</a>
-<li> <a href="./chapter8/index.html"><tt>geneid</tt> parameter file</a>
-<li> <a href="./chapter9/index.html">Source code documentation</a>
-<li> <a href="./chapter10/index.html"><tt>geneid</tt> history</a>
-</ol>
-</font>
+<div class="hero">
+  <h1>geneid <span class="ver">v1.6</span></h1>
+  <p class="lead">A program for predicting genes in anonymous eukaryotic genomic
+  sequences &mdash; splice sites, exons, and complete gene structures &mdash;
+  ab&nbsp;initio or guided by annotations, protein homology and RNA&#8209;seq.</p>
+  <p class="links">
+    <a href="https://github.com/guigolab/geneid">GitHub</a>
+    <a href="https://github.com/guigolab/geneid/wiki">Wiki</a>
+    <a href="chapter3/index.html">Install</a>
+    <a href="chapter4/index.html">Run</a>
+  </p>
 </div>
-</td>
-</table>
 
-<br><p><br><p><br><p>
+<div class="toc">
+  <h2>Manual</h2>
+  <div class="grid">
+    <a class="card" href="chapter1/index.html"><span class="n">1</span><span class="t">What is geneid?</span><span class="d">Overview, what it predicts, where to get it.</span></a>
+    <a class="card" href="chapter2/index.html"><span class="n">2</span><span class="t">Signals, exons and genes</span><span class="d">The prediction hierarchy: sites &rarr; exons &rarr; assembled genes; frame and remainder.</span></a>
+    <a class="card" href="chapter3/index.html"><span class="n">3</span><span class="t">Installing geneid</span><span class="d">Build from source, dependencies (zlib, optional htslib).</span></a>
+    <a class="card" href="chapter4/index.html"><span class="n">4</span><span class="t">Running geneid</span><span class="d">Input, the full command-line reference, output formats.</span></a>
+    <a class="card" href="chapter5/index.html"><span class="n">5</span><span class="t">Assembling exons (-O)</span><span class="d">Chaining externally-supplied elements into gene structures.</span></a>
+    <a class="card" href="chapter6/index.html"><span class="n">6</span><span class="t">External annotations (-R)</span><span class="d">Guiding or forcing predictions with GFF / bigBed / BAM evidence.</span></a>
+    <a class="card" href="chapter7/index.html"><span class="n">7</span><span class="t">RNA-seq &amp; homology (-S / -Y)</span><span class="d">Expression coverage scoring, junctions, UTRs, multi-library input.</span></a>
+    <a class="card" href="chapter8/index.html"><span class="n">8</span><span class="t">The parameter file</span><span class="d">Isochores, signal profiles, the coding model, and the gene model.</span></a>
+    <a class="card" href="chapter9/index.html"><span class="n">9</span><span class="t">Source code &amp; architecture</span><span class="d">How the code is organised and where each stage lives.</span></a>
+    <a class="card" href="chapter10/index.html"><span class="n">10</span><span class="t">History &amp; references</span><span class="d">Authors, version history, and how to cite geneid.</span></a>
+  </div>
+</div>
 
-<table border=0>
-<tr>
-<td align=left bgcolor=darkgreen>
-<script>
-var modifieddate=document.lastModified
-    document.write("<font size=1 face  = 'arial black'  color='white'>" + 
-                   "Last modified: " + modifieddate)
-</script>
-</td>
-</table>
+<footer class="site">
+  geneid is free software under the GNU General Public License.
+  Developed by Enrique Blanco, Tyler Alioto and Roderic Guig&oacute; at the CRG.
+  Questions: <a href="mailto:geneid@crg.es">geneid@crg.es</a>.
+</footer>
 
-<br><p>
-Enrique Blanco Garcia &copy; 2003<br><p><br><p>
-</center>
 </body>
 </html>
-
-
-
-

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,160 @@
+/* geneid manual — shared stylesheet. Self-contained: no external fonts or CDNs. */
+
+:root {
+  --bg: #ffffff;
+  --fg: #1b1f24;
+  --muted: #5b6672;
+  --accent: #1667c8;
+  --accent-soft: #e8f0fb;
+  --border: #e2e6ea;
+  --code-bg: #f5f7f9;
+  --code-fg: #24313d;
+  --sidebar-bg: #f7f9fb;
+  --note-bg: #eef5ff;
+  --note-bd: #1667c8;
+  --tip-bg: #eefaf0;
+  --tip-bd: #24a148;
+  --warn-bg: #fff6e9;
+  --warn-bd: #d98a00;
+  --table-stripe: #f7f9fb;
+  --measure: 74ch;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14181d;
+    --fg: #d7dde3;
+    --muted: #92a0ad;
+    --accent: #64a6f5;
+    --accent-soft: #1b2836;
+    --border: #29313a;
+    --code-bg: #1b2129;
+    --code-fg: #cdd6df;
+    --sidebar-bg: #171c22;
+    --note-bg: #16222f;
+    --note-bd: #3d7fd0;
+    --tip-bg: #14251a;
+    --tip-bd: #3aa85a;
+    --warn-bg: #2a2113;
+    --warn-bd: #cf9231;
+    --table-stripe: #191f26;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+/* ---- layout ---------------------------------------------------------- */
+.layout { display: flex; align-items: flex-start; max-width: 1200px; margin: 0 auto; }
+
+.sidebar {
+  flex: 0 0 250px;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 1.4rem 1rem 2rem;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  font-size: 0.92rem;
+}
+.sidebar .brand {
+  display: block;
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--fg);
+  text-decoration: none;
+  letter-spacing: -0.01em;
+}
+.sidebar .brand .ver { color: var(--muted); font-weight: 400; font-size: 0.8rem; }
+.sidebar ol { list-style: none; margin: 1.1rem 0 0; padding: 0; counter-reset: ch; }
+.sidebar ol li { counter-increment: ch; margin: 0.15rem 0; }
+.sidebar ol li a {
+  display: block;
+  padding: 0.32rem 0.55rem;
+  border-radius: 6px;
+  color: var(--muted);
+  text-decoration: none;
+}
+.sidebar ol li a::before { content: counter(ch) ". "; color: var(--muted); opacity: 0.7; }
+.sidebar ol li a:hover { background: var(--accent-soft); color: var(--fg); }
+.sidebar ol li a.current { background: var(--accent-soft); color: var(--accent); font-weight: 600; }
+
+.content { flex: 1 1 auto; min-width: 0; padding: 2.2rem clamp(1.1rem, 4vw, 3rem) 4rem; }
+main { max-width: var(--measure); }
+
+/* ---- typography ------------------------------------------------------ */
+h1, h2, h3 { line-height: 1.25; letter-spacing: -0.015em; scroll-margin-top: 1rem; }
+h1 { font-size: 2rem; margin: 0 0 0.3rem; }
+.eyebrow { color: var(--accent); font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 0.4rem; }
+.lead { font-size: 1.12rem; color: var(--muted); margin: 0.2rem 0 2rem; }
+h2 { font-size: 1.4rem; margin: 2.6rem 0 0.8rem; padding-top: 0.6rem; border-top: 1px solid var(--border); }
+h3 { font-size: 1.12rem; margin: 1.8rem 0 0.5rem; }
+p, ul, ol, dl { margin: 0.7rem 0; }
+li { margin: 0.28rem 0; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+strong { font-weight: 650; }
+hr { border: 0; border-top: 1px solid var(--border); margin: 2.4rem 0; }
+
+/* ---- code ------------------------------------------------------------ */
+code, kbd, pre, .mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace; }
+code { background: var(--code-bg); color: var(--code-fg); padding: 0.12em 0.4em; border-radius: 5px; font-size: 0.9em; }
+pre {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.95rem 1.1rem;
+  border-radius: 9px;
+  border: 1px solid var(--border);
+  overflow-x: auto;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+pre code { background: none; padding: 0; border-radius: 0; font-size: inherit; }
+pre .cmd { color: var(--accent); }        /* shell prompt / command highlight */
+.flag { color: var(--accent); font-weight: 600; }
+
+/* ---- callouts -------------------------------------------------------- */
+.callout { border-left: 4px solid var(--note-bd); background: var(--note-bg); padding: 0.7rem 1rem; border-radius: 0 8px 8px 0; margin: 1.2rem 0; }
+.callout p:first-child { margin-top: 0; } .callout p:last-child { margin-bottom: 0; }
+.callout.tip { border-color: var(--tip-bd); background: var(--tip-bg); }
+.callout.warn { border-color: var(--warn-bd); background: var(--warn-bg); }
+.callout .label { font-weight: 700; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 0.2rem; }
+
+/* ---- tables ---------------------------------------------------------- */
+.tablewrap { overflow-x: auto; margin: 1.2rem 0; }
+table { border-collapse: collapse; width: 100%; font-size: 0.92rem; }
+th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+th { font-weight: 650; border-bottom: 2px solid var(--border); white-space: nowrap; }
+tbody tr:nth-child(even) { background: var(--table-stripe); }
+td code { white-space: nowrap; }
+
+/* flag reference: first column is the flag */
+table.flags td:first-child { white-space: nowrap; font-weight: 600; }
+
+/* ---- misc ------------------------------------------------------------ */
+dt { font-weight: 650; margin-top: 0.7rem; }
+dd { margin: 0.1rem 0 0 1.2rem; color: var(--fg); }
+.pagenav { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.4rem; border-top: 1px solid var(--border); font-size: 0.95rem; }
+.pagenav a { display: inline-flex; flex-direction: column; }
+.pagenav .dir { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.pagenav .next { text-align: right; margin-left: auto; }
+footer.site { margin-top: 3rem; color: var(--muted); font-size: 0.85rem; }
+
+/* mobile */
+.menutoggle { display: none; }
+@media (max-width: 820px) {
+  .layout { flex-direction: column; }
+  .sidebar { position: static; height: auto; width: 100%; flex-basis: auto; border-right: 0; border-bottom: 1px solid var(--border); }
+  .sidebar ol { columns: 2; }
+  .content { padding: 1.5rem 1.2rem 3rem; }
+}


### PR DESCRIPTION
Rewrites the HTML manual under `docs/`, which dated to **2003 / v1.2** &mdash; dead `imim.es` links, `<font>`-tag / table-layout markup, encoding errors, and content missing ~20 years of features (the whole RNA-seq/BAM pipeline, U12 introns, UTRs, the intron-length model, bigWig/bigBed inputs, GFF3, and half the flags).

## What's here
- **A shared stylesheet** (`docs/style.css`): self-contained (no external fonts or CDNs), responsive, light **and** dark, with a persistent chapter sidebar, styled code blocks, tables and callouts.
- **A landing page** (`docs/index.html`): hero + card grid.
- **All 10 chapters rewritten** and grounded in the current codebase:
  1. What is geneid? &nbsp; 2. Signals, exons and genes &nbsp; 3. Installing (zlib + optional htslib) &nbsp; 4. Running geneid &mdash; the full v1.6 command-line reference &nbsp; 5. Assembling exons (`-O`) &nbsp; 6. External annotations (`-R`: GFF/bigBed/BAM) &nbsp; 7. RNA-seq &amp; homology (`-S`/`-Y`: expression scoring `-L`/`-Q`, multi-library `-K`, junction floor `-I`, UTRs) &nbsp; 8. The parameter file &nbsp; 9. Source code &amp; architecture (a module map by pipeline stage, replacing the dead file-list) &nbsp; 10. History &amp; references (timeline through v1.6; current authors; how to cite).

## Verification
- Every page validated well-formed.
- Rendered and checked in-browser in **both light and dark** themes (sidebar, tables, callouts, code).
- Facts pulled from the current source: version, the complete `-h` flag set, the Makefile/deps, the parameter-file structure, the `src/` module list, and the release history.

## Notes
- The old per-chapter sample sub-directories (`chapter4/{formats_html,samples_html,sequence}`, `chapter9/{code_html,images}`) are now orphaned; I left them in place rather than delete content unprompted &mdash; say the word and I'll remove them.
- Chapter 7 documents `-I` (junction floor), which lives in #77; the flags are consistent whichever of #77/#78/this lands first.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code