### PR TITLE
docs: cite the 2018 Current Protocols geneid chapter (Alioto et al.)

### DIFF
--- a/docs/chapter10/index.html
+++ b/docs/chapter10/index.html
@@ -74,9 +74,10 @@
   <ul>
     <li>G. Parra, E. Blanco and R. Guig&oacute;. <em>geneid in Drosophila.</em>
       Genome Research 10:511&ndash;515, 2000.</li>
-    <li>E. Blanco, G. Parra and R. Guig&oacute;. <em>Using geneid to identify
-      genes.</em> Current Protocols in Bioinformatics, Unit&nbsp;4.3. John Wiley
-      &amp; Sons.</li>
+    <li>T. Alioto, E. Blanco, G. Parra and R. Guig&oacute;. <em>Using geneid to
+      Identify Genes.</em> Current Protocols in Bioinformatics 64(1):e56, 2018.
+      <a href="https://doi.org/10.1002/cpbi.56">doi:10.1002/cpbi.56</a>.
+      PMID:&nbsp;30332532.</li>
   </ul>
 
   <h2>Bibliography</h2>
@@ -92,8 +93,10 @@
       5:681&ndash;702, 1998.</li>
     <li>G. Parra, E. Blanco and R. Guig&oacute;. <em>geneid in Drosophila.</em>
       Genome Research 10:511&ndash;515, 2000.</li>
-    <li>E. Blanco, G. Parra and R. Guig&oacute;. <em>Using geneid to identify
-      genes.</em> Current Protocols in Bioinformatics, Unit&nbsp;4.3, 2002.</li>
+    <li>T. Alioto, E. Blanco, G. Parra and R. Guig&oacute;. <em>Using geneid to
+      Identify Genes.</em> Current Protocols in Bioinformatics 64(1):e56, 2018.
+      <a href="https://doi.org/10.1002/cpbi.56">doi:10.1002/cpbi.56</a>.
+      PMID:&nbsp;30332532.</li>
   </ul>
 
   <h2>Acknowledgements</h2>


### PR DESCRIPTION
Updates the Current Protocols citation in the manual (chapter 10) to the current 2018 edition, in both the **How to cite** and **Bibliography** sections:

> Alioto T, Blanco E, Parra G, Guig&oacute; R. *Using geneid to Identify Genes.* Curr Protoc Bioinformatics. 2018 Dec;64(1):e56. [doi:10.1002/cpbi.56](https://doi.org/10.1002/cpbi.56). PMID: 30332532.

This replaces the older, incomplete Unit&nbsp;4.3 reference (the 2018 chapter is the updated edition of the same work, and now lists Alioto as first author). Well-formed; docs-only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with Claude Code